### PR TITLE
update proto2js to survive yuicompressor, which seems to remove "import" symbol in preprocessing.

### DIFF
--- a/bin/proto2js
+++ b/bin/proto2js
@@ -147,7 +147,7 @@ function build_json(file, min, asObject) {
  */
 function build_js(file, min) {
     var json = build_json(file, min, true);
-    return [json, '.import('+JSON.stringify(json, null, min ? 0 : 4)+')'];
+    return [json, '["import"]('+JSON.stringify(json, null, min ? 0 : 4)+')'];
 }
 
 /**


### PR DESCRIPTION
This is a concession, not a fix, which allows compiled schemas to be included in YuiCompressed output as generated by Sencha Cmd. Would you consider it?
