### PR TITLE
fix: make node detection a bit more forgiving

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1951,14 +1951,17 @@ export namespace util {
         public length(): number;
     }
 
+    /** Whether running within node or not. */
+    let isNode: boolean;
+
+    /** Global object reference. */
+    let global: object;
+
     /** An immuable empty array. */
     const emptyArray: any[];
 
     /** An immutable empty object. */
     const emptyObject: object;
-
-    /** Whether running within node or not. */
-    const isNode: boolean;
 
     /**
      * Tests if the specified value is an integer.

--- a/src/util/minimal.js
+++ b/src/util/minimal.js
@@ -25,8 +25,18 @@ util.pool = require("@protobufjs/pool");
 // utility to work with the low and high bits of a 64 bit value
 util.LongBits = require("./longbits");
 
+/** Tests whether the specified object is most likely a node.js process. */
+function isNodeProcess(process) {
+    return Boolean(process && process.versions && process.versions.node);
+}
+
+/** Tests whether the specified object is most likely a node.js global. */
+function isNodeGlobal(global) {
+    return global && isNodeProcess(global.process);
+}
+
 // global object reference
-util.global = typeof global !== "undefined" && Object.prototype.toString.call(global) === "[object global]" && global
+util.global = typeof global !== "undefined" && isNodeGlobal(global) && global
            || typeof window !== "undefined" && window
            || typeof self   !== "undefined" && self
            || this; // eslint-disable-line no-invalid-this
@@ -52,7 +62,7 @@ util.emptyObject = Object.freeze ? Object.freeze({}) : /* istanbul ignore next *
  * @type {boolean}
  * @const
  */
-util.isNode = Boolean(util.global.process && util.global.process.versions && util.global.process.versions.node);
+util.isNode = isNodeProcess(util.global.process);
 
 /**
  * Tests if the specified value is an integer.

--- a/src/util/minimal.js
+++ b/src/util/minimal.js
@@ -30,11 +30,11 @@ util.LongBits = require("./longbits");
  * @memberof util
  * @type {boolean}
  */
-util.isNode = typeof global !== "undefined"
-           && global
-           && global.process
-           && global.process.versions
-           && global.process.versions.node;
+util.isNode = Boolean(typeof global !== "undefined"
+                   && global
+                   && global.process
+                   && global.process.versions
+                   && global.process.versions.node);
 
 /**
  * Global object reference.

--- a/src/util/minimal.js
+++ b/src/util/minimal.js
@@ -25,18 +25,23 @@ util.pool = require("@protobufjs/pool");
 // utility to work with the low and high bits of a 64 bit value
 util.LongBits = require("./longbits");
 
-/** Tests whether the specified object is most likely a node.js process. */
-function isNodeProcess(process) {
-    return Boolean(process && process.versions && process.versions.node);
-}
+/**
+ * Whether running within node or not.
+ * @memberof util
+ * @type {boolean}
+ */
+util.isNode = typeof global !== "undefined"
+           && global
+           && global.process
+           && global.process.versions
+           && global.process.versions.node;
 
-/** Tests whether the specified object is most likely a node.js global. */
-function isNodeGlobal(global) {
-    return global && isNodeProcess(global.process);
-}
-
-// global object reference
-util.global = typeof global !== "undefined" && isNodeGlobal(global) && global
+/**
+ * Global object reference.
+ * @memberof util
+ * @type {Object}
+ */
+util.global = util.isNode && global
            || typeof window !== "undefined" && window
            || typeof self   !== "undefined" && self
            || this; // eslint-disable-line no-invalid-this
@@ -55,14 +60,6 @@ util.emptyArray = Object.freeze ? Object.freeze([]) : /* istanbul ignore next */
  * @const
  */
 util.emptyObject = Object.freeze ? Object.freeze({}) : /* istanbul ignore next */ {}; // used on prototypes
-
-/**
- * Whether running within node or not.
- * @memberof util
- * @type {boolean}
- * @const
- */
-util.isNode = isNodeProcess(util.global.process);
 
 /**
  * Tests if the specified value is an integer.


### PR DESCRIPTION
A follow-up to https://github.com/protobufjs/protobuf.js/pull/1441, specifically https://github.com/protobufjs/protobuf.js/pull/1441#issuecomment-658355477, that makes the node.js check a bit more forgiving in case the `global` object has been augmented.

Fixes https://github.com/protobufjs/protobuf.js/issues/1443, fixes https://github.com/protobufjs/protobuf.js/pull/1444