### PR TITLE
Fix decoding of varints with extra padding bytes

### DIFF
--- a/src/reader.js
+++ b/src/reader.js
@@ -92,8 +92,16 @@ Reader.prototype.uint32 = (function read_uint32_setup() {
         value = (value | (this.buf[this.pos] & 127) << 21) >>> 0; if (this.buf[this.pos++] < 128) return value;
         value = (value | (this.buf[this.pos] &  15) << 28) >>> 0; if (this.buf[this.pos++] < 128) return value;
 
+        if (this.buf[this.pos++] >= 128
+                && this.buf[this.pos++] >= 128
+                && this.buf[this.pos++] >= 128
+                && this.buf[this.pos++] >= 128
+                && this.buf[this.pos++] >= 128) {
+            throw Error("varint too long");
+        }
+
         /* istanbul ignore if */
-        if ((this.pos += 5) > this.len) {
+        if (this.pos > this.len) {
             this.pos = this.len;
             throw indexOutOfRange(this, 10);
         }

--- a/tests/comp_int32.js
+++ b/tests/comp_int32.js
@@ -1,0 +1,16 @@
+var tape = require("tape");
+
+var protobuf  = require("..");
+
+tape.test("int32 values with padding", function(test) {
+    // 12345 encoded as a varint with 7 extra 0 bytes on the end
+    var buf = Uint8Array.from([185, 224, 128, 128, 128, 128, 128, 128, 0]);
+
+    var reader = protobuf.Reader.create(buf);
+
+    test.equal(reader.int32(), 12345, "should decode padded varint");
+
+    test.equal(reader.pos, 9, "should have consumed the entire test buffer");
+
+    test.end();
+});


### PR DESCRIPTION
According to the protobuf conformance tests, it's valid for a varint to
have unnecessary trailing zero bytes. This case wasn't being handled
properly. Fixes #1067.