### PR TITLE
fix!: encoding of empty Buffers

### DIFF
--- a/src/converter.js
+++ b/src/converter.js
@@ -71,7 +71,7 @@ function genValuePartial_fromObject(gen, field, fieldIndex, prop) {
             case "bytes": gen
                 ("if(typeof d%s===\"string\")", prop)
                     ("util.base64.decode(d%s,m%s=util.newBuffer(util.base64.length(d%s)),0)", prop, prop, prop)
-                ("else if(d%s.length)", prop)
+                ("else if(d%s.length >= 0)", prop)
                     ("m%s=d%s", prop, prop);
                 break;
             case "string": gen

--- a/tests/api_converters.js
+++ b/tests/api_converters.js
@@ -12,7 +12,7 @@ tape.test("converters", function(test) {
 
         test.test(test.name + " - Message#toObject", function(test) {
 
-            test.plan(5);
+            test.plan(6);
 
             test.test(test.name + " - called with defaults = true", function(test) {
                 var obj = Message.toObject(Message.create(), { defaults: true });
@@ -23,7 +23,7 @@ tape.test("converters", function(test) {
                 test.same(obj.uint64Val, { low: 0, high: 0, unsigned: true }, "should set uint64Val");
                 test.same(obj.uint64Repeated, [], "should set uint64Repeated");
 
-                test.same(obj.bytesVal, [], "should set bytesVal");
+                test.same(obj.bytesVal, protobuf.util.newBuffer(0), "should set bytesVal");
                 test.same(obj.bytesRepeated, [], "should set bytesRepeated");
 
                 test.equal(obj.enumVal, 1, "should set enumVal to the first defined value");
@@ -130,6 +130,22 @@ tape.test("converters", function(test) {
 
                 test.end();
             });
+
+            test.test(test.name + " - Message.toObject with empty buffers", function(test) {
+                var msg = Message.create({
+                    bytesVal: protobuf.util.newBuffer(0),
+                });
+
+                test.equal(Message.toObject(msg, { bytes: String }).bytesVal, "", "bytes to base64 strings");
+
+                if (protobuf.util.isNode) {
+                    const bytesVal = Message.toObject(msg, { bytes: Buffer }).bytesVal; 
+                    test.ok(Buffer.isBuffer(bytesVal), "bytes to buffers");
+                    test.equal(bytesVal.length, 0, "empty buffer");
+                }
+
+                test.end();
+            });            
 
         });
 

--- a/tests/data/convert.js
+++ b/tests/data/convert.js
@@ -412,7 +412,7 @@ $root.Message = (function() {
         if (object.bytesVal != null)
             if (typeof object.bytesVal === "string")
                 $util.base64.decode(object.bytesVal, message.bytesVal = $util.newBuffer($util.base64.length(object.bytesVal)), 0);
-            else if (object.bytesVal.length)
+            else if (object.bytesVal.length >= 0)
                 message.bytesVal = object.bytesVal;
         if (object.bytesRepeated) {
             if (!Array.isArray(object.bytesRepeated))
@@ -421,7 +421,7 @@ $root.Message = (function() {
             for (var i = 0; i < object.bytesRepeated.length; ++i)
                 if (typeof object.bytesRepeated[i] === "string")
                     $util.base64.decode(object.bytesRepeated[i], message.bytesRepeated[i] = $util.newBuffer($util.base64.length(object.bytesRepeated[i])), 0);
-                else if (object.bytesRepeated[i].length)
+                else if (object.bytesRepeated[i].length >= 0)
                     message.bytesRepeated[i] = object.bytesRepeated[i];
         }
         switch (object.enumVal) {

--- a/tests/data/test.js
+++ b/tests/data/test.js
@@ -3522,7 +3522,7 @@ $root.jspb = (function() {
                 if (object.bytesField != null)
                     if (typeof object.bytesField === "string")
                         $util.base64.decode(object.bytesField, message.bytesField = $util.newBuffer($util.base64.length(object.bytesField)), 0);
-                    else if (object.bytesField.length)
+                    else if (object.bytesField.length >= 0)
                         message.bytesField = object.bytesField;
                 return message;
             };
@@ -4261,7 +4261,7 @@ $root.jspb = (function() {
                 if (object.bytesField != null)
                     if (typeof object.bytesField === "string")
                         $util.base64.decode(object.bytesField, message.bytesField = $util.newBuffer($util.base64.length(object.bytesField)), 0);
-                    else if (object.bytesField.length)
+                    else if (object.bytesField.length >= 0)
                         message.bytesField = object.bytesField;
                 if (object.unused != null)
                     message.unused = String(object.unused);
@@ -6701,7 +6701,7 @@ $root.jspb = (function() {
                 if (object.data != null)
                     if (typeof object.data === "string")
                         $util.base64.decode(object.data, message.data = $util.newBuffer($util.base64.length(object.data)), 0);
-                    else if (object.data.length)
+                    else if (object.data.length >= 0)
                         message.data = object.data;
                 return message;
             };
@@ -14741,7 +14741,7 @@ $root.google = (function() {
                 if (object.stringValue != null)
                     if (typeof object.stringValue === "string")
                         $util.base64.decode(object.stringValue, message.stringValue = $util.newBuffer($util.base64.length(object.stringValue)), 0);
-                    else if (object.stringValue.length)
+                    else if (object.stringValue.length >= 0)
                         message.stringValue = object.stringValue;
                 if (object.aggregateValue != null)
                     message.aggregateValue = String(object.aggregateValue);


### PR DESCRIPTION
closes #1500
fixes #885

The fix is from @jawid-h in #1500. Thanks to him.
I added tests.

Note the change in behavior:
```typescript
-                test.same(obj.bytesVal, [], "should set bytesVal");
+                test.same(obj.bytesVal, protobuf.util.newBuffer(0), "should set bytesVal");
```

The default value for an empty `Buffer` is now a Buffer of length 0 vs an empty array before.

I have not included the generated files in this CL (`dist/*` and `index.d.ts`).
Please let me know if they should be there and I'll add them. 