### PR TITLE
Properly iterate and return method descriptors

### DIFF
--- a/ext/descriptor/index.js
+++ b/ext/descriptor/index.js
@@ -660,12 +660,12 @@ Service.prototype.toDescriptor = function toDescriptor() {
 
     // Methods
     var methods = [];
-    for (var i = 0; i < this.methodsArray; ++i)
+    for (var i = 0; i < this.methodsArray.length; ++i)
         methods.push(this._methodsArray[i].toDescriptor());
 
     return exports.ServiceDescriptorProto.create({
         name: this.name,
-        methods: methods,
+        method: methods,
         options: toDescriptorOptions(this.options, exports.ServiceOptions)
     });
 };


### PR DESCRIPTION
The current implementation of Service.toDescriptor() does not properly return the service's method descriptors. The method iterator references the _methodsArray Array instance rather than its length. Also, the methods are returned in the 'methods' member of the returned object, instead of the 'method' member as defined by the spec. This PR corrects these two errors and produces accurate method descriptors for a given service.