### PR TITLE
Allow empty statements

### DIFF
--- a/src/parse.js
+++ b/src/parse.js
@@ -306,6 +306,8 @@ function parse(source, root, options) {
                 return;
 
             switch (token) {
+                case ";":
+                    break;
 
                 case "map":
                     parseMapField(type, token);
@@ -490,6 +492,9 @@ function parse(source, root, options) {
         var enm = new Enum(token);
         ifBlock(enm, function parseEnum_block(token) {
           switch(token) {
+            case ";":
+              break;
+
             case "option":
               parseOption(enm, token);
               skip(";");
@@ -603,7 +608,7 @@ function parse(source, root, options) {
             /* istanbul ignore else */
             if (token === "rpc")
                 parseMethod(service, token);
-            else
+            else if (token !== ";")
                 throw illegal(token);
         });
         parent.add(service);
@@ -647,7 +652,7 @@ function parse(source, root, options) {
             if (token === "option") {
                 parseOption(method, token);
                 skip(";");
-            } else
+            } else if (token !== ";")
                 throw illegal(token);
 
         });
@@ -684,6 +689,8 @@ function parse(source, root, options) {
     var token;
     while ((token = next()) !== null) {
         switch (token) {
+            case ";":
+                break;
 
             case "package":
 

--- a/tests/comp_empty-statements.js
+++ b/tests/comp_empty-statements.js
@@ -1,0 +1,14 @@
+var tape = require("tape");
+
+var protobuf = require("..");
+
+var proto = ";\
+message A { ; required string a = 2;; }\
+enum B { ; b = 1;; };;\
+service C { ; rpc c0 (A) returns (A) { ; };; };;";
+
+tape.test("empty statements", function(test) {
+    protobuf.parse(proto);
+    test.pass("should parse without errors");
+    test.end();
+});


### PR DESCRIPTION
The protobuf language specification ([0]) allows empty statements to
appear in several places. For example, the following protobuf is
well-formed and is accepted by protoc, but was previously rejected by
pbjs:

    message A {
      string a = 1;;
    }

Support empty statements by ignoring them.

[0]: https://developers.google.com/protocol-buffers/docs/reference/proto2-spec#message_definition