### PR TITLE
allow file-level options everywhere in the file

### DIFF
--- a/src/parse.js
+++ b/src/parse.js
@@ -714,10 +714,6 @@ function parse(source, root, options) {
 
             case "option":
 
-                /* istanbul ignore if */
-                if (!head)
-                    throw illegal(token);
-
                 parseOption(ptr, token);
                 skip(";");
                 break;

--- a/tests/data/test.proto
+++ b/tests/data/test.proto
@@ -33,7 +33,6 @@
 syntax = "proto2";
 
 option java_package = "com.google.apps.jspb.proto";
-option java_multiple_files = true;
 
 import "google/protobuf/descriptor.proto";
 
@@ -268,3 +267,5 @@ message Deeply {
     }
   }
 }
+
+option java_multiple_files = true;


### PR DESCRIPTION
Fixes #1111. According to proto3 syntax defined [here](https://developers.google.com/protocol-buffers/docs/reference/proto3-spec), an option can appear anywhere in the file. Don't break if we see an option after messages.

I also updated `tests/data/test.proto` to have a test coverage for this use case.