### PR TITLE
Skip object check for types with a defined custom wrapper.

### DIFF
--- a/src/converter.js
+++ b/src/converter.js
@@ -6,7 +6,8 @@
 var converter = exports;
 
 var Enum = require("./enum"),
-    util = require("./util");
+    util = require("./util"),
+    wrappers = require("./wrappers");
 
 /**
  * Generates a partial value fromObject conveter.
@@ -32,7 +33,9 @@ function genValuePartial_fromObject(gen, field, fieldIndex, prop) {
                     ("break");
             } gen
             ("}");
-        } else gen
+        } else if (wrappers[field.resolvedType.fullName]) gen
+            ("m%s=types[%i].fromObject(d%s)", prop, fieldIndex, prop);
+          else gen
             ("if(typeof d%s!==\"object\")", prop)
                 ("throw TypeError(%j)", field.fullName + ": object expected")
             ("m%s=types[%i].fromObject(d%s)", prop, fieldIndex, prop);


### PR DESCRIPTION
This PR would give the ability to pass a primitive value for a non primitive type as long as a custom wrapper is defined for it.

# Use Case
We would like to be able to define fields that can be multiple different primitive types, however the library currently will throw an error if a message field resolves to a type and the value is not an object. If a custom wrapper is defined for that type, then it should be assumed that the wrapper will handle serialization.

Message:
```protobuf
message StringOrDouble {
  oneof kind {
    string stringValue = 1;
    double doubleValue = 2;
  }  
}

message MyMessage {
  StringOrDouble value = 1;
}
```

Protobuf Wrapper:
```javascript
{
  '.StringOrDouble': {
    fromObject(value) {
      return (typeof value === 'string') ? this.create({ stringValue: value }) : this.create({ doubleValue: value });
    },
    toObject(message) {
      return (typeof message.stringValue === 'string') ? message.stringValue : message.doubleValue;
    }
  }
}
```
