### PR TITLE
Add new StreamingDecoder class for resumable decoding

### DIFF
--- a/examples/streaming-decoder.js
+++ b/examples/streaming-decoder.js
@@ -1,0 +1,67 @@
+// proof of concept for streaming decoding message-by-message
+var protobuf = require("..");
+const { utf8 } = require("../src/util");
+
+// test protocol
+var proto = `
+syntax="proto3";
+message RootMessage {
+	uint32 field = 1;
+	repeated SubMessage msg_list = 2;
+}
+message SubMessage {
+	float field = 1;
+}
+`;
+
+var root = protobuf.parse(proto, {keepCase:true}).root,
+	RootMessage = root.lookupType("RootMessage");
+
+// generate a test example to decode
+var msg = {field:99, msg_list:[]};
+for (var i=0; i<30; i++)
+	msg.msg_list.push({
+		field: Math.random()
+	});
+var msg_str = RootMessage.encodeDelimited(msg).finish();
+
+// NORMAL DECODE
+console.log("One-shot decoding:")
+var msg_decoded = RootMessage.decodeDelimited(msg_str);
+console.log(msg_decoded);
+
+// STREAMING DECODE >>>>>
+console.log("\nStreamed decoding:")
+
+// simulated mesage chunks, as would come from network/disk
+function chunkify(str, num_chunks){
+	str = new Uint8Array(str);
+	var chunk_size = Math.ceil(str.length/num_chunks);
+	num_chunks = Math.ceil(str.length/chunk_size);
+	var chunks = [];
+	for (var i=0, o=0; i<num_chunks; ++i)
+		chunks.push(str.slice(o, o += chunk_size));
+	return chunks;
+}
+var chunks = chunkify(msg_str, 10);
+
+var discard = 0;
+function onmessage(msg, stack){
+	// console.log("Got msg:", msg, stack);
+	// add to DOM tree?
+	var keep = msg.field > .5;
+	if (!keep)
+		discard++;
+	return keep;	
+}
+var decoder = RootMessage.StreamingDecoderDelimited(onmessage);
+for (let i=0; i<chunks.length; i++){
+	// current root message is returned for each call;
+	// also accessible via decoder.root
+	console.log("decoding chunk", i);
+	var partial_root = decoder.write(chunks[i]);
+}
+// finalized DOM tree (also accessible via decoder.root)
+var complete_root = decoder.end();
+console.log(complete_root);
+console.log(discard+" message(s) discarded on-the-fly");

--- a/lib/codegen/index.js
+++ b/lib/codegen/index.js
@@ -6,10 +6,10 @@ module.exports = codegen;
  * @memberof util
  * @param {string[]} functionParams Function parameter names
  * @param {string} [functionName] Function name if not anonymous
+ * @param {bool} [isGenerator] Whether the function is a generator
  * @returns {Codegen} Appender that appends code to the function's body
  */
