### PR TITLE
Ensure descriptor conversion can handle default values

### DIFF
--- a/ext/descriptor/index.js
+++ b/ext/descriptor/index.js
@@ -215,7 +215,7 @@ Type.fromDescriptor = function fromDescriptor(descriptor, syntax) {
         for (i = 0; i < descriptor.field.length; ++i) {
             var field = Field.fromDescriptor(descriptor.field[i], syntax);
             type.add(field);
-            if (descriptor.field[i].hasOwnProperty("oneofIndex")) // eslint-disable-line no-prototype-builtins
+            if (descriptor.field[i].oneofIndex)
                 type.oneofsArray[descriptor.field[i].oneofIndex].add(field);
         }
     /* Extension fields */ if (descriptor.extension)

--- a/ext/descriptor/test.js
+++ b/ext/descriptor/test.js
@@ -52,3 +52,9 @@ if (diff) {
     process.exitCode = 1;
 } else
     console.log("no differences");
+
+// This test was able to reproduce https://github.com/dcodeIO/protobuf.js/issues/1196
+var msgDefaults = descriptor.FileDescriptorSet.toObject(msg, {defaults: true}); 
+buf = descriptor.FileDescriptorSet.encode(msgDefaults).finish();
+protobuf.Root.fromDescriptor(buf, "proto2").resolveAll();
+console.log("cycle with defaults successful");


### PR DESCRIPTION
Fixes #1196

If the descriptor has been serialized/deserialized by something that set the default values, then an error occurs during reading the descriptor. This fixes it.