### PR TITLE
fix(types): bring back Field.rule to .d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -602,8 +602,9 @@ export class Method extends ReflectionObject {
      * @param [responseStream] Whether the response is streamed
      * @param [options] Declared options
      * @param [comment] The comment for this method
+     * @param [parsedOptions] Declared options, properly parsed into an object
      */
-    constructor(name: string, type: (string|undefined), requestType: string, responseType: string, requestStream?: (boolean|{ [k: string]: any }), responseStream?: (boolean|{ [k: string]: any }), options?: { [k: string]: any }, comment?: string);
+    constructor(name: string, type: (string|undefined), requestType: string, responseType: string, requestStream?: (boolean|{ [k: string]: any }), responseStream?: (boolean|{ [k: string]: any }), options?: { [k: string]: any }, comment?: string, parsedOptions?: { [k: string]: any });
 
     /** Method type. */
     public type: string;
@@ -628,6 +629,9 @@ export class Method extends ReflectionObject {
 
     /** Comment for this method */
     public comment: (string|null);
+
+    /** Options properly parsed into an object */
+    public parsedOptions: any;
 
     /**
      * Constructs a method from a method descriptor.
@@ -666,6 +670,12 @@ export interface IMethod {
 
     /** Method options */
     options?: { [k: string]: any };
+
+    /** Method comments */
+    comment: string;
+
+    /** Method options properly parsed into an object */
+    parsedOptions?: { [k: string]: any };
 }
 
 /** Reflected namespace. */

--- a/src/field.js
+++ b/src/field.js
@@ -78,13 +78,13 @@ function Field(name, id, type, rule, extend, options, comment) {
     if (extend !== undefined && !util.isString(extend))
         throw TypeError("extend must be a string");
 
+    if (rule === "proto3_optional") {
+        rule = "optional";
+    }
     /**
      * Field rule, if any.
      * @type {string|undefined}
      */
-    if (rule === "proto3_optional") {
-        rule = "optional";
-    }
     this.rule = rule && rule !== "optional" ? rule : undefined; // toJSON
 
     /**


### PR DESCRIPTION
The misplaced jsdoc comment triggered removal of the `.d.ts` line, making the unintended breaking change in the exported type.

(the added `parsedOptions` is from some older PR, the actual breaking change is in the 6.11.0 branch, not visible here)