-function codegen(functionParams, functionName) {
-
+function codegen(functionParams, functionName, isGenerator) {
     /* istanbul ignore if */
     if (typeof functionParams === "string") {
         functionName = functionParams;
@@ -75,7 +75,7 @@ function codegen(functionParams, functionName) {
     }
 
     function toString(functionNameOverride) {
-        return "function " + (functionNameOverride || functionName || "") + "(" + (functionParams && functionParams.join(",") || "") + "){\n  " + body.join("\n  ") + "\n}";
+        return "function" + (isGenerator ? "* " : " ") + (functionNameOverride || functionName || "") + "(" + (functionParams && functionParams.join(",") || "") + "){\n  " + body.join("\n  ") + "\n}";
     }
 
     Codegen.toString = toString;

--- a/src/decoder_streaming.js
+++ b/src/decoder_streaming.js
@@ -1,0 +1,276 @@
+"use strict";
+module.exports = {
+	StreamingDecoder,
+	streaming_decode,
+};
+
+var Enum    = require("./enum"),
+	types   = require("./types"),
+	util    = require("./util"),
+	StreamingReader = require("./reader_streaming");
+
+/**
+ * Wrapper class around the streaming_decode generator
+ * 
+ * @param {Type} type The message type object which this StreamingDecoder should decode for
+ * @param {Function} onmessage Callback for completed messages
+ * @param {int} length Hint about the length of the message. You can use -1 to indicate
+ * 	that the message is length delimited, meaning it is preceded on the wire by a uint32
+ * 	indicating the length of the message. Can also be undefined, meaning it will keep
+ * 	decoding until there is no more input left.
+ */
+function StreamingDecoder(type, onmessage, length){
+	if (!(onmessage instanceof Function))
+		throw Error("StreamingDecoder callback is required and must be a function");
+	/** The message Type class the decoder is for  */
+	this.type = type;
+	/** The onmessage callback */
+	this.onmessage = onmessage;
+	/** Hint about the message's length for decoding  */
+	this.limit = length;
+	/** Message tree stack used for onmessage callback */
+	this.stack = [];
+	/** The root message, which also gets returned by calls to write() and end() */
+	this.root = null;
+	/** The StreamingReader object used by the generator */
+	this.reader = null;
+	/** The generator used internally to pause decoding for more data */
+	this.generator = null;
+	/** Whether user has manually specified that this is the last input */
+	this.eof = false;
+};
+/**
+ * Decode a chunk of data
+ * @param {Array|Uin8Array|String|Buffer} [data] Data to be decoded by the decoder. If not provided
+ *  then this is equivalent to calling `end()`, signaling the end of input.
+ * @param {bool} [eof] Whether this is the last data input. Equivalent to calling `write()`, no
+ *  arguments, or `end(data)`.
+ * @returns {Message} The partially, or fully completed root message; same as this.root
+ */
+StreamingDecoder.prototype.write = function StreamingDecoder_write(data, eof){
+	// end of input reached prior
+	if (this.eof)
+		return this.root;
+	// first data we receive, we start the generator
+	if (!this.generator){
+		this.reader = new StreamingReader(data);
+		this.generator = this.type._streaming_decode(this.reader, this.limit, this.stack, this.onmessage);
+		// note, first next() call's args are ignored
+		this.root = this.generator.next().value;
+	}
+	// requesting additional data
+	else this.generator.next(data);
+	// signal end of input
+	if (data !== undefined && eof)
+		this.generator.next();
+	// end of input signaled by user
+	if (data === undefined || eof)
+		this.eof = true;
+	return this.root;
+}
+/**
+ * Alias for `write(data, true)`
+ */
+StreamingDecoder.prototype.end = function StreamingDecoder_end(data){
+	return this.write(data, true);
+}
+
+
+/**
+ * Creates a new codegen object, which can be used to obtain a custom function for
+ * streamed decoding type `mtype` specifically
+ */
+function streaming_decode(mtype) {
+	/* This is a private method, to be called by a wrapper class with arguments all initialized
+		reader: StreamingReader
+		limit: limit to number of bytes to be read (total); this is passed to reader.done,
+			so if it is undefined, it will read until eof is reached
+		stack: array of objects of the form:
+				[{
+					message: (Message) parent message,
+					field: (str) field name for child / next item in stack,
+					repeated: (bool) whether field is repeated
+				}, ...]
+			This is a stack indicating the current messages in the tree; the first element
+			is the root element, while the last element is the parent which triggered the current
+			message decoding, and will is the target of the field
+		cbk: the onmessage callback to be called whenever a message is completed;
+			the signature for the cbk will be (message, stack) -> bool; it should
+			return true if the message should be added to its parent, or false if
+			it should not be added 
+	*/
+
+	// I've aligned all G(...) code generation lines, so they're more easily identifiable; also
+	// I've added tabs to the generated code and renamed variables so that the source code is easier
+	// to read and debug; I think the any performance hit on runtime will be minimal, and makes it easier to
+	// maintain. Other than that, everything is very much the same as the traditional "decode.js", with small
+	// changes to handle the streaming generator (via yield) and the onmessage callback.
+	var G = util.codegen(["reader", "limit", "stack", "cbk"], mtype.name + "$_streaming_decode", true);
+
+	G("var msg = new this.ctor;");
+	G("var stack_item = {message: msg};");
+	// We set a reference of the root message on the StreamingReader, so that the reader can
+	// yield the current progress of that root message whenever it pauses for more data
+	G("if (stack.push(stack_item) === 1){");
+	G("	reader.root = msg;");
+		// Is it a length delimited message? -1 is our magic number for indicating length delimited
+	G("	if (limit == -1)");
+	G("		limit = yield* reader.uint32();");
+	G("}");
+	
+	// Decoding loop;
+	// non-packed repeated fields (including map fields, which are implicity repeated), are accumulated
+	// across iterations of this loop; when a field is seen the first time, it is initialized to empty array (or object for maps);
+	// subsequent loop iterations will push/add to the array/object
+	G("while (!reader.done(limit)){");
+		// Field identifier
+	G("	var tag = yield* reader.uint32();");
+		// End of group; stop here
+	if (mtype.group)
+	G("	if ((tag & 7) === 4) break;");
+	
+		// Field number
+	G("	switch (tag >>> 3){");
+
+	// Hardcoded logic for each field [number]; generated code will be a bit more verbose and repeated,
+	// but potentially a bit faster since we don't need to check as many branches
+	for (var i=0; i<mtype.fieldsArray.length; ++i){
+		var field = mtype._fieldsArray[i].resolve(),
+			type = field.resolvedType instanceof Enum ? "int32" : field.type,
+			field_str = util.safePropString(field.name),
+			ref = "msg" + util.safeProp(field.name);
+
+	G("		case %i:", field.id);
+
+		// Map fields; equivalent to an embedded message with {key=1, value=2};
+		if (field.map){
+				// First time seeing this field; initialize the map container object
+	G("			if (%s === util.emptyObject)", ref);
+	G("				%s = {};", ref);
+
+				// Initial value for key/value fields of the map
+				if (types.defaults[field.keyType] !== undefined)
+	G("				var key = %j;", types.defaults[field.keyType]);
+				else
+	G("				var key = null;");
+				if (types.defaults[type] !== undefined)
+	G("				var value = %j;", types.defaults[type]);
+				else
+	G("				var value = null;");
+
+				// Whether the value (if it is a message) should be included
+	G("				var incl = true;");
+
+				// Maps fields are like messages, so have multiple fields within;
+				// here we're looping through to find the two fields key=1, value=2
+	G("				var map_limit = (yield* reader.uint32()) + reader.bytes_read();");
+	G("				while (!reader.done(map_limit)){");
+	G("					var map_tag = yield* reader.uint32();");
+	G("					switch (map_tag >>> 3){");
+							// key (primitive only)
+	G("						case 1: key = yield* reader.%s(); break;", field.keyType)
+	G("						case 2:");
+							// value, message; field value cannot be a group, so no need to handle that side case
+		   					if (types.basic[type] === undefined){
+	G("							var field_limit = (yield* reader.uint32()) + reader.bytes_read();")
+	G("							stack_item.repeated = false;")
+	G("							stack_item.field = %s;", field_str)
+	G("							value = yield* types[%i]._streaming_decode(reader, field_limits, stack, cbk);", i);
+								// did cbk request this message [not] be included?
+	G("							incl = value;");
+							}
+							// value, primitive
+							else
+	G("							value = yield* reader.%s();", type);
+	G("							break;");
+							// unknown type; shouldn't occur in practice
+	G("						default:");
+	G("							yield* r.skipType(tag2&7);");
+	G("							break;");
+	G("					}");
+	G("				}");
+			// Add key-value pair to the map container
+			if (types.long[field.keyType] !== undefined)
+	G("				incl && (%s[typeof key === 'object' ? util.longToHash(key) : key] = value);", ref);
+			else
+	G("				incl && (%s[key] = value);", ref);        
+		}
+		// Repeated fields
+		else if (field.repeated){
+				// First time seeing this field; initialize the repeated container array
+	G("			if (!(%s && %s.length))", ref, ref)
+	G("				%s = []", ref);
+
+			// Packable, meaning we can parse N primitive types in a row (always check for forward and backward compatiblity)
+			if (types.packed[type] !== undefined){
+	G("			if ((tag & 7) === 2){");
+	G("				var field_limit = (yield* reader.uint32()) + reader.bytes_read();");
+	G("				while (!reader.done(field_limit))")
+	G("					%s.push(yield* reader.%s())", ref, type)
+	G("			} else");
+			}
+			// Non-packed; we just push a single item
+	G("			{");
+				// Non-packed message
+			if (types.basic[type] === undefined){
+					// Groups have their own "end group" marker, so no need for decoding byte limit
+				if (field.resolvedType.group)
+	G("				var field_limit = undefined;");
+				else
+	G("				var field_limit = (yield* reader.uint32()) + reader.bytes_read();");
+
+	G("				stack_item.repeated = true;")
+	G("				stack_item.field = %s;", field_str)
+	G("				var value = yield* types[%i]._streaming_decode(reader, field_limit, stack, cbk);", i);
+					// Note here we check if cbk requested the message [not] be included
+	G("				value && %s.push(value)", ref)
+				}
+				// Non-packed primitive
+				else
+	G("				%s.push(yield* reader.%s())", ref, type);
+	G("			}")
+		}
+		// Single message
+		else if (types.basic[type] === undefined){
+			// Nearly identical to logic for "non-packed repeated message" above
+			if (field.resolvedType.group)
+	G("			var field_limit = undefined;");
+			else
+	G("			var field_limit = (yield* reader.uint32()) + reader.bytes_read();");
+
+	G("			stack_item.repeated = false;");
+	G("			stack_item.field = %s;", field_str);
+	G("			var value = yield* types[%i]._streaming_decode(reader, field_limit, stack, cbk);", i);
+	G("			value && %s = value;", ref)
+		}
+		// Single primitive
+		else
+	G("			%s = yield* reader.%s();", ref, type);
+
+
+	G("			break;");
+	}
+	// Any remaining unknown fields
+	G("		default:")
+	G("			yield* reader.skipType(tag & 7);")
+	G("			break;")
+
+	G("	}")
+	G("}");
+
+	// Throw errors if "required" fields are not present
+	for (var i = 0; i < mtype._fieldsArray.length; ++i) {
+		var rfield = mtype._fieldsArray[i];
+		if (rfield.required){
+	G("if (!msg.hasOwnProperty(%j))", rfield.name)
+	G("	throw util.ProtocolError(%j, {instance:\"missing required '%s'\"});", rfield.name);
+		}
+	}
+
+	// Message decoding complete; call streaming cbk to handle it
+	G("var incl = cbk(msg, stack);");
+	G("stack.pop();");
+	G("return incl ? msg : undefined;");
+
+	return G;
+}

--- a/src/decoder_streaming.js
+++ b/src/decoder_streaming.js
@@ -13,15 +13,16 @@ var Enum    = require("./enum"),
  * Wrapper class around the streaming_decode generator
  * 
  * @param {Type} type The message type object which this StreamingDecoder should decode for
- * @param {Function} onmessage Callback for completed messages
- * @param {int} length Hint about the length of the message. You can use -1 to indicate
+ * @param {Function} [onmessage] Callback for completed messages. This can be undefined/null/falsey
+ * 	if you don't want a callback. This matches the behavior of a callback `function(){ return true; }`.
+ * @param {int} [length] Hint about the length of the message. You can use -1 to indicate
  * 	that the message is length delimited, meaning it is preceded on the wire by a uint32
  * 	indicating the length of the message. Can also be undefined, meaning it will keep
  * 	decoding until there is no more input left.
  */
 function StreamingDecoder(type, onmessage, length){
-	if (!(onmessage instanceof Function))
-		throw Error("StreamingDecoder callback is required and must be a function");
+	if (!(onmessage instanceof Function || !onmessage))
+		throw Error("StreamingDecoder callback must be a function if specified");
 	/** The message Type class the decoder is for  */
 	this.type = type;
 	/** The onmessage callback */
@@ -268,7 +269,7 @@ function streaming_decode(mtype) {
 	}
 
 	// Message decoding complete; call streaming cbk to handle it
-	G("var incl = cbk(msg, stack);");
+	G("var incl = !cbk || cbk(msg, stack);");
 	G("stack.pop();");
 	G("return incl ? msg : undefined;");
 

--- a/src/reader_streaming.js
+++ b/src/reader_streaming.js
@@ -1,0 +1,337 @@
+"use strict";
+module.exports = StreamingReader;
+
+const Reader = require("./reader");
+const BufferReader = require("./reader_buffer");
+
+/**
+ * A StreamingReader mimics the same API as Reader and BufferReader, except each
+ * tokenizing method has been converted to a generator. The generator will pause
+ * when the underlying buffer is exhuasted, and the user can use gen.next(buffer)
+ * to feed in additional streamed input to be read.
+ * 
+ * @param {*} buffer Initial data to be read; this is forwarded to Reader.create internally
+ * @todo
+ * 	- Some kind of 'reset_bytes_read', in case there are multiple message concatenated in the
+ * 		same stream. We could reset the bytes read (and eof) and just continue decoding using the same
+ * 		StreamingReader
+ *  - Allow them to pass a Reader/BufferReader to the constructor or generator.next()?
+ */
+function StreamingReader(buffer){
+	/**
+     * The root message of the input data that we are decoding. The partially (or completed for
+	 * final iteration) root is yielded each time we pause for more data
+     * @type {Message}
+     */
+	this.root = null;
+	/**
+	 * Reader currently being used to read tokens. This can be the same as nxt_reader.
+	 * If it is *not* nxt_reader, it will be a temporary reader created internally to
+	 * buffer bytes while we transition between the previous data input(s) and nxt_reader's
+	 * data input.
+	 * @type {Reader}
+	 */
+	this.cur_reader = Reader.create(buffer);
+	/**
+     * Internal reader object that holds the next (or possibly current) data input
+     * @type {Reader}
+     */
+	this.nxt_reader = this.cur_reader;
+	/**
+	 * The byte position in cur_reader.buf, indicating where nxt_reader.buf begins. You can use
+	 * !nxt_pos to check if cur_reader == nxt_reader (e.g. cur_reader is not a temp buffer). If
+	 * we drain `cur_reader` and it needs to buffer more data, if cur_reader.pos is >= this nxt_pos,
+	 * we can just start reading from nxt_reader, instead of doing another buffer operation.
+	 * @type {int}
+	 */
+	this.nxt_pos = 0;
+	/**
+	 * Whether cur_reader is the last input provided by the user. When true, nxt_reader is
+	 * not used and nxt_pos must be zero.
+	 * @type {bool}
+	 */
+	this.eof = false;
+	/**
+	 * Bytes read from all previous readers; use bytes_read to get total bytes read thus far
+	 * @type {int}
+	 */
+	this.prev_bytes = 0;
+}
+
+/**
+ * Whether reading has finished
+ * @param {int} bytes If specified, reading is considered done when >= bytes have been read
+ */
+StreamingReader.prototype.done = function(bytes){
+	if (bytes !== undefined)
+		return this.bytes_read() >= bytes;
+	return this.eof && this.cur_reader.pos >= this.cur_reader.len;
+}
+/**
+ * How many bytes have been read (e.g. equivalent to Reader.pos). Note
+ * that cur_reader.pos is not clamped, so may be > cur_reader.len
+ */
+StreamingReader.prototype.bytes_read = function(){
+	return this.prev_bytes + this.cur_reader.pos;
+}
+
+/**
+ * Ensure the internal reader being used can read at least N bytes. The
+ * reader will yield, accepting additional input until the byte count is
+ * satisifed, or no additional input is available.
+ *
+ * Reader is not a traditional parser which parses each byte individually
+ * and maintains state machine. Unfortunately that makes it troublesome to
+ * pause/resume parsing. If the N bytes requested straddles 2+ buffers, we need
+ * to create a temporary reader with N bytes copied from those straddled buffers.
+ * The alternative would be to rewrite the parser, but it would likely mean slower
+ * parsing for the general case (general case being where we do not stream input,
+ * and so don't need to yield for additional input)
+ * 
+ * @param {int} n maximum number of bytes needed to read the token
+ * @param {int} excess if > 0, it will buffer up to excess-1 extra
+ * 	bytes when buffering, so that we are not repeatedly copying data to a temporary buffer every
+ *	time we need to parse another token. Example: we have 9 bytes but need 10; we
+ *	can buffer the minimal amount 10, but if only 1 byte is actually required, on
+ *	the next iteration we will be back where we started, 9 bytes but need 10; thus,
+ *	repeated buffering until we can swap out our temporary cur_reader for nxt_reader.
+ *
+ *	A good value for this is 10, since that is the max bytes needed for a primitive type;
+ *	though if the data inputs happen to be in very small chunks (< 10 bytes... unlikely in
+ *	practice) a larger value would be better.
+ */
+StreamingReader.prototype._buffer_bytes = function* StreamingReader_buffer_bytes(n, excess=0){
+	// cur_reader meets byte reqs
+	var cur_avail = this.cur_reader.len-this.cur_reader.pos;
+	if (cur_avail >= n || this.eof || !n)
+		return;
+	
+	// if cur_reader is a temp buffer, check if it still contains data that needs to be processed
+	if (this.nxt_pos){
+		// cur_reader no longer needed, swap out for nxt_reader
+		if (this.cur_reader.pos >= this.nxt_pos){
+			this.prev_bytes += this.nxt_pos;
+			this.nxt_reader.pos = this.cur_reader.pos-this.nxt_pos;
+			this.cur_reader = this.nxt_reader;
+			this.nxt_pos = 0;
+			cur_avail = this.cur_reader.len-this.cur_reader.pos;
+			// nxt_reader (now the cur_reader) meets byte reqs
+			if (cur_avail >= n)
+				return;
+		}
+	}
+	// if cur_reader is temp buffer, we now know it has data still;
+	// otherwise, if *not* a temp buffer, we need to check if it has data or not
+	if (!this.nxt_pos){
+		if (cur_avail <= 0){
+			this.prev_bytes += this.cur_reader.len;
+			yield* this._fetch_nxt_reader();
+			this.cur_reader = this.nxt_reader;
+			if (this.eof)
+				return;
+			// now we have a non-empty, non-temp-buffer cur_reader; does it meet byte reqs?
+			cur_avail = this.cur_reader.len-this.cur_reader.pos;
+			if (cur_avail >= n)
+				return;
+		}
+		// make sure nxt_reader is set, to mirror the tmp buffer case so we can use the same logic for both
+		yield* this._fetch_nxt_reader();
+		if (this.eof)
+			return;
+	}
+
+	// data required straddles cur_reader and nxt_reader (and may require 1+ additional nxt_readers as well)
+	var tmp_reader = Reader.create(new this.cur_reader.buf.constructor(n+(excess ? excess-1 : 0)));
+	var ti = 0;
+	// copy bytes from cur_reader
+	this.prev_bytes += this.cur_reader.len-cur_avail;
+	for (var si=this.cur_reader.pos; ti<cur_avail; ++si, ++ti)
+		tmp_reader.buf[ti] = this.cur_reader.buf[si];
+	this.cur_reader = tmp_reader;
+	// if cur_reader is temp buffer and partially contains nxt_reader, we don't need to copy the first nxt_reader fully
+	cur_avail = this.nxt_reader.len - this.nxt_reader.pos;
+	// repeatedly buffer from nxt_reader until we have required bytes, or eof reached
+	while (true){
+		this.nxt_pos = ti; // start position of nxt_reader.buf, as copied into cur_reader.buf
+		var bytes2copy = this.cur_reader.len - ti,
+			insufficient = cur_avail < bytes2copy;
+		if (insufficient)
+			bytes2copy = cur_avail;
+		for (var si=0; si<bytes2copy; ++si, ++ti)
+			this.cur_reader.buf[ti] = this.nxt_reader.buf[si];
+		// still need more input?
+		if (insufficient){
+			yield* this._fetch_nxt_reader();
+			// the temp reader will be our eof reader
+			if (this.eof){
+				// pretend it is a non-temp reader
+				this.nxt_pos = 0;
+				// artificially decrease length
+				this.cur_reader.len = ti;
+				return;
+			}
+			cur_avail = this.nxt_reader.len;
+		}
+		else return;
+	}
+}
+
+/**
+ * Retrieves additional input from user, via next() of the yielded generator
+ */
+StreamingReader.prototype._fetch_nxt_reader = function* StreamingReader_fetch_nxt_reader(){
+	// repeatedly fetch input from user (generator's next() method) until we get something
+	do {
+		var nxt = yield this.root;
+		if (nxt === undefined){
+			this.eof = true;
+			return;
+		}
+		this.nxt_reader = Reader.create(nxt);
+	} while (this.nxt_reader.len <= 0);
+}
+
+var max_bytes = {
+	// All these use uint32 internally, which is max 10 bytes
+	uint32: 10,
+	int32: 10,
+	sint32: 10,
+	bool: 10,
+	// All these use Long internally, which is max 10 bytes
+	int64: 10,
+	uint64: 10,
+	sint64: 10,
+	// These have fixed 4 byte length
+	fixed32: 4,
+	sfixed32: 4,
+	float: 4,
+	// These have fixed 8 byte length
+	fixed64: 8,
+	sfixed64: 8,
+	double: 8
+};
+for (var primitive in max_bytes){
+	// closure, since we aren't using "let" in this lib
+	StreamingReader.prototype[primitive] = (function(p){
+		var bytes = max_bytes[p];
+		return function*(){
+			yield* this._buffer_bytes(bytes, 10);
+			return this.cur_reader[p]();
+		}
+	})(primitive);
+}
+
+// Byte/string is a little more complicated; can't just delegate to base Reader/BufferReader method
+StreamingReader.prototype._bytes_or_string = function* StreamingReader_bytes_or_string(convert_string){
+	// code adapted from Reader/BufferReader classes
+	var length = yield* this.uint32();
+	var value;
+	// empty bytes
+	if (!length)
+		return new this.cur_reader.buf.constructor(0);
+	// otherwise buffer and slice
+	yield* this._buffer_bytes(length);
+	var cur_avail = this.cur_reader.len - this.cur_reader.pos;
+	if (cur_avail < length)
+		throw indexOutOfRange(this.cur_reader, length);
+	// no slicing needed if we've created a temporary specifically for this token
+	if (this.nxt_pos && !this.cur_reader.pos && cur_avail == len){
+		value = this.cur_reader.buf;
+		this.cur_reader.pos = len;
+	}
+	// safer to make slice/copy of data
+	else{
+		var buf = this.cur_reader.buf,
+			start = this.cur_reader.pos,
+			end = (this.cur_reader.pos += length);
+		if (Array.isArray(buf))
+			value = buf.slice(start, end);
+        else if (convert_string && cur_reader instanceof BufferReader){
+			// can do a fused slice + string convert for buffers
+			return (buf.utf8Slice ?
+				buf.utf8Slice(start, end) :
+				buf.toString("utf-8", start, end)
+			);
+		}
+		else
+			value = this.cur_reader._slice.call(buf, start, end);
+	}
+	if (!convert_string)
+		return value;
+	// convert to string
+	if (cur_reader instanceof BufferReader){
+		return (buf.utf8Slice ?
+			value.utf8Slice(0, value.length) :
+			value.toString("utf-8")
+		);
+	}
+	return utf8.read(value, 0, value.length);
+}
+StreamingReader.prototype.bytes = function* StreamingReader_bytes(){
+	return yield* this._bytes_or_string(false);
+}
+StreamingReader.prototype.string = function* StreamingReader_string(){
+	return yield* this._bytes_or_string(true);
+}
+
+// Skip we handle differently, since we don't need to read any data, just move the pointer
+StreamingReader.prototype.skip = function* StreamingReader_skip(length) {
+	// skip N bytes
+    if (typeof length === "number"){
+		if (length <= 0)
+			return;
+		while (true) {
+			var cur_avail = this.cur_reader.len - this.cur_reader.pos;
+			if (cur_avail >= length){
+				this.cur_reader.pos += length;
+				return;
+			}
+			length -= Math.max(0, cur_avail); // max, in case current position > length makes avail negative
+			// this trick will fetch the next batch of input without buffering
+			this.cur_reader.pos = this.cur_reader.len;
+			yield* this._buffer_bytes(1);
+			if (this.eof)
+				throw indexOutOfRange(this.cur_reader, length);
+		}
+    }
+	// skip a varlength number
+	while (true){
+		while (this.cur_reader.pos < this.cur_reader.len){
+			if (!(this.cur_reader.buf[this.cur_reader.pos++] & 128))
+				return
+		}
+		// this trick will fetch the next batch of input without buffering
+		yield* this._buffer_bytes(1);
+		if (this.eof)
+			throw indexOutOfRange(this.cur_reader);
+	}
+};
+
+StreamingReader.prototype.skipType = function* StreamingReader_skipType(wireType){
+    switch (wireType) {
+        case 0:
+            yield* this.skip();
+            break;
+        case 1:
+            yield* this.skip(8);
+            break;
+        case 2: {
+			var bytes = yield* this.uint32();
+            yield* this.skip(bytes);
+            break;
+		}
+        case 3:
+            while (true){
+				var bytes = yield* this.uint32();
+				wireType = bytes & 7;
+				if (wireType == 4)
+					return;
+                yield* this.skipType(wireType);
+            }
+        case 5:
+            yield* this.skip(4);
+            break;
+        default:
+            throw Error("invalid wire type " + wireType + " at offset " + this.cur_reader.pos);
+    }
+};

--- a/src/type.js
+++ b/src/type.js
@@ -532,7 +532,7 @@ Type.prototype.decodeDelimited = function decodeDelimited(reader) {
  * the onmessage callback, you can also have more intimate control over the construction of the message
  * tree, or simply process messages on-the-fly without keeping them around.
  * 
- * @param {Function} onmessage A callback function to be called whenever a message is completed;
+ * @param {Function} [onmessage] An optional callback function to be called whenever a message is completed;
  *  the signature for the cbk must be `(message, stack) -> bool`. It should return true if the
  *  message should be added to its parent, or false if it should not be added. The `stack` argument
  *  indicates a stack of ancestor messages in the form:
@@ -546,7 +546,7 @@ Type.prototype.decodeDelimited = function decodeDelimited(reader) {
  *	The first element is the root element, while the last element is the parent which triggered the
  *  current message decoding. This last parent's field is the one which the current message may
  *  be added to if desired (either manually if false is returned, or automatically if true is returned).
- * @param {int} length Optional hint about the length of the message (in bytes) to be decoded. If left
+ * @param {int} [length] Optional hint about the length of the message (in bytes) to be decoded. If left
  *  undefined, decoding will continue as long as there is more input. You may also set this to -1 to
  *  indicate a length delimited message (see `StreamingDecoderDelimited`)
  */
@@ -554,6 +554,7 @@ Type.prototype.StreamingDecoder = function StreamingDecoderFactory(onmessage, le
     // new Type.StreamingDecoder() wouldn't work... don't think we can infer Type from the constructor in that case
     return new StreamingDecoder(this, onmessage, length);
 }
+
 /**
  * Identical to `Type.StreamingDecoder(onmessage, -1)`. This assumes the message is preceded by a uint32
  * indicating the number of bytes in the message. That number will be read at the start of decoding and
@@ -562,6 +563,7 @@ Type.prototype.StreamingDecoder = function StreamingDecoderFactory(onmessage, le
 Type.prototype.StreamingDecoderDelimited = function StreamingDecoderDelimitedFactory(onmessage){
     return new StreamingDecoder(this, onmessage, -1);
 }
+
 /** Private method used internal for the StreamingDecoder class */
 Type.prototype._streaming_decode = function _streaming_decode(reader, length, stack, cbk){
     return this.setup()._streaming_decode(reader, length, stack, cbk); // overrides this method

--- a/src/type.js
+++ b/src/type.js
@@ -18,7 +18,8 @@ var Enum      = require("./enum"),
     decoder   = require("./decoder"),
     verifier  = require("./verifier"),
     converter = require("./converter"),
-    wrappers  = require("./wrappers");
+    wrappers  = require("./wrappers"),
+    { StreamingDecoder, streaming_decode } = require("./decoder_streaming");
 
 /**
  * Constructs a new reflected message type instance.
@@ -445,6 +446,10 @@ Type.prototype.setup = function setup() {
         types  : types,
         util   : util
     });
+    this._streaming_decode = streaming_decode(this)({
+        types  : types,
+        util   : util
+    });
     this.verify = verifier(this)({
         types : types,
         util  : util
@@ -519,6 +524,49 @@ Type.prototype.decodeDelimited = function decodeDelimited(reader) {
         reader = Reader.create(reader);
     return this.decode(reader, reader.uint32());
 };
+
+/**
+ * Factory which returns a new StreamingDecoder object, with the onmessage callback specified.
+ * A StreamingDecoder can decode a message in chunks, pausing when more data is needed to continue
+ * parsing. This is ideal for large streams, which may arrive from disk or network in parts. With
+ * the onmessage callback, you can also have more intimate control over the construction of the message
+ * tree, or simply process messages on-the-fly without keeping them around.
+ * 
+ * @param {Function} onmessage A callback function to be called whenever a message is completed;
+ *  the signature for the cbk must be `(message, stack) -> bool`. It should return true if the
+ *  message should be added to its parent, or false if it should not be added. The `stack` argument
+ *  indicates a stack of ancestor messages in the form:
+ * 
+ *	    [{
+ *			message: (Message) parent message,
+ *			field: (str) field name for child / next item in stack,
+ *			repeated: (bool) whether field is repeated
+ *      }, ...]
+ *
+ *	The first element is the root element, while the last element is the parent which triggered the
+ *  current message decoding. This last parent's field is the one which the current message may
+ *  be added to if desired (either manually if false is returned, or automatically if true is returned).
+ * @param {int} length Optional hint about the length of the message (in bytes) to be decoded. If left
+ *  undefined, decoding will continue as long as there is more input. You may also set this to -1 to
+ *  indicate a length delimited message (see `StreamingDecoderDelimited`)
+ */
+Type.prototype.StreamingDecoder = function StreamingDecoderFactory(onmessage, length){
+    // new Type.StreamingDecoder() wouldn't work... don't think we can infer Type from the constructor in that case
+    return new StreamingDecoder(this, onmessage, length);
+}
+/**
+ * Identical to `Type.StreamingDecoder(onmessage, -1)`. This assumes the message is preceded by a uint32
+ * indicating the number of bytes in the message. That number will be read at the start of decoding and
+ * used as a hint for the message length.
+ */
+Type.prototype.StreamingDecoderDelimited = function StreamingDecoderDelimitedFactory(onmessage){
+    return new StreamingDecoder(this, onmessage, -1);
+}
+/** Private method used internal for the StreamingDecoder class */
+Type.prototype._streaming_decode = function _streaming_decode(reader, length, stack, cbk){
+    return this.setup()._streaming_decode(reader, length, stack, cbk); // overrides this method
+};
+
 
 /**
  * Verifies that field values are valid and that required fields are present.

--- a/src/util.js
+++ b/src/util.js
@@ -11,7 +11,8 @@ var roots = require("./roots");
 var Type, // cyclic
     Enum;
 
-util.codegen = require("@protobufjs/codegen");
+//util.codegen = require("@protobufjs/codegen");
+util.codegen = require("../lib/codegen");
 util.fetch   = require("@protobufjs/fetch");
 util.path    = require("@protobufjs/path");
 
@@ -68,13 +69,22 @@ util.isReserved = function isReserved(name) {
 };
 
 /**
+ * Returns a safe property name as a string, e.g. safePropString("x") -> "'x'"
+ * @param {string} prop Property name
+ * @returns {string} Safe accessor
+ */
+ util.safePropString = function safePropString(prop) {
+    return "\"" + prop.replace(safePropBackslashRe, "\\\\").replace(safePropQuoteRe, "\\\"") + "\"";
+};
+
+/**
  * Returns a safe property accessor for the specified property name.
  * @param {string} prop Property name
  * @returns {string} Safe accessor
  */
 util.safeProp = function safeProp(prop) {
     if (!/^[$\w_]+$/.test(prop) || util.isReserved(prop))
-        return "[\"" + prop.replace(safePropBackslashRe, "\\\\").replace(safePropQuoteRe, "\\\"") + "\"]";
+        return "[" + safePropString(prop) + "]";
     return "." + prop;
 };
 


### PR DESCRIPTION
This adds a new `MyMessage.StreamingDecoder[Delimited]` method, which creates a `StreamingDecoder` object. This can be used to decode messages in chunks, which is useful when you have very large serialized data that you want to decode and process as it comes in from network or disk.

Along with the chunked decoding, you can pass in an `onmessage` callback, allowing you to process messages yourself as they come in, in a sort of simple SAX-style manner. Via this callback, you can choose to exclude a message from being inserted into the root message's DOM tree. This is useful for large data, where you don't necessarily want to load everything into RAM before you start processing it.

Simple usage is like so:
```javascript
function onmessage(msg, stack){
    // process msg
    return true;
}
var decoder = MyMessage.StreamingDecoder(onmessage)
decoder.write(chunk1)
decoder.write(chunk2)
decoder.end()
console.log(decoder.root)
```
See `streaming-decoder.js` file for a working example.

### Implementation details

Rather than write an entirely new byte-by-byte parser that uses a state machine, I figured it would be best to try and reuse as much of the existing code as possible, and make minimal changes to the existing codebase. The new decoder is a generator function which will pause decoding when the current data has been exhausted, and resume when the user provides more data (via `write`/`end` methods). There are two new files which most of the code resides:
1. `reader_streaming.js`: Implements a `StreamingReader` class, which mimics the `Reader` class API. It replaces all the methods with generator functions, which can pause when more data is needed. Internally, it keeps `Reader` objects for the current user input, and possibly next user input. It will try to call the underlying `Reader` method when possible to do all the parsing. One complicated thing is that when transitioning between the current and next data inputs, it may create a temporary buffer so it has enough bytes available to read the next token. Additonally and unfortunately, the bytes, string, skip, and skipType methods couldn't easily be made to reuse the `Reader` class implementations, so there is a bit of code duplication between `Reader` and `StreamingReader`.
2. `decoder_streaming.js`: This is very very similar to `decoder.js`, except coded as a generator function so it can use the `SreamingReader` class. Besides some cleanup I did, it is pretty close to `decoder.js`, so I think the two functions could be merged to conditionally generate a streaming decoder vs traditional decoder from the same method. I left them separate since I wanted these changes to be non-invasive at first.

I didn't do a whole lot of testing, if anyone wants to pitch in on that front; I can help fix bugs if you have a test case. Honestly, I am not really using this library anyways 😄  so don't think I'll have a lot of time to invest to get this into a mergeable state, whatever steps that entails (if the maintainers don't reject this outright). So if anyone want to pick this up and run with it, feel free!