### PR TITLE
Created a bower package

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,8 +6,7 @@
     "license": "Apache-2.0",
     "homepage": "http://dcode.io/",
     "dependencies": {
-        "bytebuffer": "latest",
-        "ascli": "latest"
+        "bytebuffer": "latest"
     },
     "keywords": ["net", "buffer", "protobuf", "serialization", "bytebuffer", "websocket", "webrtc"],
     "ignore": [


### PR DESCRIPTION
It would be wonderful to be able to include ProtoBuf.js in a project using [bower](http://bower.io/), which is a package manager for front-end components.

I've taken the liberty of packaging this repo up as a bower package so that it can be published.

The package can then be registered with the following command:

``` bash
bower register protobug git@github.com:dcodeIO/ProtoBuf.js.git
```
