### PR TITLE
Allow values to be 'null' for types with a defined custom wrapper

### DIFF
--- a/src/converter.js
+++ b/src/converter.js
@@ -6,7 +6,8 @@
 var converter = exports;
 
 var Enum = require("./enum"),
-    util = require("./util");
+    util = require("./util"),
+    wrappers = require("./wrappers");
 
 /**
  * Generates a partial value fromObject conveter.
@@ -129,7 +130,11 @@ converter.fromObject = function fromObject(mtype) {
             genValuePartial_fromObject(gen, field, /* not sorted */ i, prop + "[i]")
         ("}")
     ("}");
-
+        // Wrapper fields
+        } else if (field.resolvedType && wrappers[field.resolvedType.fullName]) { gen
+    ("if(typeof d%s!==\"undefined\"){", prop);
+        genValuePartial_fromObject(gen, field, /* not sorted */ i, prop)
+    ("}");
         // Non-repeated fields
         } else {
             if (!(field.resolvedType instanceof Enum)) gen // no need to test for null/undefined if an enum (uses switch)


### PR DESCRIPTION
This PR would give the ability to pass null for a property as long as a custom wrapper is defined for it. If a protobuf wrapper exists then the converter only checks for `undefined` rather than `undefined` or `null`.

This is a breaking change because it changes behavior for objects serialized with null values on fields that have an existing protobuf wrapper. This could potentially be addressed with an added configuration option to enable this behavior.

# Use Case
We would like to make message fields 'nullable' so that the grpc client can can overwrite columns in our database with null. Currently this is not possible even with custom wrappers because all null values are filtered out.

Message:
```protobuf
message MyString {
  bool null = 1;
  string value = 2;
}

message MyMessage {
  MyString foo = 1;
}
```

Protobuf Wrapper:
```javascript
{
  '.MyString': {
    fromObject(value) {
      if (value === null) {
        return this.create({ null: true });
      }
      
      return this.create({ value });
    },
    toObject(message) {
      return message.null ? null : message.value;
    }
  }
};
```

This use case is also dependent on [Pull Request 1271](https://github.com/protobufjs/protobuf.js/pull/1271) in order to be able to pass `string | null` as the property value and not fail the object check.