### PR TITLE
Bundled definitions correct loading

### DIFF
--- a/src/root.js
+++ b/src/root.js
@@ -94,6 +94,16 @@ Root.prototype.load = function load(filename, options, callback) {
             throw err;
         cb(err, root);
     }
+	
+	// Bundled definition existence checking
+	function getBundledFileName(filename) {
+		const idx = filename.lastIndexOf("google/protobuf/");
+		if (idx > -1) {
+            var altname = filename.substring(idx);
+            if (altname in common) return altname; 
+        }
+		return null;
+	}
 
     // Processes a single file
     function process(filename, source) {
@@ -109,11 +119,11 @@ Root.prototype.load = function load(filename, options, callback) {
                     i = 0;
                 if (parsed.imports)
                     for (; i < parsed.imports.length; ++i)
-                        if (resolved = self.resolvePath(filename, parsed.imports[i]))
+                        if (resolved = (getBundledFileName(parsed.imports[i]) || self.resolvePath(filename, parsed.imports[i])))
                             fetch(resolved);
                 if (parsed.weakImports)
                     for (i = 0; i < parsed.weakImports.length; ++i)
-                        if (resolved = self.resolvePath(filename, parsed.weakImports[i]))
+                        if (resolved = (getBundledFileName(parsed.weakImports[i]) || self.resolvePath(filename, parsed.weakImports[i])))
                             fetch(resolved, true);
             }
         } catch (err) {
@@ -125,14 +135,6 @@ Root.prototype.load = function load(filename, options, callback) {
 
     // Fetches a single file
     function fetch(filename, weak) {
-
-        // Strip path if this file references a bundled definition
-        var idx = filename.lastIndexOf("google/protobuf/");
-        if (idx > -1) {
-            var altname = filename.substring(idx);
-            if (altname in common)
-                filename = altname;
-        }
 
         // Skip if already loaded / attempted
         if (self.files.indexOf(filename) > -1)

--- a/src/root.js
+++ b/src/root.js
@@ -95,15 +95,15 @@ Root.prototype.load = function load(filename, options, callback) {
         cb(err, root);
     }
 	
-	// Bundled definition existence checking
-	function getBundledFileName(filename) {
-		const idx = filename.lastIndexOf("google/protobuf/");
-		if (idx > -1) {
+    // Bundled definition existence checking
+    function getBundledFileName(filename) {
+	const idx = filename.lastIndexOf("google/protobuf/");
+        if (idx > -1) {
             var altname = filename.substring(idx);
             if (altname in common) return altname; 
         }
-		return null;
-	}
+        return null;
+    }
 
     // Processes a single file
     function process(filename, source) {

--- a/src/root.js
+++ b/src/root.js
@@ -97,7 +97,7 @@ Root.prototype.load = function load(filename, options, callback) {
 	
     // Bundled definition existence checking
     function getBundledFileName(filename) {
-	const idx = filename.lastIndexOf("google/protobuf/");
+        const idx = filename.lastIndexOf("google/protobuf/");
         if (idx > -1) {
             var altname = filename.substring(idx);
             if (altname in common) return altname; 

--- a/tests/node/api_load-sync.js
+++ b/tests/node/api_load-sync.js
@@ -37,8 +37,8 @@ tape.test("load sync", function(test) {
 });
 
 tape.test("should load bundled definitions even if resolvePath method was overrided", function(test) {
-    const protoFilePath = "tests/data/common.proto";
-    let root = new protobuf.Root();
+    var protoFilePath = "tests/data/common.proto";
+    var root = new protobuf.Root();
     root.resolvePath = (origin, target) => origin === "" && target === protoFilePath ? target : null;
 
     root.loadSync(protoFilePath);

--- a/tests/node/api_load-sync.js
+++ b/tests/node/api_load-sync.js
@@ -35,3 +35,14 @@ tape.test("load sync", function(test) {
 
     test.end();
 });
+
+tape.test("should load bundled definitions even if resolvePath method was overrided", function(test) {
+    const protoFilePath = "tests/data/common.proto";
+    let root = new protobuf.Root();
+    root.resolvePath = (origin, target) => origin === "" && target === protoFilePath ? target : null;
+
+    root.loadSync(protoFilePath);
+
+    test.ok(root.lookup("Something"), "should parse message Something");
+    test.end();
+});


### PR DESCRIPTION
In some cases when method `resolvePath` of the `Root` was overrided bundled definitions will not load correctly. This small patch fixes this behavior.