### PR TITLE
Remove Buffer declaration

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,7 @@
 // DO NOT EDIT! This is a generated file. Edit the JSDoc in src/*.js instead and run 'npm run types'.
 
+import * as Long from "long";
+
 export as namespace protobuf;
 
 /**
@@ -1807,13 +1809,6 @@ export interface Constructor<T> extends Function {
 
 /** Properties type. */
 type Properties<T> = { [P in keyof T]?: T[P] };
-
-/**
- * Any compatible Buffer instance.
- * This is a minimal stand-alone definition of a Buffer instance. The actual type is that exported by node's typings.
- */
-export interface Buffer extends Uint8Array {
-}
 
 /**
  * Any compatible Long instance.

--- a/src/util/minimal.js
+++ b/src/util/minimal.js
@@ -106,13 +106,6 @@ util.isSet = function isSet(obj, prop) {
 };
 
 /**
- * Any compatible Buffer instance.
- * This is a minimal stand-alone definition of a Buffer instance. The actual type is that exported by node's typings.
- * @interface Buffer
- * @extends Uint8Array
- */
-
-/**
  * Node's Buffer class if available.
  * @type {Constructor<Buffer>}
  */


### PR DESCRIPTION
It should be up to the user of the library to provide an environment with a Buffer definition. 

Regarding the addition of the long import, that change was never applied to the definition file.

I am unclear if the `index.d.ts` file should be included in the commit.
