### PR TITLE
feat: support proper JSON for Value and Duration

### DIFF
--- a/src/converter.js
+++ b/src/converter.js
@@ -32,10 +32,15 @@ function genValuePartial_fromObject(gen, field, fieldIndex, prop) {
                     ("break");
             } gen
             ("}");
-        } else gen
-            ("if(typeof d%s!==\"object\")", prop)
-                ("throw TypeError(%j)", field.fullName + ": object expected")
+        } else {
+            if (field.type !== "google.protobuf.Value" && field.type !== "google.protobuf.Duration")
+            // google.protobuf.Value and google.protobuf.Duration can accept non-objects
+                gen
+                ("if(typeof d%s!==\"object\")", prop)
+                    ("throw TypeError(%j)", field.fullName + ": object expected");
+            gen
             ("m%s=types[%i].fromObject(d%s)", prop, fieldIndex, prop);
+        }
     } else {
         var isUnsigned = false;
         switch (field.type) {
@@ -132,10 +137,12 @@ converter.fromObject = function fromObject(mtype) {
 
         // Non-repeated fields
         } else {
-            if (!(field.resolvedType instanceof Enum)) gen // no need to test for null/undefined if an enum (uses switch)
+            if (!(field.resolvedType instanceof Enum) && field.type !== "google.protobuf.Value")
+            // no need to test for null/undefined if an enum (uses switch) and for google.protobuf.Value (can be null)
+                gen
     ("if(d%s!=null){", prop); // !== undefined && !== null
         genValuePartial_fromObject(gen, field, /* not sorted */ i, prop);
-            if (!(field.resolvedType instanceof Enum)) gen
+            if (!(field.resolvedType instanceof Enum) && field.type !== "google.protobuf.Value") gen
     ("}");
         }
     } return gen

--- a/src/wrappers.js
+++ b/src/wrappers.js
@@ -100,3 +100,172 @@ wrappers[".google.protobuf.Any"] = {
         return this.toObject(message, options);
     }
 };
