### PR TITLE
Fixes #1316: In synchronous mode throw before checking for the presence of a callback

### DIFF
--- a/src/root.js
+++ b/src/root.js
@@ -86,12 +86,12 @@ Root.prototype.load = function load(filename, options, callback) {
     // Finishes loading by calling the callback (exactly once)
     function finish(err, root) {
         /* istanbul ignore if */
+        if (sync)
+            throw err;
         if (!callback)
             return;
         var cb = callback;
         callback = null;
-        if (sync)
-            throw err;
         cb(err, root);
     }
 	

--- a/tests/data/imports-invalid.proto
+++ b/tests/data/imports-invalid.proto
@@ -1,0 +1,1 @@
+import "./invalid.proto";

--- a/tests/node/api_load-sync.js
+++ b/tests/node/api_load-sync.js
@@ -26,6 +26,10 @@ tape.test("load sync", function(test) {
     }, Error, "should throw when trying to load an invalid proto");
 
     test.throws(function() {
+        protobuf.loadSync("tests/data/imports-invalid.proto");
+    }, Error, "should throw when trying to import an invalid proto");
+
+    test.throws(function() {
         protobuf.loadSync("tests/data/invalid.json");
     }, Error, "should throw when trying to load invalid json");
 


### PR DESCRIPTION
This ensures that throws are propagated all the way up the call stack and now swallowed by process.