### PR TITLE
pbjs/sparse: fix namespace replacement, include transitive dependencies

### DIFF
--- a/cli/pbjs.js
+++ b/cli/pbjs.js
@@ -251,10 +251,16 @@ exports.main = function main(args, callback) {
         if (tobj.fieldsArray)
             tobj.fieldsArray.forEach(function(fobj) {
                 fobj.referenced = true;
+                var type = fobj.resolvedType;
+                if (type && !type.referenced)
+                    markReferenced(type);
             });
         if (tobj.oneofsArray)
             tobj.oneofsArray.forEach(function(oobj) {
                 oobj.referenced = true;
+                var type = oobj.resolvedType;
+                if (type && !type.referenced)
+                    markReferenced(type);
             });
         // also mark an extension field's extended type, but not its (other) fields
         if (tobj.extensionField)
@@ -286,7 +292,6 @@ exports.main = function main(args, callback) {
                 if (hasReferenced) { // replace with plain namespace if a namespace subclass
                     if (obj instanceof protobuf.Type || obj instanceof protobuf.Service) {
                         var robj = new protobuf.Namespace(obj.name, obj.options);
-                        robj.nested = obj.nested;
                         parent.add(robj);
                     }
                 } else // remove completely if nothing inside is referenced

--- a/src/namespace.js
+++ b/src/namespace.js
@@ -225,8 +225,8 @@ Namespace.prototype.add = function add(object) {
     else {
         var prev = this.get(object.name);
         if (prev) {
-            if (prev instanceof Namespace && object instanceof Namespace && !(prev instanceof Type || prev instanceof Service)) {
-                // replace plain namespace but keep existing nested elements and options
+            if (prev instanceof Namespace && object instanceof Namespace && !(prev instanceof Service)) {
+                // replace plain namespace or type, but keep existing nested elements and options
                 var nested = prev.nestedArray;
                 for (var i = 0; i < nested.length; ++i)
                     object.add(nested[i]);


### PR DESCRIPTION
This fixes sparse mode for my use-case. Protos are spread over several
files, and may include nested messages/enums from other files.
Additionally, this fixes the case where a Type is replaced by a Namespace,
e.g. when an enum is used without its containing message type.

Fixes #1436