### PR TITLE
Service: add support for RPCs with raw messages

### DIFF
--- a/cli/targets/static.js
+++ b/cli/targets/static.js
@@ -596,11 +596,12 @@ function buildService(ref, service) {
         "@constructor",
         "@param {$protobuf.RPCImpl} rpcImpl RPC implementation",
         "@param {boolean} [requestDelimited=false] Whether requests are length-delimited",
-        "@param {boolean} [responseDelimited=false] Whether responses are length-delimited"
+        "@param {boolean} [responseDelimited=false] Whether responses are length-delimited",
+        "@param {boolean} [rawMessages=false] Whether to disable message encoding and decoding"
     ]);
-    push("function " + escapeName(service.name) + "(rpcImpl, requestDelimited, responseDelimited) {");
+    push("function " + escapeName(service.name) + "(rpcImpl, requestDelimited, responseDelimited, rawMessages) {");
     ++indent;
-    push("$protobuf.rpc.Service.call(this, rpcImpl, requestDelimited, responseDelimited);");
+    push("$protobuf.rpc.Service.call(this, rpcImpl, requestDelimited, responseDelimited, rawMessages);");
     --indent;
     push("}");
     push("");
@@ -616,11 +617,12 @@ function buildService(ref, service) {
             "@param {$protobuf.RPCImpl} rpcImpl RPC implementation",
             "@param {boolean} [requestDelimited=false] Whether requests are length-delimited",
             "@param {boolean} [responseDelimited=false] Whether responses are length-delimited",
+            "@param {boolean} [rawMessages=false] Whether to disable message encoding and decoding",
             "@returns {" + escapeName(service.name) + "} RPC service. Useful where requests and/or responses are streamed."
         ]);
-        push(escapeName(service.name) + ".create = function create(rpcImpl, requestDelimited, responseDelimited) {");
+        push(escapeName(service.name) + ".create = function create(rpcImpl, requestDelimited, responseDelimited, rawMessages) {");
             ++indent;
-            push("return new this(rpcImpl, requestDelimited, responseDelimited);");
+            push("return new this(rpcImpl, requestDelimited, responseDelimited, rawMessages);");
             --indent;
         push("};");
     }

