### PR TITLE
fix: util.global = global when this is undefined

### DIFF
--- a/src/util/minimal.js
+++ b/src/util/minimal.js
@@ -44,7 +44,8 @@ util.isNode = Boolean(typeof global !== "undefined"
 util.global = util.isNode && global
            || typeof window !== "undefined" && window
            || typeof self   !== "undefined" && self
-           || this; // eslint-disable-line no-invalid-this
+           || this // eslint-disable-line no-invalid-this
+           || global; // for user-defined global variable
 
 /**
  * An immuable empty array.


### PR DESCRIPTION
`this` may be `undefined` in strict mode, which will cause error in the following code:

```javascript
util.Long = /* istanbul ignore next */ util.global.dcodeIO && /* istanbul ignore next */ util.global.dcodeIO.Long
         || /* istanbul ignore next */ util.global.Long
         || util.inquire("long");
```

Instead keeps the util.global as undefined, we assign user defined `global` to `util.global`. This can be very useful when using protobuf.js in some specifical platform (for example: game engine).