### PR TITLE
fix: empty buffers submitted to a `repeated bytes` field were converted to `undefined`

### DIFF
--- a/src/converter.js
+++ b/src/converter.js
@@ -71,7 +71,7 @@ function genValuePartial_fromObject(gen, field, fieldIndex, prop) {
             case "bytes": gen
                 ("if(typeof d%s===\"string\")", prop)
                     ("util.base64.decode(d%s,m%s=util.newBuffer(util.base64.length(d%s)),0)", prop, prop, prop)
-                ("else if(d%s.length)", prop)
+                ("else if(d%s.length >= 0)", prop)
                     ("m%s=d%s", prop, prop);
                 break;
             case "string": gen

--- a/tests/data/convert.js
+++ b/tests/data/convert.js
@@ -421,7 +421,7 @@ $root.Message = (function() {
             for (var i = 0; i < object.bytesRepeated.length; ++i)
                 if (typeof object.bytesRepeated[i] === "string")
                     $util.base64.decode(object.bytesRepeated[i], message.bytesRepeated[i] = $util.newBuffer($util.base64.length(object.bytesRepeated[i])), 0);
-                else if (object.bytesRepeated[i].length)
+                else if (object.bytesRepeated[i].length >= 0)
                     message.bytesRepeated[i] = object.bytesRepeated[i];
         }
         switch (object.enumVal) {


### PR DESCRIPTION
I believe it is related to the [following issue (#885)](https://github.com/protobufjs/protobuf.js/issues/885). We're experiencing the same problem.

When we're having following `message` in `.proto` file:

```proto
message SomeMessage {
  repeated bytes objects = 1;
}
```

and trying to submit an empty `Buffer` in `objects` list field, the code compiled by `protobufjs` ignores it. I believe by having following statement:

```js
else if (objects[i].length) ...
```

This PR fixes that by including zero-length buffers in the check.

