### PR TITLE
Add support for enum value options

### DIFF
--- a/ext/descriptor/README.md
+++ b/ext/descriptor/README.md
@@ -59,7 +59,7 @@ The extension adds `.fromDescriptor(descriptor[, syntax])` and `#toDescriptor([s
 | **EnumDescriptorProto**       | Enum             |
 | EnumOptions                   |                  |
 | EnumValueDescriptorProto      |                  |
-| EnumValueOptions              |                  | not supported
+| EnumValueOptions              |                  |
 | **ServiceDescriptorProto**    | Service          |
 | ServiceOptions                |                  |
 | **MethodDescriptorProto**     | Method           |

--- a/ext/descriptor/index.js
+++ b/ext/descriptor/index.js
@@ -543,17 +543,27 @@ Enum.fromDescriptor = function fromDescriptor(descriptor) {
 
     // Construct values object
     var values = {};
+    var valueOptions = {};
     if (descriptor.value)
         for (var i = 0; i < descriptor.value.length; ++i) {
             var name  = descriptor.value[i].name,
-                value = descriptor.value[i].number || 0;
+                value = descriptor.value[i].number || 0,
+                options = descriptor.value[i].options;
             values[name && name.length ? name : "NAME" + value] = value;
+            if (options)
+                valueOptions[name] = fromDescriptorOptions(options, exports.EnumValueOptions);
         }
+
+    if (Object.keys(valueOptions).length === 0)
+        valueOptions = undefined;
 
     return new Enum(
         descriptor.name && descriptor.name.length ? descriptor.name : "Enum" + unnamedEnumIndex++,
         values,
-        fromDescriptorOptions(descriptor.options, exports.EnumOptions)
+        fromDescriptorOptions(descriptor.options, exports.EnumOptions),
+        undefined,
+        undefined,
+        valueOptions
     );
 };
 
@@ -565,8 +575,14 @@ Enum.prototype.toDescriptor = function toDescriptor() {
 
     // Values
     var values = [];
-    for (var i = 0, ks = Object.keys(this.values); i < ks.length; ++i)
-        values.push(exports.EnumValueDescriptorProto.create({ name: ks[i], number: this.values[ks[i]] }));
+    for (var i = 0, ks = Object.keys(this.values); i < ks.length; ++i) {
+        var options = this.valueOptions && toDescriptorOptions(this.valueOptions[ks[i]], exports.EnumValueOptions);
+        values.push(exports.EnumValueDescriptorProto.create({
+            name: ks[i],
+            number: this.values[ks[i]],
+            options
+        }));
+    }
 
     return exports.EnumDescriptorProto.create({
         name: this.name,

--- a/ext/descriptor/test.js
+++ b/ext/descriptor/test.js
@@ -29,12 +29,12 @@ var protobuf   = require("../../"),
 
 // var root = protobuf.Root.fromJSON(proto).resolveAll();
 var root = protobuf.loadSync("tests/data/google/protobuf/descriptor.proto").resolveAll();
-
+root.loadSync("tests/data/options.proto").resolveAll();
 // console.log("Original proto", JSON.stringify(root, null, 2));
 
 var msg  = root.toDescriptor();
 
-// console.log("\nDescriptor", JSON.stringify(msg.toObject(), null, 2));
+// console.log("\nDescriptor", msg.toJSON());
 
 var buf  = descriptor.FileDescriptorSet.encode(msg).finish();
 var root2 = protobuf.Root.fromDescriptor(buf, "proto2").resolveAll();

--- a/index.d.ts
+++ b/index.d.ts
@@ -160,8 +160,9 @@ export class Enum extends ReflectionObject {
      * @param [options] Declared options
      * @param [comment] The comment for this enum
      * @param [comments] The value comments for this enum
+     * @param [valueOptions] Declared options for values of this enum
      */
-    constructor(name: string, values?: { [k: string]: number }, options?: { [k: string]: any }, comment?: string, comments?: { [k: string]: string });
+    constructor(name: string, values?: { [k: string]: number }, options?: { [k: string]: any }, comment?: string, comments?: { [k: string]: string }, valueOptions?: { [k: string]: { [k: string]: any } });
 
     /** Enum values by id. */
     public valuesById: { [k: number]: string };
@@ -178,6 +179,9 @@ export class Enum extends ReflectionObject {
     /** Reserved ranges, if any. */
     public reserved: (number[]|string)[];
 
+    /** Declared options for values of this enum. */
+    public valueOptions: { [k: string]: { [k: string]: any } };
+
     /**
      * Constructs an enum from an enum descriptor.
      * @param name Enum name
@@ -193,6 +197,15 @@ export class Enum extends ReflectionObject {
      * @returns Enum descriptor
      */
     public toJSON(toJSONOptions?: IToJSONOptions): IEnum;
+
+    /**
+     * Adds an option for a specific enum value.
+     * @param [valueName] Enum value for option
+     * @param [optionName] Name of option
+     * @param [optionValue] Value of option
+     * @returns `this`
+     */
+    public setValueOption(valueName?: string, optionName?: string, optionValue?: any): Enum;
 
     /**
      * Adds a value to this enum.
@@ -237,6 +250,9 @@ export interface IEnum {
 
     /** Enum options */
     options?: { [k: string]: any };
+
+    /** Declared options for values of this enum */
+    valueOptions?: { [k: string]: { [k: string]: any } };
 }
 
 /** Reflected message field. */

--- a/index.d.ts
+++ b/index.d.ts
@@ -180,7 +180,7 @@ export class Enum extends ReflectionObject {
     public reserved: (number[]|string)[];
 
     /** Declared options for values of this enum. */
-    public valueOptions: { [k: string]: { [k: string]: any } };
+    public valueOptions?: { [k: string]: { [k: string]: any } };
 
     /**
      * Constructs an enum from an enum descriptor.

--- a/src/enum.js
+++ b/src/enum.js
@@ -58,7 +58,7 @@ function Enum(name, values, options, comment, comments, valueOptions) {
 
     /**
      *  Declared options for values of this enum.
-     * @type {Object.<string,Object<string,*>>}
+     * @type {Object.<string,Object<string,*>>|undefined}
      */
     this.valueOptions = valueOptions; // toJSON
 

--- a/tests/comp_options-textformat.js
+++ b/tests/comp_options-textformat.js
@@ -15,7 +15,14 @@ message Test {\
   string value = 1 [(my_options) = { a: \"foo\" b: \"bar\" }];\
   string value2 = 2 [(my_options) = { a: \"foo\" b { c: \"bar\" } }];\
   string value3 = 3 [(my_options) = { a: \"foo\", b: \"bar\" }];\
-}";
+}\
+extend google.protobuf.EnumValueOptions {\
+  MyOptions my_val_options = 50000;\
+}\
+enum TestEnum {\
+  A = 0 [(my_val_options) = { a: \"foo\" b { c: \"bar\" } }];\
+}\
+";
 
 tape.test("options in textformat", function(test) {
     var root = protobuf.parse(proto).root;
@@ -23,5 +30,8 @@ tape.test("options in textformat", function(test) {
     test.same(Test.fields.value.options, { "(my_options).a": "foo", "(my_options).b": "bar" }, "should parse correctly");
     test.same(Test.fields.value2.options, { "(my_options).a": "foo", "(my_options).b.c": "bar" }, "should parse correctly when nested");
     test.same(Test.fields.value3.options, { "(my_options).a": "foo", "(my_options).b": "bar" }, "should parse correctly when comma-separated");
+
+    var TestEnum = root.lookup("TestEnum");
+    test.same(TestEnum.valueOptions['A'], { "(my_val_options).a": "foo", "(my_val_options).b.c": "bar" }, "should parse correctly when nested");
     test.end();
 });

--- a/tests/data/options.proto
+++ b/tests/data/options.proto
@@ -1,0 +1,7 @@
+syntax = "proto2";
+
+enum TestEnum {
+    A = 0 [deprecated=true];
+    B = 1 [deprecated=false];
+    C = 3;
+}


### PR DESCRIPTION
I noticed that the parser skips enum value options, making them unavailable to reflection. This PR adds parser and reflection support for enum value options.

These options will now be parsed into a new `Enum#valueOptions` field.

 e.g.
```protobuf
// test/data/options.proto
syntax = "proto2";

enum TestEnum {
    A = 0 [deprecated=true];
    B = 1 [deprecated=false];
    C = 3;
}
```
yields
```json
$ node ./bin/pbjs tests/data/options.proto
{
  "nested": {
    "TestEnum": {
      "valueOptions": {
        "A": {
          "deprecated": true
        },
        "B": {
          "deprecated": false
        }
      },
      "values": {
        "A": 0,
        "B": 1,
        "C": 3
      }
    }
  }
}
```

What do you think?

I've also added support to `toDescriptor`/`fromDescriptor`, which seems to work on manual testing/inspection (`node ext/descriptor/test.js`).

Happy to add more tests, or change the data structure, if the project has an opinion.