### PR TITLE
Allow plain JS object repeated fields to use toArray() method

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,7 @@
 // DO NOT EDIT! This is a generated file. Edit the JSDoc in src/*.js instead and run 'npm run types'.
 
+import * as Long from "long";
+
 export as namespace protobuf;
 
 /**
@@ -1807,6 +1809,11 @@ export interface Constructor<T> extends Function {
 
 /** Properties type. */
 type Properties<T> = { [P in keyof T]?: T[P] };
+
+/** Type that is convertible to array. */
+export interface ToArray<T> {
+    toArray(): T[];
+}
 
 /**
  * Any compatible Buffer instance.

--- a/src/converter.js
+++ b/src/converter.js
@@ -17,11 +17,14 @@ var Enum = require("./enum"),
  * @returns {Codegen} Codegen instance
  * @ignore
  */
-function genValuePartial_fromObject(gen, field, fieldIndex, prop) {
+function genValuePartial_fromObject(gen, field, fieldIndex, prop, ref) {
     /* eslint-disable no-unexpected-multiline, block-scoped-var, no-redeclare */
+    if (ref === undefined) {
+      ref = "d" + prop;
+    }
     if (field.resolvedType) {
         if (field.resolvedType instanceof Enum) { gen
-            ("switch(d%s){", prop);
+            ("switch(%s){", ref);
             for (var values = field.resolvedType.values, keys = Object.keys(values), i = 0; i < keys.length; ++i) {
                 if (field.repeated && values[keys[i]] === field.typeDefault) gen
                 ("default:");
@@ -33,24 +36,24 @@ function genValuePartial_fromObject(gen, field, fieldIndex, prop) {
             } gen
             ("}");
         } else gen
-            ("if(typeof d%s!==\"object\")", prop)
+            ("if(typeof %s!==\"object\")", ref)
                 ("throw TypeError(%j)", field.fullName + ": object expected")
-            ("m%s=types[%i].fromObject(d%s)", prop, fieldIndex, prop);
+            ("m%s=types[%i].fromObject(%s)", prop, fieldIndex, ref);
     } else {
         var isUnsigned = false;
         switch (field.type) {
             case "double":
             case "float": gen
-                ("m%s=Number(d%s)", prop, prop); // also catches "NaN", "Infinity"
+                ("m%s=Number(%s)", prop, ref); // also catches "NaN", "Infinity"
                 break;
             case "uint32":
             case "fixed32": gen
-                ("m%s=d%s>>>0", prop, prop);
+                ("m%s=%s>>>0", prop, ref);
                 break;
             case "int32":
             case "sint32":
             case "sfixed32": gen
-                ("m%s=d%s|0", prop, prop);
+                ("m%s=%s|0", prop, ref);
                 break;
             case "uint64":
                 isUnsigned = true;
@@ -60,28 +63,28 @@ function genValuePartial_fromObject(gen, field, fieldIndex, prop) {
             case "fixed64":
             case "sfixed64": gen
                 ("if(util.Long)")
-                    ("(m%s=util.Long.fromValue(d%s)).unsigned=%j", prop, prop, isUnsigned)
-                ("else if(typeof d%s===\"string\")", prop)
-                    ("m%s=parseInt(d%s,10)", prop, prop)
-                ("else if(typeof d%s===\"number\")", prop)
-                    ("m%s=d%s", prop, prop)
-                ("else if(typeof d%s===\"object\")", prop)
-                    ("m%s=new util.LongBits(d%s.low>>>0,d%s.high>>>0).toNumber(%s)", prop, prop, prop, isUnsigned ? "true" : "");
+                    ("(m%s=util.Long.fromValue(%s)).unsigned=%j", prop, ref, isUnsigned)
+                ("else if(typeof %s===\"string\")", ref)
+                    ("m%s=parseInt(%s,10)", prop, ref)
+                ("else if(typeof %s===\"number\")", ref)
+                    ("m%s=%s", prop, ref)
+                ("else if(typeof %s===\"object\")", ref)
+                    ("m%s=new util.LongBits(%s.low>>>0,%s.high>>>0).toNumber(%s)", prop, ref, ref, isUnsigned ? "true" : "");
                 break;
             case "bytes": gen
-                ("if(typeof d%s===\"string\")", prop)
-                    ("util.base64.decode(d%s,m%s=util.newBuffer(util.base64.length(d%s)),0)", prop, prop, prop)
-                ("else if(d%s.length)", prop)
-                    ("m%s=d%s", prop, prop);
+                ("if(typeof %s===\"string\")", ref)
+                    ("util.base64.decode(%s,m%s=util.newBuffer(util.base64.length(%s)),0)", ref, prop, ref)
+                ("else if(%s.length)", ref)
+                    ("m%s=%s", prop, ref);
                 break;
             case "string": gen
-                ("m%s=String(d%s)", prop, prop);
+                ("m%s=String(%s)", prop, ref);
                 break;
             case "bool": gen
-                ("m%s=Boolean(d%s)", prop, prop);
+                ("m%s=Boolean(%s)", prop, ref);
                 break;
             /* default: gen
-                ("m%s=d%s", prop, prop);
+                ("m%s=%s", prop, ref);
                 break; */
         }
     }
@@ -120,13 +123,21 @@ converter.fromObject = function fromObject(mtype) {
     ("}");
 
         // Repeated fields
-        } else if (field.repeated) { gen
-    ("if(d%s){", prop)
-        ("if(!Array.isArray(d%s))", prop)
+        } else if (field.repeated) {
+          gen("if(d%s){", prop);
+          var arrayRef = "d" + prop;
+          if (field.useToArray()) {
+            arrayRef = "array" + field.id;
+            gen("var %s", arrayRef);
+            gen("if (d%s!=null&&d%s.toArray) { %s = d%s.toArray() } else { %s = d%s }",
+                prop, prop, arrayRef, prop, arrayRef, prop);
+          }
+          gen
+        ("if(!Array.isArray(%s))", arrayRef)
             ("throw TypeError(%j)", field.fullName + ": array expected")
         ("m%s=[]", prop)
-        ("for(var i=0;i<d%s.length;++i){", prop);
-            genValuePartial_fromObject(gen, field, /* not sorted */ i, prop + "[i]")
+        ("for(var i=0;i<%s.length;++i){", arrayRef);
+            genValuePartial_fromObject(gen, field, /* not sorted */ i, prop + "[i]", arrayRef + "[i]")
         ("}")
     ("}");
 

--- a/src/encoder.js
+++ b/src/encoder.js
@@ -58,25 +58,31 @@ function encoder(mtype) {
     ("}");
 
             // Repeated fields
-        } else if (field.repeated) { gen
-    ("if(%s!=null&&%s.length){", ref, ref); // !== undefined && !== null
-
+        } else if (field.repeated) {
+          var arrayRef = ref;
+          if (field.useToArray()) {
+            arrayRef = "array" + field.id;
+            gen("var %s", arrayRef);
+            gen("if (%s!=null&&%s.toArray) { %s = %s.toArray() } else { %s = %s }",
+                ref, ref, arrayRef, ref, arrayRef, ref);
+          }
+          gen("if(%s!=null&&%s.length){", arrayRef, arrayRef); // !== undefined && !== null
             // Packed repeated
             if (field.packed && types.packed[type] !== undefined) { gen
 
         ("w.uint32(%i).fork()", (field.id << 3 | 2) >>> 0)
-        ("for(var i=0;i<%s.length;++i)", ref)
-            ("w.%s(%s[i])", type, ref)
+        ("for(var i=0;i<%s.length;++i)", arrayRef)
+            ("w.%s(%s[i])", type, arrayRef)
         ("w.ldelim()");
 
             // Non-packed
             } else { gen
 
-        ("for(var i=0;i<%s.length;++i)", ref);
+        ("for(var i=0;i<%s.length;++i)", arrayRef);
                 if (wireType === undefined)
-            genTypePartial(gen, field, index, ref + "[i]");
+            genTypePartial(gen, field, index, arrayRef + "[i]");
                 else gen
-            ("w.uint32(%i).%s(%s[i])", (field.id << 3 | wireType) >>> 0, type, ref);
+            ("w.uint32(%i).%s(%s[i])", (field.id << 3 | wireType) >>> 0, type, arrayRef);
 
             } gen
     ("}");

--- a/src/field.js
+++ b/src/field.js
@@ -316,6 +316,10 @@ Field.prototype.resolve = function resolve() {
     return ReflectionObject.prototype.resolve.call(this);
 };
 
+Field.prototype.useToArray = function useToArray() {
+    return !!this.getOption("(js_use_toArray)");
+};
+
 /**
  * Decorator function as returned by {@link Field.d} and {@link MapField.d} (TypeScript).
  * @typedef FieldDecorator

--- a/src/typescript.jsdoc
+++ b/src/typescript.jsdoc
@@ -13,3 +13,10 @@
  * @type {Object.<string,*>}
  * @tstype { [P in keyof T]?: T[P] }
  */
+
+/**
+ * Type that is convertible to array.
+ * @interface ToArray
+ * @template T
+ * @tstype toArray(): T[];
+ */

--- a/src/verifier.js
+++ b/src/verifier.js
@@ -148,11 +148,19 @@ function verifier(mtype) {
             ("}");
 
         // repeated fields
-        } else if (field.repeated) { gen
-            ("if(!Array.isArray(%s))", ref)
+        } else if (field.repeated) {
+          var arrayRef = ref;
+          if (field.useToArray()) {
+            arrayRef = "array" + field.id;
+            gen("var %s", arrayRef);
+            gen("if (%s!=null&&%s.toArray) { %s = %s.toArray() } else { %s = %s }",
+                ref, ref, arrayRef, ref, arrayRef, ref);
+          }
+          gen
+            ("if(!Array.isArray(%s))", arrayRef)
                 ("return%j", invalid(field, "array"))
-            ("for(var i=0;i<%s.length;++i){", ref);
-                genVerifyValue(gen, field, i, ref + "[i]")
+            ("for(var i=0;i<%s.length;++i){", arrayRef);
+                genVerifyValue(gen, field, i, arrayRef + "[i]")
             ("}");
 
         // required or present fields

--- a/tests/comp_toArray.js
+++ b/tests/comp_toArray.js
@@ -1,0 +1,24 @@
+var tape = require("tape");
+
+var protobuf = require("..");
+
+var proto = "message Outer {repeated int32 numbers = 1 [(js_use_toArray) = true];}";
+
+function SomeNumbers(numbers) {
+    this._numbers = numbers;
+}
+
+SomeNumbers.prototype.toArray = function () {
+    return this._numbers;
+};
+
+var msg = { numbers: new SomeNumbers([1, 2, 3]) };
+
+tape.test("toArray", function(test) {
+    var root = protobuf.parse(proto).root,
+        Outer = root.lookup("Outer");
+
+    var dec = Outer.decode(Outer.encode(msg).finish());
+    test.same(dec, {numbers: [1, 2, 3]}, "should encode and decode back properly");
+    test.end();
+});


### PR DESCRIPTION
We have several use cases for wanting to build up complex nested protobuf
objects incrementally over time before serializing where representing an array
with a repeated field is not helpful during the connstruction process:

- Protobuf maps only support integral and string as keys, so we sometimes have
  fields that are repeated message objects that represent a complex key and
  a value. In order to build up this field over time in a non-quadratic way,
  it would be nice to be able to use an object containing (say) a Map, which
  can be converted to a list of messages once at encoding time.

- We have a `repeated int64` field that represents a histogram (each number
  represents a number of events that fell in a certain duration bucket).
  This histogram generally contains large stretches of 0s so we have a
  compressed encoding where we use negative numbers to encode stretches of
  zeroes. We want to only convert from the uncompressed to compressed encoding
  when we're ready to encode.

These challenges can be solved by creating a hierarchy of classes very similar
to your protobuf hierarchy and converting to protobufs manually when it's time
to encode, but this is a lot of effort to create and maintain. One could also
use JS proxies to trap indexing and trigger some sort of just-in-time conversion
to array, but that's annoying to write and probably not particularly efficient.)

Instead, this change allows plain JS objects to contain non-Arrays for repeated
fields as long as they have a toArray method. Implementations of encode,
fromObject, and verify are updated to call toArray if necessary.  The jsdoc in
static and static-module targets reference this in field typings where
appropriate, which is processed correctly by pbts.

This change only looks for toArray on fields that explicitly contain a
`[(js_use_toArray) = true]` option. This is because of unbenchmarked guesses
that maybe leaving the toArray check out will be faster for fields that don't
need it. This feature would be simpler to use if toArray was just hardcoded,
though.

Note that protobufjs does not require you to declare options, but you'll want to
declare the option if you want to use your proto file with the official protobuf
compiler. Something like this should do the trick:

    import "google/protobuf/descriptor.proto";

    extend google.protobuf.FieldOptions {
      bool js_use_toArray = 50505;
    }

Note that this import will cause protobuf.js to include thousands of lines of
generated code in your output; see #1300.

Example TypeScript usage:

    # report.proto
    syntax = "proto3";
    message Report {
      repeated Entry entries = 1 [(js_use_toArray)=true];
    }
    message Entry {
      string key1 = 1;
      string key2 = 2;
      string value = 3;
    }

    # run.ts
    import {IReport, IEntry, Report, Entry} from "./report";

    class MyEntries {
        private readonly entries = new Map<string, Entry>();
        public set(key1: string, key2: string, value: string) {
            const entry = new Entry({key1, key2, value});
            const key = JSON.stringify({key1, key2});
            this.entries.set(key, entry);
        }
        public toArray(): IEntry[] {
            return Array.from(this.entries.values());
        }
    }

    const r: IReport = new Report({entries: new MyEntries()});
    const nestedEntries = r.entries as MyEntries;
    nestedEntries.set("x", "y", "v");
    nestedEntries.set("x", "y", "w");
    nestedEntries.set("a", "b", "c");

    const roundTrip = Report.decode(Report.encode(r).finish());
    console.log(roundTrip);