### PR TITLE
add no-mixed-operators to the default eslint-disable list

### DIFF
--- a/cli/pbjs.js
+++ b/cli/pbjs.js
@@ -22,6 +22,7 @@ exports.main = function main(args, callback) {
         "id-length",
         "no-control-regex",
         "no-magic-numbers",
+        "no-mixed-operators",
         "no-prototype-builtins",
         "no-redeclare",
         "no-shadow",


### PR DESCRIPTION
This pull request should resolve issue #1632 