### PR TITLE
verify now allows string values in enums

### DIFF
--- a/src/verifier.js
+++ b/src/verifier.js
@@ -24,9 +24,12 @@ function genVerifyValue(gen, field, fieldIndex, ref) {
             ("switch(%s){", ref)
                 ("default:")
                     ("return%j", invalid(field, "enum value"));
-            for (var keys = Object.keys(field.resolvedType.values), j = 0; j < keys.length; ++j) gen
-                ("case %i:", field.resolvedType.values[keys[j]]);
-            gen
+            for (var keys = Object.keys(field.resolvedType.values), j = 0; j < keys.length; ++j) {
+                gen
+                    ("case %i:", field.resolvedType.values[keys[j]])
+                    ("case %j:", keys[j]);
+                }
+                gen
                     ("break")
             ("}");
         } else {


### PR DESCRIPTION
This fixes #1261

I haven't figured out the test suite yet, so that will follow. But in the mean time, I hope this addition could be considered.