### PR TITLE
docs: fix the JSON example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,11 +285,15 @@ The library utilizes JSON descriptors that are equivalent to a .proto definition
 // awesome.json
 {
   "nested": {
-    "AwesomeMessage": {
-      "fields": {
-        "awesomeField": {
-          "type": "string",
-          "id": 1
+    "awesomepackage": {
+      "nested": {
+          "AwesomeMessage": {
+          "fields": {
+            "awesomeField": {
+              "type": "string",
+              "id": 1
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
The json example was not equivalent to the .proto file. The message type should be nested in a namespace.