### PR TITLE
fix code gen error, if proto pacakge name contains javascript reserved word

### DIFF
--- a/cli/targets/static.js
+++ b/cli/targets/static.js
@@ -251,7 +251,7 @@ function buildFunction(type, functionName, gen, scope) {
             )
                 return {
                     "type": "Identifier",
-                    "name": "$root" + type.fullName
+                    "name": "$root." + exportName(type)
                 };
             // replace types[N] with the field's actual type
             if (


### PR DESCRIPTION
fix codegen error, if proto pacakge name contains javascript reserved word, codegen will gen error code in static/static-module target

## e.g.

### test.proto

```proto
package function.b; // `function` is a reserved word
message Msg {
  optional int32 a = 1;
}
```

use `pbjs -t static-module -w es6 -o test.js test.proto`

### result test.js

```javascript
/// ...part of code
export const function_ = $root.function_ = (() => { // correct

/// ...part of code
Msg.decode = function decode(reader, length) {
    if (!(reader instanceof $Reader))
        reader = $Reader.create(reader);
    let end = length === undefined ? reader.len : reader.pos + length, message = new $root.function.b.Msg(); // incorrect

/// ...part of code
Msg.fromObject = function fromObject(object) {
    if (object instanceof $root.function.b.Msg) //  incorrect
```

# --> incorrect code `$root.function.b.Msg()`
# --> correct code is `$root.function_.b.Msg()`