### PR TITLE
build: be more explicit about tested versions of nodejs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,11 @@ language: node_js
 node_js:
   - node
   - lts/*
+  - 12
+  - 11
+  - 10
+  - 8
+  - 6
   - 4.3.2
   - 4
 branches:


### PR DESCRIPTION
At a glance, it's hard to understand what versions of node.js this library is being tested against.  This makes things a tad more explicit.