### PR TITLE
fix: parse.js "parent.add(oneof)“ error

### DIFF
--- a/src/namespace.js
+++ b/src/namespace.js
@@ -6,6 +6,7 @@ var ReflectionObject = require("./object");
 ((Namespace.prototype = Object.create(ReflectionObject.prototype)).constructor = Namespace).className = "Namespace";
 
 var Field    = require("./field"),
+    OneOf    = require("./oneof"),
     util     = require("./util");
 
 var Type,    // cyclic
@@ -217,7 +218,7 @@ Namespace.prototype.getEnum = function getEnum(name) {
  */
 Namespace.prototype.add = function add(object) {
 
-    if (!(object instanceof Field && object.extend !== undefined || object instanceof Type || object instanceof Enum || object instanceof Service || object instanceof Namespace))
+    if (!(object instanceof Field && object.extend !== undefined || object instanceof Type || object instanceof Enum || object instanceof Service || object instanceof Namespace || object instanceof OneOf))
         throw TypeError("object must be a valid nested object");
 
     if (!this.nested)


### PR DESCRIPTION
In parse.js line 391, case rule === "proto3_optional" will do "parent.add(oneof)". But namespace.js not compatible this type.