### PR TITLE
Fixed codegen if exported type name ends with ".Object"

### DIFF
--- a/cli/lib/tsd-jsdoc/publish.js
+++ b/cli/lib/tsd-jsdoc/publish.js
@@ -295,7 +295,7 @@ function getTypeOf(element) {
     name = name.replace(/\bfunction(?:\(\))?\b/g, "Function");
 
     // Convert plain Object back to just object
-    name = name.replace(/\b(Object\b(?!\.))/g, function($0, $1) {
+    name = name.replace(/((?<!\.)\bObject\b(?!\.))/g, function($0, $1) {
         return $1.toLowerCase();
     });
 


### PR DESCRIPTION
Message named `Object` should be allowed when a `package`  name is specified.

```protobuffer
syntax = "proto3";
package foo;
message Object {
    int32 bar = 1;
}
```

```javascript
'Object.'.match(/((?<!\.)\bObject\b(?!\.))/g) // null
'.Object'.match(/((?<!\.)\bObject\b(?!\.))/g) // null
'Object'.match(/((?<!\.)\bObject\b(?!\.))/g) // ["Object"]
```