### PR TITLE
fix: Plumb the forceNumber flag to the converter

### DIFF
--- a/cli/targets/static.js
+++ b/cli/targets/static.js
@@ -407,11 +407,11 @@ function buildType(ref, type) {
         else if (field.map)
             push(escapeName(type.name) + ".prototype" + prop + " = $util.emptyObject;"); // overwritten in constructor
         else if (field.long)
-            push(escapeName(type.name) + ".prototype" + prop + " = $util.Long ? $util.Long.fromBits("
+            push(escapeName(type.name) + ".prototype" + prop + " = " + (!config.forceNumber ? "$util.Long ? $util.Long.fromBits("
                     + JSON.stringify(field.typeDefault.low) + ","
                     + JSON.stringify(field.typeDefault.high) + ","
                     + JSON.stringify(field.typeDefault.unsigned)
-                + ") : " + field.typeDefault.toNumber(field.type.charAt(0) === "u") + ";");
+                + ") : " : "") + field.typeDefault.toNumber(field.type.charAt(0) === "u") + ";");
         else if (field.bytes) {
             push(escapeName(type.name) + ".prototype" + prop + " = $util.newBuffer(" + JSON.stringify(Array.prototype.slice.call(field.typeDefault)) + ");");
         } else
@@ -555,7 +555,7 @@ function buildType(ref, type) {
             "@param {Object.<string,*>} " + (config.beautify ? "object" : "d") + " Plain object",
             "@returns {" + exportName(type) + "} " + type.name
         ]);
-        buildFunction(type, "fromObject", protobuf.converter.fromObject(type));
+        buildFunction(type, "fromObject", protobuf.converter.fromObject(type, config));
 
         push("");
         pushComment([

--- a/tests/api_type.js
+++ b/tests/api_type.js
@@ -33,6 +33,15 @@ var def2 = {
     }
 };
 
+var def3 = {
+    fields: {
+        a: {
+            type: "int64",
+            id: 1
+        }
+    }
+};
+
 tape.test("reflected types", function(test) {
 
     var type = protobuf.Type.fromJSON("Test", def);
@@ -97,6 +106,24 @@ tape.test("reflected types", function(test) {
         type.add(new protobuf.Field("b", 2, "uint32"));
     }, Error, "should throw when trying to add reserved names");
 
+
+    test.end();
+});
+
+tape.test("with no forceNumber option, Longs are used", function(test) {
+
+    var type = protobuf.Type.fromJSON("Test", def3);
+    type.fromObject = protobuf.converter.fromObject(type)({util: protobuf.util});
+    test.same(type.fromObject({a: 1}).a, protobuf.util.Long.fromNumber(1));
+
+    test.end();
+});
+
+tape.test("with forceNumber option, numbers are used", function(test) {
+
+    var type = protobuf.Type.fromJSON("Test", def3);
+    type.fromObject = protobuf.converter.fromObject(type, { forceNumber: true })({util: protobuf.util});
+    test.same(type.fromObject({a: 1}).a, 1);
 
     test.end();
 });


### PR DESCRIPTION
This change makes sure that the generated code also does not attempt to
auto-detect the presence of the `Long` library if the code is generated
with `--force-number`. With tests!