### PR TITLE
fix: wrong arg type to pushComment

### DIFF
--- a/cli/targets/static.js
+++ b/cli/targets/static.js
@@ -36,7 +36,7 @@ function static_target(root, options, callback) {
         }
         if (config.comments) {
             if (root.comment) {
-                pushComment("@fileoverview " + root.comment);
+                pushComment(["@fileoverview " + root.comment]);
                 push("");
             }
             push("// Exported root namespace");


### PR DESCRIPTION
`pushComment` should have array of string as it's arg, not string