### PR TITLE
Add an option to convert fields to camelCase

### DIFF
--- a/src/ProtoBuf/Reflect.js
+++ b/src/ProtoBuf/Reflect.js
@@ -48,7 +48,11 @@ ProtoBuf.Reflect = (function(ProtoBuf) {
          * @type {string}
          * @expose
          */
-        this.name = name;
+        this.name = ProtoBuf.convertFieldsToCamelCase && this instanceof Message.Field ? name.replace(/(_[a-zA-Z])/g,
+            function(match) {
+                return match.toUpperCase().replace('_','');
+            }
+        ) : name;
     };
 
     /**


### PR DESCRIPTION
This is a non-breaking alternative to #51. As you suggested, it adds an option to convert all fields to their camelCase equivalent at parse time.

Rationale:
1. The convention for field names is snake_case (and it's followed in every .proto file I've seen), while JavaScript normally uses camelCase for object properties.
2. Getter and setter functions aren't very native to JavaScript since it has `Object.defineProperty`.
3. The official Java implementation relies on the snake_case convention for fields and converts them to camelCase for getter and setter methods (the only way to access the fields).
