### PR TITLE
Add to existing protobuf namespace instead of overwriting it

### DIFF
--- a/cli/targets/static.js
+++ b/cli/targets/static.js
@@ -110,11 +110,19 @@ function buildNamespace(ref, ns) {
     if (!ns)
         return;
     if (ns.name !== "") {
+        if (!(ns instanceof Type) && !(ns instanceof Service)) {
+            push("");
+            pushComment([
+                ns.comment || "Namespace " + ns.name + ".",
+                ns.parent instanceof protobuf.Root ? "@exports " + escapeName(ns.name) : "@memberof " + exportName(ns.parent),
+                "@namespace"
+            ]);
+        }
         push("");
         if (!ref && config.es6)
-            push("export const " + escapeName(ns.name) + " = " + escapeName(ref) + "." + escapeName(ns.name) + " = (() => {");
+            push("export const " + escapeName(ns.name) + " = " + escapeName(ref) + "." + escapeName(ns.name) + " = ((" + escapeName(ns.name) + ") => {");
         else
-            push(escapeName(ref) + "." + escapeName(ns.name) + " = (function() {");
+            push(escapeName(ref) + "." + escapeName(ns.name) + " = (function(" + escapeName(ns.name) + ") {");
         ++indent;
     }
 
@@ -122,15 +130,6 @@ function buildNamespace(ref, ns) {
         buildType(undefined, ns);
     } else if (ns instanceof Service)
         buildService(undefined, ns);
-    else if (ns.name !== "") {
-        push("");
-        pushComment([
-            ns.comment || "Namespace " + ns.name + ".",
-            ns.parent instanceof protobuf.Root ? "@exports " + escapeName(ns.name) : "@memberof " + exportName(ns.parent),
-            "@namespace"
-        ]);
-        push((config.es6 ? "const" : "var") + " " + escapeName(ns.name) + " = {};");
-    }
 
     ns.nestedArray.forEach(function(nested) {
         if (nested instanceof Enum)
@@ -142,7 +141,7 @@ function buildNamespace(ref, ns) {
         push("");
         push("return " + escapeName(ns.name) + ";");
         --indent;
-        push("})();");
+        push("})(" + escapeName(ref) + util.safeProp(escapeName(ns.name)) + " || {});");
     }
 }
 


### PR DESCRIPTION
Addresses a bug related to loading multiple pbjs-generated JS files on one page.

When loading .js files generated by pbjs (static-module) if those .js files contain protos that belong to the same namespace, they will clobber each other at runtime.

**Repro**

a.proto
```
syntax = "proto3";
package my_pkg;

message MyMessageA {
    string a_field = 1;
}
```

b.proto
```
syntax = "proto3";
package my_pkg;

message MyMessageB {
    string b_field = 1;
}
```

```
pbjs -t static-module -w es6 -o a.js a.proto
```
```
pbjs -t static-module -w es6 -o b.js b.proto
```

After running these commands, a.js and b.js both contain:
```
export const my_pkg = $root.my_pkg = (() => {
```

So if b.js is loaded after a.js, it will erase the entries created by a.js, and vice versa.

**Solution**
This PR makes a change to code generation so the protobuf namespaces are extended at runtime:

```
export const my_pkg = $root.my_pkg = ((my_pkg) => {
   ...
})($root.my_pkg || {});
```

This changed solved the problem for us at dropbox.




