### PR TITLE
fix: Don't imply --wrap es6 from --es6 in pbjs

### DIFF
--- a/cli/pbjs.js
+++ b/cli/pbjs.js
@@ -194,9 +194,8 @@ exports.main = function main(args, callback) {
         return resolved;
     };
 
-    // Use es6 syntax if not explicitly specified on the command line and the es6 wrapper is used
-    if (argv.wrap === "es6" || argv.es6) {
-        argv.wrap = "es6";
+    // `--wrap es6` implies `--es6` but not the other way around. You can still use e.g. `--es6 --wrap commonjs`
+    if (argv.wrap === "es6") {
         argv.es6 = true;
     }
 


### PR DESCRIPTION
The documented and epected behaviour is that `--wrap es6` implies `---es6` but not the other way around.

Closes #1308