### PR TITLE
fix: Import Long types

### DIFF
--- a/cli/pbts.js
+++ b/cli/pbts.js
@@ -151,6 +151,10 @@ exports.main = function(args, callback) {
                     "// DO NOT EDIT! This is a generated file. Edit the JSDoc in src/*.js instead and run 'npm run types'.",
                     ""
                 );
+            output.push(
+                "import * as Long from \"long\";",
+                ""
+            );               
             if (argv.global)
                 output.push(
                     "export as namespace " + argv.global + ";",


### PR DESCRIPTION
`Long` is implicitly loaded as dependency. If that fails for some reason, `Long` will be undefined.

This PR makes sure that the types for `Long` are always in place.