--- a/index.d.ts
+++ b/index.d.ts
@@ -1309,8 +1309,9 @@ export namespace rpc {
          * @param rpcImpl RPC implementation
          * @param [requestDelimited=false] Whether requests are length-delimited
          * @param [responseDelimited=false] Whether responses are length-delimited
+         * @param [rawMessages=false] Whether to disable message encoding and decoding
          */
-        constructor(rpcImpl: RPCImpl, requestDelimited?: boolean, responseDelimited?: boolean);
+        constructor(rpcImpl: RPCImpl, requestDelimited?: boolean, responseDelimited?: boolean, rawMessages?: boolean);
 
         /** RPC implementation. Becomes `null` once the service is ended. */
         public rpcImpl: (RPCImpl|null);
@@ -1320,6 +1321,9 @@ export namespace rpc {
 
         /** Whether responses are length-delimited. */
         public responseDelimited: boolean;
+
+        /** Whether to disable message encoding and decoding. */
+        public rawMessages: boolean;
 
         /**
          * Calls a service method through {@link rpc.Service#rpcImpl|rpcImpl}.
@@ -1346,14 +1350,14 @@ export namespace rpc {
  * @param requestData Request data
  * @param callback Callback function
  */
-type RPCImpl = (method: (Method|rpc.ServiceMethod<Message<{}>, Message<{}>>), requestData: Uint8Array, callback: RPCImplCallback) => void;
+type RPCImpl = (method: (Method|rpc.ServiceMethod<Message<{}>, Message<{}>>), requestData: Uint8Array | {}, callback: RPCImplCallback) => void;
 
 /**
  * Node-style callback as used by {@link RPCImpl}.
  * @param error Error, if any, otherwise `null`
  * @param [response] Response data or `null` to signal end of stream, if there hasn't been an error
  */
-type RPCImplCallback = (error: (Error|null), response?: (Uint8Array|null)) => void;
+type RPCImplCallback = (error: (Error|null), response?: (Uint8Array|{}|null)) => void;
 
 /** Reflected service. */
 export class Service extends NamespaceBase {
@@ -1393,9 +1397,10 @@ export class Service extends NamespaceBase {
      * @param rpcImpl RPC implementation
      * @param [requestDelimited=false] Whether requests are length-delimited
      * @param [responseDelimited=false] Whether responses are length-delimited
+     * @param [rawMessages=false] Whether to disable message encoding and decoding
      * @returns RPC service. Useful where requests and/or responses are streamed.
      */
-    public create(rpcImpl: RPCImpl, requestDelimited?: boolean, responseDelimited?: boolean): rpc.Service;
+    public create(rpcImpl: RPCImpl, requestDelimited?: boolean, responseDelimited?: boolean, rawMessages?: boolean): rpc.Service;
 }
 
 /** Service descriptor. */

--- a/src/rpc/service.js
+++ b/src/rpc/service.js
@@ -38,8 +38,9 @@ var util = require("../util/minimal");
  * @param {RPCImpl} rpcImpl RPC implementation
  * @param {boolean} [requestDelimited=false] Whether requests are length-delimited
  * @param {boolean} [responseDelimited=false] Whether responses are length-delimited
+ * @param {boolean} [rawMessages=false] Whether to disable message encoding and decoding
  */
-function Service(rpcImpl, requestDelimited, responseDelimited) {
+function Service(rpcImpl, requestDelimited, responseDelimited, rawMessages) {
 
     if (typeof rpcImpl !== "function")
         throw TypeError("rpcImpl must be a function");
@@ -63,6 +64,12 @@ function Service(rpcImpl, requestDelimited, responseDelimited) {
      * @type {boolean}
      */
     this.responseDelimited = Boolean(responseDelimited);
+
+    /**
+     * Whether to disable message encoding and decoding.
+     * @type {boolean}
+     */
+    this.rawMessages = Boolean(rawMessages);
 }
 
 /**
@@ -91,9 +98,12 @@ Service.prototype.rpcCall = function rpcCall(method, requestCtor, responseCtor, 
     }
 
     try {
+        var encodeMethod = requestCtor[self.requestDelimited ? "encodeDelimited" : "encode"];
+        var decodeMethod = responseCtor[self.responseDelimited ? "decodeDelimited" : "decode"];
+
         return self.rpcImpl(
             method,
-            requestCtor[self.requestDelimited ? "encodeDelimited" : "encode"](request).finish(),
+            self.rawMessages ? request : encodeMethod(request).finish(),
             function rpcCallback(err, response) {
 
                 if (err) {
@@ -108,7 +118,7 @@ Service.prototype.rpcCall = function rpcCall(method, requestCtor, responseCtor, 
 
                 if (!(response instanceof responseCtor)) {
                     try {
-                        response = responseCtor[self.responseDelimited ? "decodeDelimited" : "decode"](response);
+                        response = self.rawMessages ? response : decodeMethod(response);
                     } catch (err) {
                         self.emit("error", err, method);
                         return callback(err);

--- a/src/rpc/service.js
+++ b/src/rpc/service.js
@@ -98,13 +98,13 @@ Service.prototype.rpcCall = function rpcCall(method, requestCtor, responseCtor, 
     }
 
     try {
-        var encodeMethod = requestCtor[self.requestDelimited ? "encodeDelimited" : "encode"];
-
         return self.rpcImpl(
             method,
-            self.rawMessages ? request : encodeMethod(request).finish(),
+            self.rawMessages
+                ? request
+                : requestCtor[self.requestDelimited ? "encodeDelimited" : "encode"](request).finish(),
             function rpcCallback(err, response) {
-
+                debugger;
                 if (err) {
                     self.emit("error", err, method);
                     return callback(err);
@@ -117,8 +117,9 @@ Service.prototype.rpcCall = function rpcCall(method, requestCtor, responseCtor, 
 
                 if (!(response instanceof responseCtor)) {
                     try {
-                        var decodeMethod = responseCtor[self.responseDelimited ? "decodeDelimited" : "decode"];
-                        response = self.rawMessages ? response : decodeMethod(response);
+                        response = self.rawMessages
+                            ? response
+                            : responseCtor[self.responseDelimited ? "decodeDelimited" : "decode"](response);
                     } catch (err) {
                         self.emit("error", err, method);
                         return callback(err);

--- a/src/rpc/service.js
+++ b/src/rpc/service.js
@@ -99,7 +99,6 @@ Service.prototype.rpcCall = function rpcCall(method, requestCtor, responseCtor, 
 
     try {
         var encodeMethod = requestCtor[self.requestDelimited ? "encodeDelimited" : "encode"];
-        var decodeMethod = responseCtor[self.responseDelimited ? "decodeDelimited" : "decode"];
 
         return self.rpcImpl(
             method,
@@ -118,6 +117,7 @@ Service.prototype.rpcCall = function rpcCall(method, requestCtor, responseCtor, 
 
                 if (!(response instanceof responseCtor)) {
                     try {
+                        var decodeMethod = responseCtor[self.responseDelimited ? "decodeDelimited" : "decode"];
                         response = self.rawMessages ? response : decodeMethod(response);
                     } catch (err) {
                         self.emit("error", err, method);

--- a/tests/data/rpc-es6.d.ts
+++ b/tests/data/rpc-es6.d.ts
@@ -1,8 +1,8 @@
 import * as $protobuf from "../..";
 
 export class MyService extends $protobuf.rpc.Service {
-    constructor(rpcImpl: $protobuf.RPCImpl, requestDelimited?: boolean, responseDelimited?: boolean);
-    public static create(rpcImpl: $protobuf.RPCImpl, requestDelimited?: boolean, responseDelimited?: boolean): MyService;
+    constructor(rpcImpl: $protobuf.RPCImpl, requestDelimited?: boolean, responseDelimited?: boolean, rawMessages?: boolean);
+    public static create(rpcImpl: $protobuf.RPCImpl, requestDelimited?: boolean, responseDelimited?: boolean, rawMessages?: boolean): MyService;
     public myMethod(request: IMyRequest, callback: MyService.MyMethodCallback): void;
     public myMethod(request: IMyRequest): Promise<MyResponse>;
 }

--- a/tests/data/rpc-reserved.d.ts
+++ b/tests/data/rpc-reserved.d.ts
@@ -1,8 +1,8 @@
 import * as $protobuf from "../..";
 
 export class MyService extends $protobuf.rpc.Service {
-    constructor(rpcImpl: $protobuf.RPCImpl, requestDelimited?: boolean, responseDelimited?: boolean);
-    public static create(rpcImpl: $protobuf.RPCImpl, requestDelimited?: boolean, responseDelimited?: boolean): MyService;
+    constructor(rpcImpl: $protobuf.RPCImpl, requestDelimited?: boolean, responseDelimited?: boolean, rawMessages?: boolean);
+    public static create(rpcImpl: $protobuf.RPCImpl, requestDelimited?: boolean, responseDelimited?: boolean, rawMessages?: boolean): MyService;
     public delete(request: IMyRequest, callback: MyService.DeleteCallback): void;
     public delete(request: IMyRequest): Promise<MyResponse>;
 }

--- a/tests/data/rpc.d.ts
+++ b/tests/data/rpc.d.ts
@@ -1,8 +1,8 @@
 import * as $protobuf from "../..";
 
 export class MyService extends $protobuf.rpc.Service {
-    constructor(rpcImpl: $protobuf.RPCImpl, requestDelimited?: boolean, responseDelimited?: boolean);
-    public static create(rpcImpl: $protobuf.RPCImpl, requestDelimited?: boolean, responseDelimited?: boolean): MyService;
+    constructor(rpcImpl: $protobuf.RPCImpl, requestDelimited?: boolean, responseDelimited?: boolean, rawMessages?: boolean);
+    public static create(rpcImpl: $protobuf.RPCImpl, requestDelimited?: boolean, responseDelimited?: boolean, rawMessages?: boolean): MyService;
     public myMethod(request: IMyRequest, callback: MyService.MyMethodCallback): void;
     public myMethod(request: IMyRequest): Promise<MyResponse>;
 }


### PR DESCRIPTION
**Note:** In an attempt to simplify the code diff, this PR does _not_ contain updated `dist/*` files.

## TODO
- [x] **Help Wanted:** fix failing tests 😅
- [ ] **Write tests for new functionality**
- [ ] Commit updated build assets (i.e. run `npm run build` and commit)

Opening this PR now so I can gather early feedback from the maintainers.

## Description
The Service constructor now accepts a boolean-type `rawMessages` argument, which is `false` by default. This arg is also assigned to a public member, `this.rawMessages`.

The `rpc.Service.rpcCall() ` method now checks `self.rawMessages` to determine whether or not it should:

- **Encode the request data** before making the RPC call
- **Decode the response data** afterwards

That is, if `self.rawMessages === true`, we'll call the RPCImpl with the un-encoded, "raw" `requestData` object, and will expect to receive an un-encoded `response` object.

If `self.rawMessages === false`, we'll encode and decode messages, as in the current implementation.

## Motivation
I’m using Protobuf.js to implement a JavaScript interface for **an existing RPC implementation*** which does not use protocol buffers (it uses serialized JSON instead).

Fortunately, the “protocol” part of Protobuf still offers significant value in this use case. (Seriously, it’s revelatory, and what a great project Protobuf.js is besides!)

Since the existing RPC implementation doesn’t use Protobuf, I’m having `pbjs` generate static modules without `create()`, `encode[Delimited]()`, `decode[Delimited]()`, `verify()`, and `convert()` methods:

```bash
$ pbjs -t static-module --no-create --no-encode --no-decode --no-verify --no-convert --no-delimited ./src/*.proto > ./lib/index.js
```

I'm also generating TypeScript definitions, which covers our needs for message verification.

\* Technically I'll be writing an `RPCImpl` function which wraps the "real" RPC interface. Either way, it expects serialized JSON, not a Protobuf encoded message.

—

In practice, I found that these generated classes, sans `encode[Delimited]()` and `decode[Delimited]()` methods, **did not work with Protobuf.js’s Service class**. `rpc.Service.rpcCall()` assumes that [`requestCtor` has a `encode[Delimited]()` method](https://github.com/dcodeIO/protobuf.js/blob/6.8.6/src/rpc/service.js#L96) and that [`responseCtor` has a `decode[Delimited]()` method](https://github.com/dcodeIO/protobuf.js/blob/6.8.6/src/rpc/service.js#L111). Since my generated message constructors lack both those methods, I get a runtime error when attempting to make an RPC.

## Benefits
By adding the `rawMessages` argument and public field to `Service`, developers can now implement Protobuf without the “buf” part, using Protobuf.js’s excellent feature set to generate Service subclasses and message type definitions.

Furthermore, because `rawMessages` is an additional Service constructor option, and `false` by default, this enhancement is fully backwards compatible.

Finally, I have also overloaded the `RPCImpl` type alias to account for raw messages, so developers still benefit from type checking when defining an RPC implementation in TypeScript.

## Summary of Changes

### `rpc.Service` Implementation

- Add optional, boolean-type `rawMessages` positional argument to constructor
- Add boolean-type `this.rawMessages` public field

### `rpc.Service.rpcCall()` Implementation

- Check `this.rawMessages` before attempting to call `requestCtor.encode[Delimited]()` or  `responseCtor.decode[Delimited]()`
- **Note:** Service instances constructed with the default `rawMessages = false` will still try to call these methods; if they don't exist in this case, we'll throw an Error, as in the current implementation

### `rpc.Service` Type Definitions

- Add `rawMessages` argument and public field to type definitions (along with JSDoc comments)

### `Service extends NamespaceBase` Type Definitions

- Add `rawMessages` arg to `create()` method definition

### `RPCImpl` Type Definition

- Allow `requestData` to be of type `{}` in addition to `Uint8Array` and `null`

### `RPCImplCallback` Type Definition

- Allow `response` to be of type `{}` in addition to `Uint8Array` and `null`

### `pbjs` Static Targets Implementation

- Add `rawMessages` JSDoc comments and arguments to generated code

### `test/data` Type Definitions

- Add `rawMessages` to various class definitions within `test/data/rpc*.d.ts` files