+
+// recursive .fromObject implementation for google.protobuf.Value
+function googleProtobufValueFromObject(object, create) {
+    if (object === null) {
+        return create({
+            kind: "nullValue",
+            nullValue: 0
+        });
+    }
+    if (typeof object === "number") {
+        return create({
+            kind: "numberValue",
+            numberValue: object
+        });
+    }
+    if (typeof object === "string") {
+        return create({
+            kind: "stringValue",
+            stringValue: object
+        });
+    }
+    if (Array.isArray(object)) {
+        var array = object.map(function(element) { return googleProtobufValueFromObject(element, create); });
+        return create({
+            kind: "listValue",
+            listValue: {
+                values: array
+            }
+        });
+    }
+    if (typeof object === "object") {
+        var fields = {},
+            names = Object.keys(object),
+            i = 0;
+        for (; i < names.length; ++i) {
+            fields[names[i]] = googleProtobufValueFromObject(object[names[i]], create);
+        }
+        return create({
+            kind: "structValue",
+            structValue: {
+                fields: fields
+            }
+        });
+    }
+    return undefined;
+}
+
+// recursive .toObject implementation for google.protobuf.Value
+function googleProtobufValueToObject(message) {
+    if (message.kind === "nullValue") {
+        return null;
+    }
+    if (message.kind === "numberValue") {
+        return message.numberValue;
+    }
+    if (message.kind === "stringValue") {
+        return message.stringValue;
+    }
+    if (message.kind === "listValue") {
+        return message.listValue.values.map(googleProtobufValueToObject);
+    }
+    if (message.kind === "structValue") {
+        if (!message.structValue.fields) {
+            return {};
+        }
+        var names = Object.keys(message.structValue.fields),
+            i = 0,
+            struct = {};
+        for (; i < names.length; ++i) {
+            struct[names[i]] = googleProtobufValueToObject(message.structValue["fields"][names[i]]);
+        }
+        return struct;
+    }
+    return undefined;
+}
+
+// custom wrapper for google.protobuf.Value
+wrappers[".google.protobuf.Value"] = {
+    fromObject: function(object) {
+        // heuristic: if an object looks like a regular representation of google.protobuf.Value,
+        // with all those stringValues, etc., just accept it as is for compatibility.
+        if (typeof object === "object" && object) {
+            // something that has just one property called stringValue, listValue, etc.,
+            // and possibly a property called kind, is likely an object we don't want to touch
+            var names = Object.keys(object);
+            if (names.length === 1 && names.match(/^(?:null|number|string|list|struct)Value$/) ||
+                names.length === 2 &&
+                    names.every(function(name) {
+                        return name.match(/^(?:kind|(?:null|number|string|list|struct)Value)$/); })
+            ) {
+                return this.fromObject(object);
+            }
+        }
+
+        // otherwise, it's a JSON representation as described in google/protobuf/struct.proto
+        var self = this;
+        var message = googleProtobufValueFromObject(object, function(obj) { return self.create(obj); });
+        if (typeof message !== "undefined") {
+            return message;
+        }
+
+        // fallback to the normal .fromObject if decoding failed
+        return this.fromObject(object);
+    },
+
+    toObject: function(message, options) {
+        // decode value if requested
+        // In the next major version we will get rid of "options.values".
+        if (options && options.json && options.values) {
+            var object = googleProtobufValueToObject(message);
+            if (typeof object !== "undefined") {
+                return object;
+            }
+        }
+
+        return this.toObject(message, options);
+    }
+};
+
+// custom wrapper for google.protobuf.Duration
+wrappers[".google.protobuf.Duration"] = {
+    fromObject: function(object) {
+        var match;
+        if (typeof object === "string") {
+            // whole seconds
+            match = object.match(/^(\d+)s$/);
+            if (match) {
+                return this.create({
+                    seconds: Number(match[1]),
+                    nanos: 0
+                });
+            }
+            // fractional seconds
+            match = object.match(/^(\d*)\.(\d+)s$/);
+            if (match) {
+                var nanos = match[2];
+                // pad trailing zeros; cannot use .padEnd since it will break old versions
+                while (nanos.length < 9) {
+                    nanos = nanos + "0";
+                }
+                return this.create({
+                    seconds: match[1].length > 0 ? Number(match[1]) : 0,
+                    nanos: Number(nanos)
+                });
+            }
+        }
+        return this.fromObject(object);
+    },
+
+    toObject: function(message, options) {
+        if (options && options.json && options.values) {
+            var durationSeconds = message.seconds;
+            if (message.nanos > 0) {
+                var nanosStr = String(message.nanos);
+                // add leading zeros; cannot use .padStart since it will break old versions
+                while (nanosStr.length < 9) {
+                    nanosStr = "0" + nanosStr;
+                }
+                // nanosStr should contain 3, 6, or 9 fractional digits.
+                nanosStr = nanosStr.replace(/^((?:\d\d\d)+?)(?:0*)$/, "$1");
+                durationSeconds += "." + nanosStr;
+            }
+            durationSeconds += "s";
+            return durationSeconds;
+        }
+
+        return this.toObject(message, options);
+    }
+};

