### PR TITLE
Fix namespace resolution

### DIFF
--- a/src/namespace.js
+++ b/src/namespace.js
@@ -345,12 +345,7 @@ Namespace.prototype.lookup = function lookup(path, filterTypes, parentAlreadyChe
                 return found;
         } else if (found instanceof Namespace && (found = found.lookup(path.slice(1), filterTypes, true)))
             return found;
-
-    // Otherwise try each nested namespace
-    } else
-        for (var i = 0; i < this.nestedArray.length; ++i)
-            if (this._nestedArray[i] instanceof Namespace && (found = this._nestedArray[i].lookup(path, filterTypes, true)))
-                return found;
+    }
 
     // If there hasn't been a match, try again at the parent
     if (this.parent === null || parentAlreadyChecked)

--- a/tests/comp_google_protobuf_any.js
+++ b/tests/comp_google_protobuf_any.js
@@ -23,7 +23,7 @@ var root = protobuf.Root.fromJSON({
     }
 }).addJSON(protobuf.common["google/protobuf/any.proto"].nested).resolveAll();
 
-var Any = root.lookupType("protobuf.Any"),
+var Any = root.lookupType("google.protobuf.Any"),
     Foo = root.lookupType(".Foo"),
     Bar = root.lookupType(".Bar");
 


### PR DESCRIPTION
Let's explain it on an example:
```proto
message Foo {
    required Bar b = 1;
    required Qux q = 2;

    message Bar {
        required Corge c = 1;
    }

    message Qux {
        required Corge c = 1;

        message Corge {
            required string someString = 1;
        }
    }
}

message Corge {
    required int64 someInt = 1;
}
```
In this case, `Foo.Bar.c` should be of type `.Corge`, and hence have an integer field `someInt` ([see docs](https://developers.google.com/protocol-buffers/docs/proto#packages_and_name_resolution)). However, by running `pbjs -t static -o out.js example.proto` we can see that this is not the case, and the type resolves to `.Foo.Qux.Corge` instead:
```js
// ...
    Foo.Bar = (function() {

        /**
         * Properties of a Bar.
         * @memberof Foo
         * @interface IBar
         * @property {Foo.Qux.ICorge} c Bar c
         */
// ...
```
`protoc` generates it correctly, as seen in this generated C++ code:
```cpp
size_t Foo_Bar::ByteSizeLong() const {
// @@protoc_insertion_point(message_byte_size_start:Foo.Bar)
  size_t total_size = 0;

  // required .Corge c = 1;
  if (_internal_has_c()) {
    total_size += 1 +
      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(
        *c_);
  }
```
This PR fixes that.