### PR TITLE
fix: fromObject should not initialize oneof members

### DIFF
--- a/cli/targets/static.js
+++ b/cli/targets/static.js
@@ -394,8 +394,7 @@ function buildType(ref, type) {
         if (config.comments) {
             push("");
             var jsType = toJsType(field);
-            if (field.optional && !field.map && !field.repeated && field.resolvedType instanceof Type ||
-                    field.options && field.options.proto3_optional)
+            if (field.optional && !field.map && !field.repeated && field.resolvedType instanceof Type || field.partOf)
                 jsType = jsType + "|null|undefined";
             pushComment([
                 field.comment || type.name + " " + field.name + ".",
@@ -411,9 +410,8 @@ function buildType(ref, type) {
             push(escapeName(type.name) + ".prototype" + prop + " = $util.emptyArray;"); // overwritten in constructor
         else if (field.map)
             push(escapeName(type.name) + ".prototype" + prop + " = $util.emptyObject;"); // overwritten in constructor
-        else if (field.options && field.options.proto3_optional) {
-            push(escapeName(type.name) + ".prototype" + prop + " = null;"); // do not set default value for proto3 optional fields
-        }
+        else if (field.partOf)
+            push(escapeName(type.name) + ".prototype" + prop + " = null;"); // do not set default value for oneof members
         else if (field.long)
             push(escapeName(type.name) + ".prototype" + prop + " = $util.Long ? $util.Long.fromBits("
                     + JSON.stringify(field.typeDefault.low) + ","

--- a/package.json
+++ b/package.json
@@ -56,7 +56,10 @@
     "browserify-wrap": "^1.0.2",
     "bundle-collapser": "^1.3.0",
     "chalk": "^4.0.0",
+    "escodegen": "^1.13.0",
     "eslint": "^7.0.0",
+    "espree": "^7.1.0",
+    "estraverse": "^5.1.0",
     "gh-pages": "^3.0.0",
     "git-raw-commits": "^2.0.3",
     "git-semver-tags": "^4.0.0",
@@ -74,6 +77,7 @@
     "tape": "^5.0.0",
     "tslint": "^6.0.0",
     "typescript": "^3.7.5",
+    "uglify-js": "^3.7.7",
     "vinyl-buffer": "^1.0.1",
     "vinyl-fs": "^3.0.3",
     "vinyl-source-stream": "^2.0.0"

--- a/tests/cli.js
+++ b/tests/cli.js
@@ -1,0 +1,72 @@
+// A minimal test for pbjs tool targets.
+
+var tape = require("tape");
+var path = require("path");
+var Module = require("module");
+var protobuf = require("..");
+
+tape.test("pbjs generates static code", function(test) {
+    // Alter the require cache to make the cli/targets/static work since it requires "protobufjs"
+    // and we don't want to mess with "npm link"
+    var savedResolveFilename = Module._resolveFilename;
+    Module._resolveFilename = function(request, parent) { 
+      if (request.startsWith("protobufjs")) {
+        return request;
+      }
+      return savedResolveFilename(request, parent);
+    };
+    require.cache.protobufjs = require.cache[path.resolve("index.js")];
+
+    var staticTarget = require("../cli/targets/static");
+
+    var root = protobuf.loadSync("tests/data/cli/test.proto");
+    root.resolveAll();
+
+    staticTarget(root, {
+        create: true,
+        decode: true,
+        encode: true,
+        convert: true,
+    }, function(err, jsCode) {
+        test.error(err, 'static code generation worked');
+
+        // jsCode is the generated code; we'll eval it
+        // (since this is what we normally does with the code, right?)
+        // This is a test code. Do not use this in production.
+        var $protobuf = protobuf;
+        eval(jsCode);
+
+        var OneofContainer = protobuf.roots.default.OneofContainer;
+        var Message = protobuf.roots.default.Message;
+        test.ok(OneofContainer, "type is loaded");
+        test.ok(Message, "type is loaded");
+
+        // Check that fromObject and toObject work for plain object
+        var obj = {
+            messageInOneof: {
+                value: 42,
+            },
+            regularField: "abc",
+        };
+        var obj1 = OneofContainer.toObject(OneofContainer.fromObject(obj));
+        test.deepEqual(obj, obj1, "fromObject and toObject work for plain object");
+
+        // Check that dynamic fromObject and toObject work for static instance
+        var root = protobuf.loadSync("tests/data/cli/test.proto");
+        var OneofContainerDynamic = root.lookup("OneofContainer");
+        var instance = new OneofContainer();
+        instance.messageInOneof = new Message();
+        instance.messageInOneof.value = 42;
+        instance.regularField = "abc";
+        var instance1 = OneofContainerDynamic.toObject(OneofContainerDynamic.fromObject(instance));
+        console.log(instance1);
+        // The following test fails: will be fixed by the next commit
+        test.deepEqual(instance, instance1, "fromObject and toObject work for instance of the static type");
+        
+        test.end();
+    });
+
+    // Rollback all the require() related mess we made
+    delete require.cache.protobufjs;
+    Module._resolveFilename = savedResolveFilename;
+});

--- a/tests/cli.js
+++ b/tests/cli.js
@@ -6,6 +6,12 @@ var Module = require("module");
 var protobuf = require("..");
 
 tape.test("pbjs generates static code", function(test) {
+    // pbjs does not seem to work with Node v4, so skip this test if we're running on it
+    if (process.versions.node.match(/^4\./)) {
+        test.end();
+        return;
+    }
+
     // Alter the require cache to make the cli/targets/static work since it requires "protobufjs"
     // and we don't want to mess with "npm link"
     var savedResolveFilename = Module._resolveFilename;
@@ -59,8 +65,6 @@ tape.test("pbjs generates static code", function(test) {
         instance.messageInOneof.value = 42;
         instance.regularField = "abc";
         var instance1 = OneofContainerDynamic.toObject(OneofContainerDynamic.fromObject(instance));
-        console.log(instance1);
-        // The following test fails: will be fixed by the next commit
         test.deepEqual(instance, instance1, "fromObject and toObject work for instance of the static type");
         
         test.end();

--- a/tests/data/cli/test.proto
+++ b/tests/data/cli/test.proto
@@ -1,0 +1,13 @@
+syntax = "proto3";
+
+message Message {
+  int32 value = 1;
+}
+
+message OneofContainer {
+  oneof some_oneof {
+    string string_in_oneof = 1;
+    Message message_in_oneof = 2;
+  }
+  string regular_field = 3;
+}


### PR DESCRIPTION
Fixes #1596.

The problem happens when an instance of a statically generated class (e.g. generated with `pbjs`) is passed to a dynamically generated `.fromObject` (e.g. from a protobuf `Root` loaded in the runtime). Since the statically generated instance has all non-optional fields set to their default values in the prototype, including the `oneof` fields, the resulting message is incorrect because it has all non-primitive members of `oneof` assigned to the default value (e.g. empty string), which make serialized object deserialize incorrectly by official protobuf implementations (e.g. Python). The implementation of dynamic `.fromObject` has a safety check that does nothing if the `typeof` shows it's already an object of the correct type, but this safety check does not work since they technically have different types (static one vs dynamic one) in this particular case.

Real life scenario: someone creates an object using `pbjs` generated static class and `new`, then passes it to gRPC client based on proto files loaded dynamically (so the `.fromObject` it uses comes from a dynamic class).

To fix it, we need to make sure the `oneof` fields don't get initialized with anything other than `null`. This is the same logic I added previously (in #1584), so since proto3 `optional` fields are actually implemented as `oneof` members, I'm just extending the same logic to all `oneof` members, not just proto3 `optional` fields. I think it became clearer.

This PR consists of two parts. First, I'm adding a test to the static code generation (basically, `pbjs -t static`), because it's currently not covered by any test.  The second commit will bring an actual fix to the problem described above.