### PR TITLE
Add more comment test cases, some failing.

### DIFF
--- a/tests/data/comments-alternate-parse.proto
+++ b/tests/data/comments-alternate-parse.proto
@@ -71,3 +71,14 @@ enum Test3 {
 
     FOUR = 4; /// Other value with a comment.
 }
+
+/* One-line block comment. */
+message Test4 {}
+
+// I'm a distraction and should not part of the comment.
+/* Block comment under a line comment. */
+message Test5 {}
+
+/* I'm a distraction and should not part of the comment. */
+// Line comment under a block comment.
+message Test6 {}

--- a/tests/data/comments.proto
+++ b/tests/data/comments.proto
@@ -49,3 +49,15 @@ enum Test3 {
 
     FOUR = 4; /// Other value with a comment.
 }
+
+/* Message with no comment */
+message Test4 {}
+
+
+// I'm a distraction and should not part of the comment.
+/* Message with no comment */
+message Test5 {}
+
+/* I'm a distraction and should not part of the comment. */
+// Message with no comment
+message Test6 {}

--- a/tests/docs_comments.js
+++ b/tests/docs_comments.js
@@ -3,7 +3,7 @@ var tape = require("tape");
 var protobuf = require("..");
 
 tape.test("proto comments", function(test) {
-    test.plan(10);
+    test.plan(13);
     protobuf.load("tests/data/comments.proto", function(err, root) {
         if (err)
             throw test.fail(err.message);
@@ -11,6 +11,9 @@ tape.test("proto comments", function(test) {
         test.equal(root.lookup("Test1").comment, "Message\nwith\na\ncomment.", "should parse /**-blocks");
         test.equal(root.lookup("Test2").comment, null, "should not parse //-blocks");
         test.equal(root.lookup("Test3").comment, null, "should not parse /*-blocks");
+        test.equal(root.lookup("Test4").comment, null, "should not parse one-line block comment");
+        test.equal(root.lookup("Test5").comment, null, "should not parse block comment under line comment");
+        test.equal(root.lookup("Test6").comment, null, "should not parse line comment under block comment");
 
         test.equal(root.lookup("Test1.field1").comment, "Field with a comment.", "should parse blocks for message fields");
         test.equal(root.lookup("Test1.field2").comment, null, "should not parse lines for message fields");

--- a/tests/docs_comments_alternate_parse.js
+++ b/tests/docs_comments_alternate_parse.js
@@ -3,7 +3,7 @@ var tape = require("tape");
 var protobuf = require("..");
 
 tape.test("proto comments in alternate-parse mode", function(test) {
-    test.plan(17);
+    test.plan(20);
     var options = {alternateCommentMode: true};
     var root = new protobuf.Root();
     root.load("tests/data/comments-alternate-parse.proto", options, function(err, root) {
@@ -13,6 +13,9 @@ tape.test("proto comments in alternate-parse mode", function(test) {
         test.equal(root.lookup("Test1").comment, "Message with\na\nmulti-line comment.", "should parse double-slash multiline comment");
         test.equal(root.lookup("Test2").comment, "Message\nwith\na multiline plain slash-star\ncomment.", "should parse slash-star multiline comment");
         test.equal(root.lookup("Test3").comment, "Message\nwith\na\ncomment and stars.", "should parse doc-block multiline comment");
+        test.equal(root.lookup("Test4").comment, "One-line block comment.", "should parse one-line block comment");
+        test.equal(root.lookup("Test5").comment, "Block comment under a line comment.", "should parse block comment under line comment");
+        test.equal(root.lookup("Test6").comment, "Line comment under a block comment.", "should parse line comment under block comment");
 
         test.equal(root.lookup("Test1.field1").comment, "Field with a doc-block comment.", "should parse doc-block field comment");
         test.equal(root.lookup("Test1.field2").comment, "Field with a single-line comment starting with two slashes.", "should parse double-slash field comment");


### PR DESCRIPTION
The following new test cases were added. "Block comment under
line comment" fails in both normal and alternateCommentMode.
* One-line block comment. PASS
* Block comment under line comment. FAIL
* Line comment under block comment. PASS