### PR TITLE
Prevent jsdoc upgrade

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "gulp-uglify": "^3.0.0",
     "istanbul": "^0.4.5",
     "jaguarjs-jsdoc": "github:dcodeIO/jaguarjs-jsdoc",
-    "jsdoc": "^3.5.5",
+    "jsdoc": "3.5.5",
     "minimist": "^1.2.0",
     "reflect-metadata": "^0.1.12",
     "semver": "^5.5.0",


### PR DESCRIPTION
pbts currently doesn't work with jsdoc 3.6.x and will emit broken
definitions when trying to use it.

As the toplevel package-lock.json is not respected by `npm install` as
executed by the CLI utils, fix the jsdoc version to 3.5.5 in
package.json.

Fixes #1342