### PR TITLE
Refactor Inquire so it can resolve modules in Browsers with default CPS

### DIFF
--- a/lib/inquire/README.md
+++ b/lib/inquire/README.md
@@ -10,4 +10,10 @@ API
 * **inquire(moduleName: `string`): `?Object`**<br />
   Requires a module only if available.
 
+Browser Bundler Compatibility
+---
+Inquire can be used in browser modules if these configurations are set:
+ 1) If a bundler is used, all modules loaded with inquire() must be added to the bundle config field "externals". This is supported by [webpack](https://webpack.js.org/configuration/externals/), [browserify](https://github.com/browserify/browserify#usage) ([gulp](https://benclinkinbeard.com/posts/external-bundles-for-faster-browserify-builds/)), [rollup](https://rollupjs.org/guide/en/#inputoptions-object), and possibly others.
+ 2) When used in node/npm packages for distribution (including protobufjs) all modules loaded with inquire() must be [ignored in the package.json browser option](https://github.com/defunctzombie/package-browser-field-spec#ignore-a-module). This is also [supported by webpack, browserify and rollup](https://github.com/webpack/webpack/issues/8826#issuecomment-491081733).
+
 **License:** [BSD 3-Clause License](https://opensource.org/licenses/BSD-3-Clause)

--- a/lib/inquire/index.js
+++ b/lib/inquire/index.js
@@ -3,13 +3,24 @@ module.exports = inquire;
 
 /**
  * Requires a module only if available.
+ * All modules requested with inquire must be set as externals in browserify.json, e.g.
+ *   "externals": [
+ *     "long",
+ *     "buffer"
+ *   ]
+ * and added ignored in the package.json browser field, e.g.
+ *     "browser": {
+ *         "long": false,
+ *         "buffer": false
+ *     }
+ *
  * @memberof util
  * @param {string} moduleName Module to require
  * @returns {?Object} Required module if available and not empty, otherwise `null`
  */
 function inquire(moduleName) {
     try {
-        var mod = eval("quire".replace(/^/,"re"))(moduleName); // eslint-disable-line no-eval
+        var mod = require(moduleName);
         if (mod && (mod.length || Object.keys(mod).length))
             return mod;
     } catch (e) {} // eslint-disable-line no-empty

--- a/lib/inquire/package.json
+++ b/lib/inquire/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@protobufjs/inquire",
-  "description": "Requires a module only if available and hides the require call from bundlers.",
+  "description": "Requires a module only if available.",
   "version": "1.1.0",
   "author": "Daniel Wirtz <dcode+protobufjs@dcode.io>",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,14 @@
   ],
   "main": "index.js",
   "types": "index.d.ts",
+  "browser": {
+    "long": false,
+    "buffer": false
+  },
+  "bin": {
+    "pbjs": "bin/pbjs",
+    "pbts": "bin/pbts"
+  },
   "scripts": {
     "bench": "node bench",
     "build": "npm run build:bundle && npm run build:types",

--- a/scripts/browserify.json
+++ b/scripts/browserify.json
@@ -1,0 +1,6 @@
+{
+  "externals": [
+    "long",
+    "buffer"
+  ]
+}

--- a/scripts/bundle.js
+++ b/scripts/bundle.js
@@ -16,6 +16,7 @@ var vinylfs    = require("vinyl-fs");
 var source     = require("vinyl-source-stream");
 
 var pkg = require(path.join(__dirname, "..", "package.json"));
+var { externals } = require("./browserify.json");
 
 /*eslint-disable no-template-curly-in-string*/
 var license = [
@@ -50,7 +51,7 @@ function bundle(options) {
         prelude: prelude,
         preludePath: "./lib/prelude.js"
     })
-    .external("long");
+    .external(externals);
     if (options.exclude)
         options.exclude.forEach(bundler.exclude, bundler);
     return bundler


### PR DESCRIPTION
### inquire() cannot resolve any modules in browsers that do not allow `unsafe-eval`
inquire() will always return null in browsers with default CPS settings, even if the requested module is present. This PR fixes that issue while maintaining all desired bundling behavior or inquire.

### Problem
While investigating https://github.com/protobufjs/protobuf.js/issues/1483 I found that browsers are blocking the execution of eval() in inquire().  [This repl](https://repl.it/@seanlangbrown/unsafe-eval-protobufjs#client/index.js) reproduces and investigates the issue.

The purpose of inquire is to require a module if it is already available in the environment, but "hide" the module from bundlers so that it is not included as a dependency.  To do this, inquire js used eval() and regex as a workaround so that bundlers do not notice the require call during static code analysis:

```js
function inquire(moduleName) {
    try {
        var mod = eval("quire".replace(/^/,"re"))(moduleName); // eslint-disable-line no-eval
        if (mod && (mod.length || Object.keys(mod).length))
            return mod;
    } catch (e) {} // eslint-disable-line no-empty
    return null;
}
```

**Unfortunately, today's browsers have [CPS settings that block eval() by default](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src#unsafe_eval_expressions), so inquire() cannot require any modules at all (including modules that are available in the environment)**.  Changing the defaults so that 'unsafe-eval' is allowed, which affects the entire page and is not recommended for security.  In addition to the functional issues, many less experienced web developers using protobufJS see warning messages in the browser console and think that they must allow unsafe-eval to use protobufjs, for example https://github.com/protobufjs/protobuf.js/issues/593, https://github.com/protobufjs/protobuf.js/issues/1483.

We can show that inquire() does not work with CPS defaults by simulating the browser environment like this:
```js
function runInquireInBrowser(moduleName) {
  var blockedEval = function(){throw Error("Unsafe-Eval is blocked")};
  var browserCSPDefault = { eval: blockedEval, "Function": blockedEval };
  
  with (browserCSPDefault) {
      try {
          var mod = eval("quire".replace(/^/,"re"))(moduleName); // EXCEPTION: "Unsafe-Eval is blocked"
          if (mod && (mod.length || Object.keys(mod).length))
              return mod;
      } catch (e) {} // EXCEPTION is caught
        return null; // always returns null
  }
}
const result = runInquireInBrowser('fs');
```
We can reason that result will always be null.


### Solution
Using eval() for this made sense 10+ years ago. There is now an accepted "standard" way of configuring "externals" so dynamic requires can be made while excluding those modules from the bundles.  It is implemented by all major bundlers including [webpack](https://webpack.js.org/configuration/externals/), [browserify](https://github.com/browserify/browserify#usage) ([gulp](https://benclinkinbeard.com/posts/external-bundles-for-faster-browserify-builds/)), [rollup](https://rollupjs.org/guide/en/#inputoptions-object), and possibly others.  By using this standard we can exclude inquired modules (`long` and `buffer`) from protobufjs distributions.

There is also now a way to instruct bundlers not to include dependencies of protobufJS distributions: https://github.com/defunctzombie/package-browser-field-spec#ignore-a-module.  This can be used to prevent webpack from bundling `long` with my website that uses protobufjs.




### Implementation
- New test cases for inquire() in a simulated browser environment with eval blocked
- Removed eval() from inquire
- Added all modules loaded with inquire() to the broswerify config "externals" to prevent protobufJS from including inquired modules in it's bundle.
- Added all modules loaded with inquire() to the protobufJS package.json "browser" field so that any project that uses protobufJS and a bundler will not add inquired modules to it's bundle.
