### PR TITLE
Proto path option

### DIFF
--- a/src/root.js
+++ b/src/root.js
@@ -103,17 +103,18 @@ Root.prototype.load = function load(filename, options, callback) {
             if (!util.isString(source))
                 self.setOptions(source.options).addJSON(source.nested);
             else {
+                var protoPath = options && options.protoPath || filename;
                 parse.filename = filename;
                 var parsed = parse(source, self, options),
                     resolved,
                     i = 0;
                 if (parsed.imports)
                     for (; i < parsed.imports.length; ++i)
-                        if (resolved = self.resolvePath(filename, parsed.imports[i]))
+                        if (resolved = self.resolvePath(protoPath, parsed.imports[i]))
                             fetch(resolved);
                 if (parsed.weakImports)
                     for (i = 0; i < parsed.weakImports.length; ++i)
-                        if (resolved = self.resolvePath(filename, parsed.weakImports[i]))
+                        if (resolved = self.resolvePath(protoPath, parsed.weakImports[i]))
                             fetch(resolved, true);
             }
         } catch (err) {

--- a/tests/api_root.js
+++ b/tests/api_root.js
@@ -92,4 +92,15 @@ tape.test("reflected roots", function(test) {
             test.end();
         });
     });
+    
+    test.test(test.name + " - proto path", function(test) {
+        var root = new Root();
+        test.plan(3);
+        root.load("tests/data/protoPath/common.proto", { protoPath: 'tests/data/' }, function(err) {
+            test.notOk(err, "should skip files without error when resolvePath returns null");
+            test.ok(root.lookupType('Something', 'should load main resource in proto path'));
+            test.ok(root.lookupType('SomethingOther', 'should load other resources in proto path'));
+            test.end();
+        });
+    });
 });

--- a/tests/data/protoPath/common-other.proto
+++ b/tests/data/protoPath/common-other.proto
@@ -1,0 +1,4 @@
+syntax = "proto3";
+
+message SomethingOther {
+}

--- a/tests/data/protoPath/common.proto
+++ b/tests/data/protoPath/common.proto
@@ -1,0 +1,6 @@
+syntax = "proto3";
+
+import "protoPath/common-other.proto";
+
+message Something {
+}


### PR DESCRIPTION
It's very common the proto dependencies between many resources to use some import path base to keep its relative paths with consistence.

This PR add "--proto_path" like feature to protobuf.js.