### PR TITLE
feat: Add the `--sound-types` flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -661,6 +661,8 @@ Translates between file formats and generates static code.
   --force-number   Enforces the use of 'number' for s-/u-/int64 and s-/fixed64 fields.
   --force-message  Enforces the use of message instances instead of plain objects.
 
+  --sound-types    Avoid generating JSDoc annotations that lead to unsound types.
+
 usage: pbjs [options] file1.proto file2.json ...  (or pipe)  other | pbjs [options] -
 ```
 

--- a/cli/pbjs.js
+++ b/cli/pbjs.js
@@ -44,7 +44,7 @@ exports.main = function main(args, callback) {
             "force-message": "strict-message"
         },
         string: [ "target", "out", "path", "wrap", "dependency", "root", "lint" ],
-        boolean: [ "create", "encode", "decode", "verify", "convert", "delimited", "beautify", "comments", "es6", "sparse", "keep-case", "force-long", "force-number", "force-enum-string", "force-message" ],
+        boolean: [ "create", "encode", "decode", "verify", "convert", "delimited", "beautify", "comments", "es6", "sparse", "keep-case", "force-long", "force-number", "force-enum-string", "force-message", "sound-types" ],
         default: {
             target: "json",
             create: true,
@@ -61,7 +61,8 @@ exports.main = function main(args, callback) {
             "force-long": false,
             "force-number": false,
             "force-enum-string": false,
-            "force-message": false
+            "force-message": false,
+            "sound-types": false
         }
     });
 
@@ -139,6 +140,8 @@ exports.main = function main(args, callback) {
                 "  --force-long     Enfores the use of 'Long' for s-/u-/int64 and s-/fixed64 fields.",
                 "  --force-number   Enfores the use of 'number' for s-/u-/int64 and s-/fixed64 fields.",
                 "  --force-message  Enfores the use of message instances instead of plain objects.",
+                "",
+                "  --sound-types    Avoid generating JSDoc annotations that lead to unsound types.",
                 "",
                 "usage: " + chalk.bold.green("pbjs") + " [options] file1.proto file2.json ..." + chalk.gray("  (or pipe)  ") + "other | " + chalk.bold.green("pbjs") + " [options] -",
                 ""

--- a/cli/targets/static.js
+++ b/cli/targets/static.js
@@ -339,7 +339,7 @@ function toJsType(field, isPropertyType) {
         default:
             if (field.resolve().resolvedType) {
                 if (config.soundTypes && isPropertyType && !(field.resolvedType instanceof protobuf.Enum)) {
-                    type = exportName(field.resolvedType, false) + '|' + exportName(field.resolvedType, true);
+                    type = exportName(field.resolvedType, false) + "|" + exportName(field.resolvedType, true);
                 } else {
                     type = exportName(field.resolvedType, !(field.resolvedType instanceof protobuf.Enum || config.forceMessage));
                 }

--- a/cli/targets/static.js
+++ b/cli/targets/static.js
@@ -307,7 +307,7 @@ function buildFunction(type, functionName, gen, scope) {
         push("};");
 }
 
-function toJsType(field) {
+function toJsType(field, isPropertyType) {
     var type;
 
     switch (field.type) {
@@ -337,9 +337,13 @@ function toJsType(field) {
             type = "Uint8Array";
             break;
         default:
-            if (field.resolve().resolvedType)
-                type = exportName(field.resolvedType, !(field.resolvedType instanceof protobuf.Enum || config.forceMessage));
-            else
+            if (field.resolve().resolvedType) {
+                if (config.soundTypes && isPropertyType && !(field.resolvedType instanceof protobuf.Enum)) {
+                    type = exportName(field.resolvedType, false) + '|' + exportName(field.resolvedType, true);
+                } else {
+                    type = exportName(field.resolvedType, !(field.resolvedType instanceof protobuf.Enum || config.forceMessage));
+                }
+            } else
                 type = "*"; // should not happen
             break;
     }
@@ -361,7 +365,7 @@ function buildType(ref, type) {
         type.fieldsArray.forEach(function(field) {
             var prop = util.safeProp(field.name); // either .name or ["name"]
             prop = prop.substring(1, prop.charAt(0) === "[" ? prop.length - 1 : prop.length);
-            var jsType = toJsType(field);
+            var jsType = toJsType(field, true);
             if (field.optional)
                 jsType = jsType + "|null";
             typeDef.push("@property {" + jsType + "} " + (field.optional ? "[" + prop + "]" : prop) + " " + (field.comment || type.name + " " + field.name));
@@ -376,7 +380,7 @@ function buildType(ref, type) {
         "Constructs a new " + type.name + ".",
         type.parent instanceof protobuf.Root ? "@exports " + escapeName(type.name) : "@memberof " + exportName(type.parent),
         "@classdesc " + (type.comment || "Represents " + aOrAn(type.name) + "."),
-        config.comments ? "@implements " + escapeName("I" + type.name) : null,
+        config.comments && !config.soundTypes ? "@implements " + escapeName("I" + type.name) : null,
         "@constructor",
         "@param {" + exportName(type, true) + "=} [" + (config.beautify ? "properties" : "p") + "] Properties to set"
     ]);
@@ -389,7 +393,7 @@ function buildType(ref, type) {
         var prop = util.safeProp(field.name);
         if (config.comments) {
             push("");
-            var jsType = toJsType(field);
+            var jsType = toJsType(field, false);
             if (field.optional && !field.map && !field.repeated && field.resolvedType instanceof Type)
                 jsType = jsType + "|null|undefined";
             pushComment([
@@ -456,7 +460,10 @@ function buildType(ref, type) {
         ]);
         push(escapeName(type.name) + ".create = function create(properties) {");
             ++indent;
-            push("return new " + escapeName(type.name) + "(properties);");
+            if (config.soundTypes && config.forceMessage)
+                push("return " + escapeName(type.name) + ".fromObject(properties);");
+            else
+                push("return new " + escapeName(type.name) + "(properties);");
             --indent;
         push("};");
     }


### PR DESCRIPTION
This change adds a flag to enforce the generation of sound type
annotations (which aid in the generation of Flow types, #939).

TypeScript allows certain [unsound
type](https://www.typescriptlang.org/docs/handbook/type-compatibility.html#a-note-on-soundness)
annotations as valid, for compatibility purposes with pre-existing
JavaScript code. That's completely fine since it still allows code to be
safer than what it would be without the type annotations. However, Flow
was designed with a different set of trade-offs, erring on the side of
[soudnness](https://flow.org/en/docs/lang/types-and-expressions/).

With this flag passed in, the generated code will:

a) No longer establish any inheritance between the interface
   (properties) and message types. Interface types allow every single
   property to be optional (having `undefined` as a valid value),
   whereas message types do not allow this. Thus, it would be a
   violation of the [Liskov substitution
   principle](https://en.wikipedia.org/wiki/Liskov_substitution_principle),
   and therefore Flow does not allow this inheritance. Instead, all the
   fields in a interface type explicitly allow both interface and
   message types to be passed in instead of just interface types.
b) When the `--force-message` flag is also passed, have the message
   objects always forward calls to `.create()` to `.fromObject()` instead
   of the constructor. The reason for this is that the properties may
   have fields that are valid interface types, but the message type
   expects these to be message types.