--- a/tests/comp_google_protobuf_duration.js
+++ b/tests/comp_google_protobuf_duration.js
@@ -1,0 +1,85 @@
+var tape = require("tape");
+var long = require("long");
+
+var protobuf = require("..");
+
+var root = protobuf.Root.fromJSON({
+    nested: {
+        test: {
+            nested: {
+                Test: {
+                    fields: {
+                        value: {
+                            type: "google.protobuf.Duration",
+                            id: 1
+                        }
+                    }
+                }
+            }
+        }
+    }
+}).addJSON(protobuf.common["google/protobuf/duration.proto"].nested).resolveAll();
+
+var Test = root.lookupType("test.Test");
+
+tape.test.only("google.protobuf.Duration", function(test) {
+    // examples from google/protobuf/duration.proto
+    var integerDuration = {value: "3s"};
+    var fractionalDuration1 = {value: "3.000000001s"};
+    var fractionalDuration2 = {value: "3.000001s"};
+    var regularDuration = {
+        value: {
+            seconds: long.fromNumber(4),
+            nanos: 2
+        }
+    };
+
+    var integerDurationMessage = Test.fromObject(integerDuration);
+    var fractionalDuration1Message = Test.fromObject(fractionalDuration1);
+    var fractionalDuration2Message = Test.fromObject(fractionalDuration2);
+    var regularDurationMessage = Test.fromObject(regularDuration);
+
+    test.same(integerDurationMessage, {
+        value: {
+            seconds: 3,
+            nanos: 0
+        }
+    }, "toObject should understand integer seconds as string");
+    test.same(fractionalDuration1Message, {
+        value: {
+            seconds: 3,
+            nanos: 1
+        }
+    }, "toObject should understand fractional seconds as string 1");
+    test.same(fractionalDuration2Message, {
+        value: {
+            seconds: 3,
+            nanos: 1000
+        }
+    }, "toObject should understand fractional seconds as string 2");
+    test.same(regularDurationMessage, {
+        value: {
+            seconds: {low: 4, high: 0, unsigned: false},
+            nanos: 2
+        }
+    }, "toObject should understand regular Duration message");
+
+    test.same(Test.toObject(integerDurationMessage, {json: true, values: true}), {value: "3s"}, "toObject should produce integer seconds");
+    test.same(Test.toObject(fractionalDuration1Message, {json: true, values: true}), {value: "3.000000001s"}, "toObject should produce fractional seconds 1");
+    test.same(Test.toObject(fractionalDuration2Message, {json: true, values: true}), {value: "3.000001s"}, "toObject should produce fractional seconds 2");
+    test.same(Test.toObject(regularDurationMessage, {json: true, values: true}), {value: "4.000000002s"}, "toObject should produce fractional seconds 3");
+    test.same(Test.toObject(regularDurationMessage), regularDurationMessage, "toObject should produce a regular Duration object by default");
+
+    test.same(Test.toObject({ value: { seconds: 0, nanos: 100000000 }}, {json: true, values: true}), { value: "0.100s"}, "toObject string should contain 3, 6, or 9 fractional digits 1");
+    test.same(Test.toObject({ value: { seconds: 0, nanos: 10000000 }}, {json: true, values: true}), { value: "0.010s"}, "toObject string should contain 3, 6, or 9 fractional digits 1");
+    test.same(Test.toObject({ value: { seconds: 0, nanos: 1000000 }}, {json: true, values: true}), { value: "0.001s"}, "toObject string should contain 3, 6, or 9 fractional digits 1");
+    test.same(Test.toObject({ value: { seconds: 0, nanos: 100000 }}, {json: true, values: true}), { value: "0.000100s"}, "toObject string should contain 3, 6, or 9 fractional digits 1");
+    test.same(Test.toObject({ value: { seconds: 0, nanos: 10000 }}, {json: true, values: true}), { value: "0.000010s"}, "toObject string should contain 3, 6, or 9 fractional digits 1");
+    test.same(Test.toObject({ value: { seconds: 0, nanos: 1000 }}, {json: true, values: true}), { value: "0.000001s"}, "toObject string should contain 3, 6, or 9 fractional digits 1");
+    test.same(Test.toObject({ value: { seconds: 0, nanos: 100 }}, {json: true, values: true}), { value: "0.000000100s"}, "toObject string should contain 3, 6, or 9 fractional digits 1");
+    test.same(Test.toObject({ value: { seconds: 0, nanos: 10 }}, {json: true, values: true}), { value: "0.000000010s"}, "toObject string should contain 3, 6, or 9 fractional digits 1");
+    test.same(Test.toObject({ value: { seconds: 0, nanos: 1 }}, {json: true, values: true}), { value: "0.000000001s"}, "toObject string should contain 3, 6, or 9 fractional digits 1");
+    test.same(Test.toObject({ value: { seconds: 0, nanos: 0 }}, {json: true, values: true}), { value: "0s"}, "toObject string is valid for zero duration");
+
+    test.end();
+});

