### PR TITLE
Fix bug when creating distinct builders for files that import a common file

### DIFF
--- a/ProtoBuf.js
+++ b/ProtoBuf.js
@@ -2337,6 +2337,13 @@
                  * @expose
                  */
                 this.result = null;
+        
+                /**
+                 * Imported files.
+                 * @type {Array.<string>}
+                 * @expose
+                 */
+                this.files = {};
             };
         
             /**
@@ -2599,13 +2606,6 @@
                 // bootstrapping directives that are not required and therefore cannot be parsed by ProtoBuf.js.
                 return !(/google\/protobuf\//.test(filename));
             };
-        
-            /**
-             * Imported files.
-             * @type {Array.<string>}
-             * @expose
-             */
-            Builder.prototype.files = [];
         
             /**
              * Imports another definition into this builder.

--- a/ProtoBuf.noparse.js
+++ b/ProtoBuf.noparse.js
@@ -1629,6 +1629,13 @@
                  * @expose
                  */
                 this.result = null;
+        
+                /**
+                 * Imported files.
+                 * @type {Array.<string>}
+                 * @expose
+                 */
+                this.files = {};
             };
         
             /**
@@ -1891,13 +1898,6 @@
                 // bootstrapping directives that are not required and therefore cannot be parsed by ProtoBuf.js.
                 return !(/google\/protobuf\//.test(filename));
             };
-        
-            /**
-             * Imported files.
-             * @type {Array.<string>}
-             * @expose
-             */
-            Builder.prototype.files = [];
         
             /**
              * Imports another definition into this builder.

--- a/src/ProtoBuf/Builder.js
+++ b/src/ProtoBuf/Builder.js
@@ -57,6 +57,13 @@ ProtoBuf.Builder = (function(ProtoBuf, Lang, Reflect) {
          * @expose
          */
         this.result = null;
+
+        /**
+         * Imported files.
+         * @type {Array.<string>}
+         * @expose
+         */
+        this.files = {};
     };
 
     /**
@@ -319,13 +326,6 @@ ProtoBuf.Builder = (function(ProtoBuf, Lang, Reflect) {
         // bootstrapping directives that are not required and therefore cannot be parsed by ProtoBuf.js.
         return !(/google\/protobuf\//.test(filename));
     };
-
-    /**
-     * Imported files.
-     * @type {Array.<string>}
-     * @expose
-     */
-    Builder.prototype.files = [];
 
     /**
      * Imports another definition into this builder.

--- a/tests/import_a.proto
+++ b/tests/import_a.proto
@@ -1,4 +1,5 @@
 import "import_common.proto";
 
 message A {
+    optional Common common = 1;
 }

--- a/tests/import_b.proto
+++ b/tests/import_b.proto
@@ -1,4 +1,5 @@
 import "import_common.proto";
 
 message B {
+    optional Common common = 1;
 }

--- a/tests/suite.js
+++ b/tests/suite.js
@@ -790,6 +790,25 @@
             }
             test.done();
         },
+
+        "importDuplicateDifferentBuilder": function(test) {
+            try {
+                var builderA = ProtoBuf.protoFromFile(__dirname+"/import_a.proto");
+                var builderB;
+                test.doesNotThrow(function() {
+                    builderB = ProtoBuf.protoFromFile(__dirname+"/import_b.proto");
+                });
+                var rootA = builderA.build();
+                var rootB = builderB.build();
+                test.ok(rootA.A);
+                test.ok(rootB.B);
+                test.ok(rootA.Common);                
+                test.ok(rootB.Common);                
+            } catch (e) {
+                fail(e);
+            }
+            test.done();
+        },
         
         "extend": function(test) {
             try {


### PR DESCRIPTION
Fix bug when creating distinct builders for files that import a common file. Builder#files was being shared across all instances.

Builder's constructor now creates a fresh `.files` object for each instance, instead of using a shared object on the prototype.

Also, `.files` used to be an Array, but is now an Object since it was being used as an object like `.files[filename] = true`. All tests still pass, and this also makes debugging easier. Previously, you'd look at `.files` and see an empty array, even if it had `filename` keys set to true.

Added a test, `importDuplicateDifferentBuilder`, that would fail before this change, but now passes.
