### PR TITLE
Parse single-quoted strings

### DIFF
--- a/src/ProtoBuf/DotProto/Parser.js
+++ b/src/ProtoBuf/DotProto/Parser.js
@@ -185,13 +185,13 @@ ProtoBuf.DotProto.Parser = (function(ProtoBuf, Lang, Tokenizer) {
         if (token === "public") {
             token = this.tn.next();
         }
-        if (token !== Lang.STRINGOPEN) {
-            throw(new Error("Illegal begin of import value at line "+this.tn.line+": "+token+" ('"+Lang.STRINGOPEN+"' expected)"));
+        if (token !== Lang.STRINGOPEN && token !== Lang.STRINGOPEN_SQ) {
+            throw(new Error("Illegal begin of import value at line "+this.tn.line+": "+token+" ('"+Lang.STRINGOPEN+"' or '"+Lang.STRINGOPEN_SQ+"' expected)"));
         }
         var imported = this.tn.next();
         token = this.tn.next();
-        if (token !== Lang.STRINGCLOSE) {
-            throw(new Error("Illegal end of import value at line "+this.tn.line+": "+token+" ('"+Lang.STRINGCLOSE+"' expected)"));
+        if (token !== this.tn.stringEndsWith) {
+            throw(new Error("Illegal end of import value at line "+this.tn.line+": "+token+" ('"+this.tn.stringEndsWith+"' expected)"));
         }
         token = this.tn.next();
         if (token !== Lang.END) {
@@ -238,11 +238,11 @@ ProtoBuf.DotProto.Parser = (function(ProtoBuf, Lang, Tokenizer) {
         }
         var value;
         token = this.tn.next();
-        if (token === Lang.STRINGOPEN) {
+        if (token === Lang.STRINGOPEN || token === Lang.STRINGOPEN_SQ) {
             value = this.tn.next();
             token = this.tn.next();
-            if (token !== Lang.STRINGCLOSE) {
-                throw(new Error("Illegal end of option value in message "+parent.name+", option "+name+" at line "+this.tn.line+": "+token+" ('"+Lang.STRINGCLOSE+"' expected)"));
+            if (token !== this.tn.stringEndsWith) {
+                throw(new Error("Illegal end of option value in message "+parent.name+", option "+name+" at line "+this.tn.line+": "+token+" ('"+this.tn.stringEndsWith+"' expected)"));
             }
         } else {
             if (Lang.NUMBER.test(token)) {
@@ -566,11 +566,11 @@ ProtoBuf.DotProto.Parser = (function(ProtoBuf, Lang, Tokenizer) {
         }
         var value;
         token = this.tn.next();
-        if (token === Lang.STRINGOPEN) {
+        if (token === Lang.STRINGOPEN || token === Lang.STRINGOPEN_SQ) {
             value = this.tn.next();
             token = this.tn.next();
-            if (token != Lang.STRINGCLOSE) {
-                throw(new Error("Illegal end of field value in message "+msg.name+"#"+fld.name+", option "+name+" at line "+this.tn.line+": "+token+" ('"+Lang.STRINGCLOSE+"' expected)"));
+            if (token != this.tn.stringEndsWith) {
+                throw(new Error("Illegal end of field value in message "+msg.name+"#"+fld.name+", option "+name+" at line "+this.tn.line+": "+token+" ('"+this.tn.stringEndsWith+"' expected)"));
             }
         } else if (Lang.NUMBER.test(token, true)) {
             value = this._parseNumber(token, true);

--- a/src/ProtoBuf/DotProto/Tokenizer.js
+++ b/src/ProtoBuf/DotProto/Tokenizer.js
@@ -64,6 +64,13 @@ ProtoBuf.DotProto.Tokenizer = (function(Lang) {
          * @expose
          */
         this.readingString = false;
+
+        /**
+         * Whatever character ends the string. Either a single or double quote character.
+         * @type {string}
+         * @expose
+         */
+        this.stringEndsWith = Lang.STRINGCLOSE;
     };
 
     /**
@@ -78,7 +85,7 @@ ProtoBuf.DotProto.Tokenizer = (function(Lang) {
         if ((match = Lang.STRING.exec(this.source)) !== null) {
             var s = match[1];
             this.index = Lang.STRING.lastIndex;
-            this.stack.push(Lang.STRINGCLOSE);
+            this.stack.push(this.stringEndsWith);
             return s;
         }
         throw(new Error("Illegal string value at line "+this.line+", index "+this.index));
@@ -151,6 +158,10 @@ ProtoBuf.DotProto.Tokenizer = (function(Lang) {
         var token = this.source.substring(this.index, this.index = end);
         if (token === Lang.STRINGOPEN) {
             this.readingString = true;
+            this.stringEndsWith = Lang.STRINGCLOSE;
+        } else if (token === Lang.STRINGOPEN_SQ) {
+            this.readingString = true;
+            this.stringEndsWith = Lang.STRINGCLOSE_SQ;
         }
         return token;
     };

--- a/src/ProtoBuf/Lang.js
+++ b/src/ProtoBuf/Lang.js
@@ -39,10 +39,12 @@ ProtoBuf.Lang = (function() {
         END: ";",
         STRINGOPEN: '"',
         STRINGCLOSE: '"',
+        STRINGOPEN_SQ: "'",
+        STRINGCLOSE_SQ: "'",
         COPTOPEN: '(',
         COPTCLOSE: ')',
 
-        DELIM: /[\s\{\}=;\[\],"\(\)]/g,
+        DELIM: /[\s\{\}=;\[\],'"\(\)]/g,
         
         KEYWORD: /^(?:package|option|import|message|enum|extend|service|syntax|extensions)$/,
         RULE: /^(?:required|optional|repeated)$/,
@@ -60,7 +62,7 @@ ProtoBuf.Lang = (function() {
         ID: /^(?:[1-9][0-9]*|0|0x[0-9a-fA-F]+|0[0-7]+)$/,
         NEGID: /^\-?(?:[1-9][0-9]*|0|0x[0-9a-fA-F]+|0[0-7]+)$/,
         WHITESPACE: /\s/,
-        STRING: /"([^"\\]*(\\.[^"\\]*)*)"/g,
+        STRING: /['"]([^'"\\]*(\\.[^"\\]*)*)['"]/g,
         BOOL: /^(?:true|false)$/i,
 
         ID_MIN: 1,

--- a/tests/import_a_single_quote.proto
+++ b/tests/import_a_single_quote.proto
@@ -1,0 +1,5 @@
+import 'import_common.proto';
+
+message A {
+    optional Common common = 1;
+}

--- a/tests/string_single_quote.proto
+++ b/tests/string_single_quote.proto
@@ -1,0 +1,3 @@
+message TestSingleQuoteString {
+    required string a = 1 [ default = 'hello world' ];
+}

--- a/tests/suite.js
+++ b/tests/suite.js
@@ -1288,6 +1288,33 @@
             test.done();
         },
 
+        "singleQuotedString": function(test) {
+            try{
+                var builder = ProtoBuf.loadProtoFile(__dirname+"/string_single_quote.proto");
+                var TestSingleQuoteString = builder.build("TestSingleQuoteString");
+                test.ok(typeof TestSingleQuoteString == 'function');
+            } catch (e) {
+                fail(e);
+            }
+            test.done();
+        },
+
+        "importDuplicateSingleQuote": function(test) {
+            try {
+                var builder = ProtoBuf.loadProtoFile(__dirname+"/import_a_single_quote.proto");
+                test.doesNotThrow(function() {
+                    ProtoBuf.loadProtoFile(__dirname+"/import_b.proto", builder);
+                });
+                var root = builder.build();
+                test.ok(root.A);
+                test.ok(root.B);
+                test.ok(root.Common);
+            } catch (e) {
+                fail(e);
+            }
+            test.done();
+        },
+
         // Node.js only
         "loaders": BROWSER ? {} : {
             


### PR DESCRIPTION
Google's `protoc` allows single-quoted strings (as evidenced in https://code.google.com/p/protobuf/source/browse/trunk/src/google/protobuf/io/tokenizer.cc#614).

This patch adds support for single-quoted strings and a couple of simple tests.
