### PR TITLE
Use Object.hasOwnProperty instead of prototype method

### DIFF
--- a/src/encoder.js
+++ b/src/encoder.js
@@ -46,7 +46,7 @@ function encoder(mtype) {
         // Map fields
         if (field.map) {
             gen
-    ("if(%s!=null&&m.hasOwnProperty(%j)){", ref, field.name) // !== undefined && !== null
+    ("if(%s!=null&&Object.hasOwnProperty.call(m,%j)){", ref, field.name) // !== undefined && !== null
         ("for(var ks=Object.keys(%s),i=0;i<ks.length;++i){", ref)
             ("w.uint32(%i).fork().uint32(%i).%s(ks[i])", (field.id << 3 | 2) >>> 0, 8 | types.mapKey[field.keyType], field.keyType);
             if (wireType === undefined) gen
@@ -84,7 +84,7 @@ function encoder(mtype) {
         // Non-repeated
         } else {
             if (field.optional) gen
-    ("if(%s!=null&&m.hasOwnProperty(%j))", ref, field.name); // !== undefined && !== null
+    ("if(%s!=null&&Object.hasOwnProperty.call(m,%j))", ref, field.name); // !== undefined && !== null
 
             if (wireType === undefined)
         genTypePartial(gen, field, index, ref);


### PR DESCRIPTION
This PR addresses a situation uncovered with #1232 where the encode method calls `hasOwnProperty` of an object which may not have a prototype. This situation came about when mapping an express request to a grpc call, where a `oneOf` object is a sub-message of a parent object. Using `Object.hasOwnProperty.call` appears to a safer approach which doesn't make assumptions about the underlying object's inheritance. 