### PR TITLE
Fixed: Support message named Object

### DIFF
--- a/src/type.js
+++ b/src/type.js
@@ -204,8 +204,8 @@ Type.generateConstructor = function generateConstructor(mtype) {
         else if (field.repeated) gen
             ("this%s=[]", util.safeProp(field.name));
     return gen
-    ("if(p)for(var ks=Object.keys(p),i=0;i<ks.length;++i)if(p[ks[i]]!=null)") // omit undefined or null
-        ("this[ks[i]]=p[ks[i]]");
+    ("if(p)for(var i in p)if(p.hasOwnProperty(i) && p[i]!=null)") // omit undefined or null
+        ("this[i]=p[i]");
     /* eslint-enable no-unexpected-multiline */
 };
 


### PR DESCRIPTION
Support for protobuf messages named 'Object'.

Addresses https://github.com/dcodeIO/protobuf.js/issues/1058