### PR TITLE
Add "bundle" cli option to make js bundling optional

### DIFF
--- a/cli/pbjs.js
+++ b/cli/pbjs.js
@@ -41,7 +41,7 @@ exports.main = function main(args, callback) {
             "force-message": "strict-message"
         },
         string: [ "target", "out", "path", "wrap", "dependency", "root", "lint" ],
-        boolean: [ "create", "encode", "decode", "verify", "convert", "delimited", "typeurl", "beautify", "comments", "service", "es6", "sparse", "keep-case", "force-long", "force-number", "force-enum-string", "force-message", "null-defaults" ],
+        boolean: [ "create", "encode", "decode", "verify", "convert", "delimited", "typeurl", "beautify", "comments", "service", "es6", "sparse", "bundle", "keep-case", "force-long", "force-number", "force-enum-string", "force-message", "null-defaults" ],
         default: {
             target: "json",
             create: true,
@@ -55,6 +55,7 @@ exports.main = function main(args, callback) {
             comments: true,
             service: true,
             es6: null,
+            bundle: true,
             lint: lintDefault,
             "keep-case": false,
             "force-long": false,
@@ -99,7 +100,7 @@ exports.main = function main(args, callback) {
                 "",
                 "  -o, --out        Saves to a file instead of writing to stdout.",
                 "",
-                "  --sparse         Exports only those types referenced from a main file (experimental).",
+                "  --sparse         Exports only those types referenced from a main file (experimental). Ignored with --no-bundle.",
                 "",
                 chalk.bold.gray("  Module targets only:"),
                 "",
@@ -144,7 +145,7 @@ exports.main = function main(args, callback) {
                 "",
                 "  --null-defaults  Default value for optional fields is null instead of zero value.",
                 "",
-                "usage: " + chalk.bold.green("pbjs") + " [options] file1.proto file2.json ..." + chalk.gray("  (or pipe)  ") + "other | " + chalk.bold.green("pbjs") + " [options] -",
+                "usage: " + chalk.bold.green("pbjs") + " [options] file1.proto file2.json ..." + chalk.gray("  (or pipe)  ") + "other | " + chalk.bold.green("pbjs") + " [options] - | " + chalk.bold.green("pbjs") + " --no-bundle [options] file.proto",
                 ""
             ].join("\n"));
         return 1;
@@ -235,9 +236,12 @@ exports.main = function main(args, callback) {
 
     // Load from disk
     } else {
+        if (!argv.bundle && files.length > 1) {
+            throw Error("Only one file may be specified with --no-bundle.");
+        }
         try {
             root.loadSync(files, parseOptions).resolveAll(); // sync is deterministic while async is not
-            if (argv.sparse)
+            if (argv.sparse && argv.bundle)
                 sparsify(root);
             callTarget();
         } catch (err) {

--- a/src/namespace.js
+++ b/src/namespace.js
@@ -228,6 +228,8 @@ Namespace.prototype.add = function add(object) {
             if (prev instanceof Namespace && object instanceof Namespace && !(prev instanceof Type || prev instanceof Service)) {
                 // replace plain namespace but keep existing nested elements and options
                 var nested = prev.nestedArray;
+                if (prev.filename)
+                    object.filename = prev.filename;
                 for (var i = 0; i < nested.length; ++i)
                     object.add(nested[i]);
                 this.remove(prev);
@@ -270,10 +272,10 @@ Namespace.prototype.remove = function remove(object) {
  * Defines additial namespaces within this one if not yet existing.
  * @param {string|string[]} path Path to create
  * @param {*} [json] Nested types to create from JSON
+ * @param {string} [filename] Name of the file defining the namespace
  * @returns {Namespace} Pointer to the last namespace created or `this` if path is empty
  */
-Namespace.prototype.define = function define(path, json) {
-
+Namespace.prototype.define = function define(path, json, filename) {
     if (util.isString(path))
         path = path.split(".");
     else if (!Array.isArray(path))
@@ -290,6 +292,8 @@ Namespace.prototype.define = function define(path, json) {
                 throw Error("path conflicts with non-namespace objects");
         } else
             ptr.add(ptr = new Namespace(part));
+            if (!ptr.filename)
+                ptr.filename = filename;
     }
     if (json)
         ptr.addJSON(json);

--- a/src/parse.js
+++ b/src/parse.js
@@ -213,7 +213,7 @@ function parse(source, root, options) {
         if (!typeRefRe.test(pkg))
             throw illegal(pkg, "name");
 
-        ptr = ptr.define(pkg);
+        ptr = ptr.define(pkg, null, parse.filename);
         skip(";");
     }
 

--- a/src/root.js
+++ b/src/root.js
@@ -35,6 +35,12 @@ function Root(options) {
      * @type {string[]}
      */
     this.files = [];
+
+    /**
+     * Paths of imported files
+     * @type {string[]|null}
+     */
+     this.imports = null;
 }
 
 /**
@@ -127,6 +133,14 @@ Root.prototype.load = function load(filename, options, callback) {
                 var parsed = parse(source, self, options),
                     resolved,
                     i = 0;
+                if (self.imports === null) {
+                    if (parsed.imports)
+                        self.imports = [...parsed.imports];
+                    else
+                        self.imports = []
+                    if (parsed.weakImports)
+                        self.imports = self.imports.concat(parsed.weakImports);
+                }
                 if (parsed.imports)
                     for (; i < parsed.imports.length; ++i)
                         if (resolved = getBundledFileName(parsed.imports[i]) || self.resolvePath(filename, parsed.imports[i]))


### PR DESCRIPTION
Copied from https://github.com/protobufjs/protobuf.js/issues/1390#issuecomment-618086733:

pbjs generates a single bundle of JS for all of the transitive .protos. Therefore if you run pbjs on proto A and then proto B, and both depend on C, then you'll end up with two copies of C's generated JS code -- a.js will contain it, as well as b.js. This is a problem if you need to load proto A and B on the same page for two reasons:

- code bloat - you're loading C's code twice. If you need to load many protos and they share dependencies, you'll end up with an explosion of duplicate code.

- orphaned object references - because of the way protobuf creates the roots data structure at runtime, every time C is loaded into memory it replaces the previous instance of C. Therefore you can potentially end up with references to different instances of C. Practically I'm not sure what issues this could cause but best to be avoided.

To work around this you could use pbjs to generate one bundle of JS bundle per page, but this isn't ideal for two reasons:
- http caching - if two pages both need C's code, then ideally you have one copy of it that can be shared.
- on-demand loading - if you only have one bundle then you can't load parts of it as needed.

You could also generate one bundle for all pages, but this does not scale.

The fact that pbjs bundles at all is a little weird. The protoc tool doesn't do this for any language, including JS. And even for web browsers this isn't ideal for the reasons stated. If bundling is needed, asset bundlers (e.g. rollup / webpack) should be used for this.

Example

**my/protos/c.proto**
```
package my_protos_c;

message C {
   string some_field = 1;
}
```

**my/protos/a.proto**
```
package my_protos_a;
import "my/protos/c.proto";

message A {
  my_proto_c.C nested_msg_c = 1;
}
```

**my/protos/b.proto**
```
package my_protos_b;
import "my/protos/c.proto";

message B {
   my_proto_c.C nested_msg_c = 1;
}
```

**Strategy 1: run pbjs on each proto**
```pbjs --target static-module --out a.js a.proto```
```pbjs --target static-module  --out  b.js b.proto```

```
import {my_protos_a} from 'my/protos/a';
import {my_protos_b} from 'my/protos/b';
```

> page loads C's code twice

**Strategy 2: generate one js bundle per page with pbjs**
```pbjs --target static-module --out page_1.js a.proto```
```pbjs --target static-module --out page_2.js b.proto```

page 1
```
import {my_protos_a} from 'my/protos/page_1';
```

page 2
```
import {my_protos_b} from 'my/protos/page_2';
```

> page 1 loads different copy of C than page 2

**Strategy 3: generate one .js file for every .proto**

```pbjs --target static-module --path out/ --no-bundle a.proto```
```pbjs --target static-module --path out/ --no-bundle b.proto```
```pbjs --target static-module --path out/ --no-bundle c.proto```

```
import {my_protos_a} from 'my/protos/a';
import {my_protos_b} from 'my/protos/b';
```
> only 1 copy of C is loaded

page 1
```
import {my_protos_a} from 'my/protos/page_1';
```

page 2
```
import {my_protos_b} from 'my/protos/page_2';
```

> page 1 loads same copy of C as page 2
