### PR TITLE
docs: fix typo in roots.js

### DIFF
--- a/src/roots.js
+++ b/src/roots.js
@@ -4,7 +4,7 @@ module.exports = {};
 /**
  * Named roots.
  * This is where pbjs stores generated structures (the option `-r, --root` specifies a name).
- * Can also be used manually to make roots available accross modules.
+ * Can also be used manually to make roots available across modules.
  * @name roots
  * @type {Object.<string,Root>}
  * @example


### PR DESCRIPTION
accross -> across