### PR TITLE
allow options of the form (google.protobuf.*).*

### DIFF
--- a/ProtoBuf.js
+++ b/ProtoBuf.js
@@ -746,7 +746,10 @@
                     token = this.tn.next();
                 }
                 if (!Lang.NAME.test(token)) {
-                    throw(new Error("Illegal option name in message "+parent.name+" at line "+this.tn.line+": "+token));
+                    // we can allow options of the form google.protobuf.* since they will just get ignored anyways
+                    if (!/google\.protobuf\./.test(token)) {
+                        throw(new Error("Illegal option name in message "+parent.name+" at line "+this.tn.line+": "+token));
+                    }
                 }
                 var name = token;
                 token = this.tn.next();


### PR DESCRIPTION
Thanks for the great protobuf library! I hope this is a useful/valid change. Our organization uses protos across many languages and we have a custom option for objective-c class prefixes that was being rejected by the parser.

option (google.protobuf.objectivec_file_options).class_prefix = "IX"
