### PR TITLE
Fix type definition of parsedOptions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -860,7 +860,7 @@ export abstract class ReflectionObject {
     public options?: { [k: string]: any };
 
     /** Parsed Options. */
-    public parsedOptions?: { [k: string]: any[] };
+    public parsedOptions?: ({ [k: string]: any | { [innerK: string]: any[] } })[];
 
     /** Unique name within its namespace. */
     public name: string;


### PR DESCRIPTION
Based on tests/actual code: https://github.com/protobufjs/protobuf.js/blob/master/tests/api_object.js#L27-L36

And actual results in my code using that field, the suggested type is the correct one