### PR TITLE
fix: fix when package equal service name

### DIFF
--- a/src/namespace.js
+++ b/src/namespace.js
@@ -347,10 +347,10 @@ Namespace.prototype.lookup = function lookup(path, filterTypes, parentAlreadyChe
             return found;
 
     // Otherwise try each nested namespace
-    } else
-        for (var i = 0; i < this.nestedArray.length; ++i)
-            if (this._nestedArray[i] instanceof Namespace && (found = this._nestedArray[i].lookup(path, filterTypes, true)))
-                return found;
+    }
+    for (var i = 0; i < this.nestedArray.length; ++i)
+        if (this._nestedArray[i] instanceof Namespace && (found = this._nestedArray[i].lookup(path, filterTypes, true)))
+            return found;
 
     // If there hasn't been a match, try again at the parent
     if (this.parent === null || parentAlreadyChecked)


### PR DESCRIPTION
In the proto file, if the service name === package name, then `lookupService` does not work.

Check here: https://github.com/protobufjs/protobuf.js/blob/master/src/namespace.js#L341-L358

When it found a matched name type, it will stop fetching the `nestedArray`.


**Reproduce Code**

```
// test.proto
package greeter;

syntax = "proto2";

service greeter {
    rpc SayHello (HelloRequest) returns (HelloReply) {}
}
message HelloRequest {
    optional string name = 1;
}
message HelloReply {
    optional string message = 1;
}

```
```
// test.js
const protobuf = require('protobufjs');
const root = protobuf.loadSync('./test.proto');
const svr = root.lookupService('greeter'); // This line will throw an Error
```
```
Error: no such Service 'greeter' in Root
    at Root.lookupService (/private/tmp/node_modules/protobufjs/src/namespace.js:426:15)
    at Object.<anonymous> (/private/tmp/test-proto-service/index.js:7:18)
    at Module._compile (internal/modules/cjs/loader.js:689:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:700:10)
    at Module.load (internal/modules/cjs/loader.js:599:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:538:12)
    at Function.Module._load (internal/modules/cjs/loader.js:530:3)
    at Function.Module.runMain (internal/modules/cjs/loader.js:742:12)
    at startup (internal/bootstrap/node.js:279:19)
    at bootstrapNodeJSCore (internal/bootstrap/node.js:752:3)
```