### PR TITLE
Fix breaking build because of a minify error

### DIFF
--- a/src/root.js
+++ b/src/root.js
@@ -97,7 +97,7 @@ Root.prototype.load = function load(filename, options, callback) {
 	
     // Bundled definition existence checking
     function getBundledFileName(filename) {
-        const idx = filename.lastIndexOf("google/protobuf/");
+        var idx = filename.lastIndexOf("google/protobuf/");
         if (idx > -1) {
             var altname = filename.substring(idx);
             if (altname in common) return altname; 


### PR DESCRIPTION
Running `npm run build` fails at the minify step because of a `const` keyword in root.js: https://github.com/protobufjs/protobuf.js/blob/7bacfc8f34a1e096bca38a0ea38ecee089e8cdb5/src/root.js#L100

It looks like this was changed in https://github.com/protobufjs/protobuf.js/pull/1144. This line used to be: https://github.com/protobufjs/protobuf.js/blob/6fa4c3487c50f9e2647a384bf64cfb009752b6a7/src/root.js#L130

Here is the output:
```sh
> protobufjs@6.8.8 build /Users/erik/Code/protobuf.js
> gulp --gulpfile scripts/gulpfile.js

[15:28:28] Working directory changed to ~/Code/protobuf.js/scripts
[15:28:28] Using gulpfile ~/Code/protobuf.js/scripts/gulpfile.js
[15:28:28] Starting 'default'...
[15:28:28] Starting 'full'...
[15:28:28] Starting 'light'...
[15:28:28] Starting 'minimal'...
[15:28:28] Starting '<anonymous>'...
[15:28:28] Starting 'full-bundle'...
[15:28:28] Starting 'light-bundle'...
[15:28:28] Starting 'minimal-bundle'...
[15:28:28] Finished '<anonymous>' after 1.31 ms
[15:28:29] Finished 'minimal-bundle' after 540 ms
[15:28:29] Starting 'minimal-minify'...
[15:28:29] Finished 'light-bundle' after 728 ms
[15:28:29] Starting 'light-minify'...
[15:28:29] Finished 'full-bundle' after 963 ms
[15:28:29] Starting 'full-minify'...
[15:28:30] Finished 'minimal-minify' after 1.26 s
[15:28:30] Finished 'minimal' after 1.8 s
[15:28:30] 'light-minify' errored after 1.32 s
[15:28:30] GulpUglifyError: unable to minify JavaScript
Caused by: SyntaxError: Unexpected token: keyword (const)
File: /Users/erik/Code/protobuf.js/scripts/protobuf.min.js
Line: 4125
[15:28:30] 'light' errored after 2.05 s
[15:28:30] 'default' errored after 2.06 s
[15:28:30] The following tasks did not complete: full, full-minify
[15:28:30] Did you forget to signal async completion?
```