### PR TITLE
Support negative numbers on reserved keyword for Enums

### DIFF
--- a/src/parse.js
+++ b/src/parse.js
@@ -134,13 +134,13 @@ function parse(source, root, options) {
         }
     }
 
-    function readRanges(target, acceptStrings) {
+    function readRanges(target, acceptStrings, acceptNegatives) {
         var token, start;
         do {
             if (acceptStrings && ((token = peek()) === "\"" || token === "'"))
                 target.push(readString());
             else
-                target.push([ start = parseId(next()), skip("to", true) ? parseId(next()) : start ]);
+                target.push([ start = parseId(next(), acceptNegatives), skip("to", true) ? parseId(next(), acceptNegatives) : start ]);
         } while (skip(",", true));
         skip(";");
     }
@@ -496,7 +496,7 @@ function parse(source, root, options) {
               break;
 
             case "reserved":
-              readRanges(enm.reserved || (enm.reserved = []), true);
+              readRanges(enm.reserved || (enm.reserved = []), true, true);
               break;
 
             default:

--- a/tests/data/uncommon.proto
+++ b/tests/data/uncommon.proto
@@ -31,6 +31,8 @@ message Test2 {
 
     map<uint64,Test> longmap = 10;
 
+    Test5_Enum negative_enum = 11;
+
     /** pre */
     oneof kind;
     oneof kind2; /// post
@@ -60,6 +62,13 @@ enum Test4{
 
 enum Test4_1{
     OPTION = 1;
+}
+
+enum Test5_Enum {
+    reserved -1;
+    INVALID = 0;
+    OK = 1;
+    OK_BUT_WARNINGS = 2;
 }
 
 service Test5;


### PR DESCRIPTION
This PR Fixes https://github.com/uw-labs/bloomrpc/issues/35

As well as enabling negative numbers on `reserved` keywords for `Enums` types

example:

```proto
enum Values {
    reserved -1;
    INVALID = 0;
    OK = 1;
    OK_BUT_WARNINGS = 2;
  }
```

Before this PR there was a parsing issue when using `negative` numbers on `reserved` keywords