### PR TITLE
build: adds configuration file for tagging releases automatically

### DIFF
--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -1,0 +1,2 @@
+releaseType: node
+handleGHRelease: true


### PR DESCRIPTION
This will configure the automated tagging of GitHub releases.