### PR TITLE
fix: do not fail if no process

### DIFF
--- a/src/util/minimal.js
+++ b/src/util/minimal.js
@@ -52,7 +52,9 @@ util.emptyObject = Object.freeze ? Object.freeze({}) : /* istanbul ignore next *
  * @type {boolean}
  * @const
  */
-util.isNode = Boolean(process && process.versions && process.versions.node);
+util.isNode = Boolean(typeof process !== "undefined" && process &&
+                      typeof process.versions !== "undefined" && process.versions &&
+                      process.versions.node);
 
 /**
  * Tests if the specified value is an integer.


### PR DESCRIPTION
The problem was introduced in #1363.

```
$ npm run make
...
ReferenceError: process is not defined
    at Object.r.39.1 (evalmachine.<anonymous>:7:64076)
    at t (evalmachine.<anonymous>:7:73046)
    at Object.r.42.39 (evalmachine.<anonymous>:7:69283)
    at t (evalmachine.<anonymous>:7:73046)
    at Object.r.18.27 (evalmachine.<anonymous>:7:23855)
    at t (evalmachine.<anonymous>:7:73046)
    at Object.r.17.12 (evalmachine.<anonymous>:7:23036)
    at t (evalmachine.<anonymous>:7:73046)
    at Object.r.19.11 (evalmachine.<anonymous>:7:24055)
    at t (evalmachine.<anonymous>:7:73046)
```

Let's make sure we actually have `process` before accessing it.