--- a/tests/comp_google_protobuf_value.js
+++ b/tests/comp_google_protobuf_value.js
@@ -1,0 +1,143 @@
+var tape = require("tape");
+
+var protobuf = require("..");
+
+var root = protobuf.Root.fromJSON({
+    nested: {
+        test: {
+            nested: {
+                Test: {
+                    fields: {
+                        value: {
+                            type: "google.protobuf.Value",
+                            id: 1
+                        }
+                    }
+                }
+            }
+        }
+    }
+}).addJSON(protobuf.common["google/protobuf/struct.proto"].nested).resolveAll();
+
+var Test = root.lookupType("test.Test");
+
+tape.test("google.protobuf.Value", function(test) {
+    var originalNestedMessage = {
+        value: {
+            kind: 'listValue',
+            listValue: {
+                values: [
+                    {
+                        kind: 'nullValue',
+                        nullValue: 0
+                    },
+                    {
+                        kind: 'numberValue',
+                        numberValue: 42
+                    },
+                    {
+                        kind: 'stringValue',
+                        stringValue: 'string'
+                    },
+                    {
+                        kind: 'structValue',
+                        structValue: {
+                            fields: {
+                                a: {
+                                    kind: 'stringValue',
+                                    stringValue: 'b'
+                                },
+                                c: {
+                                    kind: 'listValue',
+                                    listValue: {
+                                        values: [
+                                            {
+                                                kind: 'numberValue',
+                                                numberValue: 3.14
+                                            },
+                                            {
+                                                kind: 'numberValue',
+                                                numberValue: 2.71
+                                            }
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    }
+                ]
+            }
+        }
+    };
+
+    // The same message as above, but without `kind` fields for oneofs, since
+    // they won't be compared in test.same below
+    var originalNestedMessageNoKind = {
+        value: {
+            listValue: {
+                values: [
+                    {
+                        nullValue: 0
+                    },
+                    {
+                        numberValue: 42
+                    },
+                    {
+                        stringValue: 'string'
+                    },
+                    {
+                        structValue: {
+                            fields: {
+                                a: {
+                                    stringValue: 'b'
+                                },
+                                c: {
+                                    listValue: {
+                                        values: [
+                                            {
+                                                numberValue: 3.14
+                                            },
+                                            {
+                                                numberValue: 2.71
+                                            }
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    }
+                ]
+            }
+        }
+    };
+
+    // the same object as above, but in the JSON format described in google/protobuf/struct.proto
+    var nestedObject = {value: [null, 42, 'string', {a: 'b', c: [3.14, 2.71]}]};
+
+    var nullObject = {value: null};
+    var numberObject = {value: 3.14159};
+    var stringObject = {value: 'some string'};
+
+    var nullMessage = Test.fromObject(nullObject);
+    var numberMessage = Test.fromObject(numberObject);
+    var stringMessage = Test.fromObject(stringObject);
+    var nestedMessage = Test.fromObject(nestedObject);
+
+    test.same(nullMessage, {value: {nullValue: 0}}, "fromObject should understand nullValue");
+    test.same(numberMessage, {value: {numberValue: 3.14159}}, "fromObject should understand numberValue");
+    test.same(stringMessage, {value: {stringValue: 'some string'}}, "fromObject should understand stringValue");
+    test.same(nestedMessage, originalNestedMessageNoKind, "fromObject should understand structValue and listValue");
+
+    test.same(Test.toObject(nullMessage, {json: true, values: true}), nullObject, "toObject should understand nullValue");
+    test.same(Test.toObject(numberMessage, {json: true, values: true}), numberObject, "toObject should understand numberValue");
+    test.same(Test.toObject(stringMessage, {json: true, values: true}), stringObject, "toObject should understand stringValue");
+    test.same(Test.toObject(nestedMessage, {json: true, values: true}), nestedObject, "toObject should understand listValue and structValue");
+
+    // it should still accept objects in the original format
+    var msg = Test.fromObject(originalNestedMessage);
+    test.same(msg, originalNestedMessageNoKind, "fromObject should accept regular google.protobuf.Value");
+    console.log(JSON.stringify(Test.toObject(msg), null, '  '));
+    test.same(Test.toObject(msg), originalNestedMessageNoKind, "toObject should generate regular Value object by default");
+
+    test.end();
+});


### PR DESCRIPTION
Fixes #839.

This PR adds support for proper JSON encoding for `google.protobuf.Value`, `google.protobuf.Struct`, and `google.protobuf.Duration`. The "proper JSON" is described in the corresponding protos: [duration](https://github.com/protocolbuffers/protobuf/blob/master/src/google/protobuf/duration.proto#L92-L100), [struct](https://github.com/protocolbuffers/protobuf/blob/master/src/google/protobuf/struct.proto), and [here](https://developers.google.com/protocol-buffers/docs/proto3#json).

To make sure this change does not break anyone, the modifications to `.toObject` are hidden under the new undocumented option `values: true`. The problem here is that we already have an undocumented option `json: true` that changes the behavior for `google.protobuf.Any`, so I cannot safely reuse it without a possibility of breaking users' code.

So, while we're in 6.x, use `{json: true, values: true}` to make `.toObject` generate proper JSON representations for these types. In 7.x I plan to remove `values` and properly document `json` (and probably make it enabled by default - this needs to be discussed).

Note that `.fromObject` is safe to be updated since it will now work in cases where it previously failed (e.g. when the duration of `"3s"` is passed instead of an object with `seconds` and `nanos`), and I consider this to be a feature and not a breaking change.

See also: #1258 - after I spent some time working on this one, I think I will be able to properly review that one too :) (cc: @johncsnyder - thanks for your PR, we'll finally get it merged soon!)