### PR TITLE
Fix encoding of int64/bool keys of maps in encoder

### DIFF
--- a/src/encoder.js
+++ b/src/encoder.js
@@ -48,6 +48,10 @@ function encoder(mtype) {
             let keyGetter;
             switch (field.keyType) {
                 case "int64":
+                case "uint64":
+                case "sint64":
+                case "fixed64":
+                case "sfixed64":
                     keyGetter = "$util.longFromHash(ks[i], false)";
                     break;
                 case "bool":

--- a/src/encoder.js
+++ b/src/encoder.js
@@ -45,10 +45,22 @@ function encoder(mtype) {
 
         // Map fields
         if (field.map) {
+            let keyGetter;
+            switch (field.keyType) {
+                case "int64":
+                    keyGetter = "$util.longFromHash(ks[i], false)";
+                    break;
+                case "bool":
+                    keyGetter = "ks[i] === \"true\"";
+                    break;
+                default:
+                    keyGetter = "ks[i]";
+                    break;
+            }
             gen
     ("if(%s!=null&&Object.hasOwnProperty.call(m,%j)){", ref, field.name) // !== undefined && !== null
         ("for(var ks=Object.keys(%s),i=0;i<ks.length;++i){", ref)
-            ("w.uint32(%i).fork().uint32(%i).%s(%s)", (field.id << 3 | 2) >>> 0, 8 | types.mapKey[field.keyType], field.keyType, field.keyType === "int64" ? "$util.longFromHash(keys[i], false)" : "ks[i]");
+            ("w.uint32(%i).fork().uint32(%i).%s(%s)", (field.id << 3 | 2) >>> 0, 8 | types.mapKey[field.keyType], field.keyType, keyGetter);
             if (wireType === undefined) gen
             ("types[%i].encode(%s[ks[i]],w.uint32(18).fork()).ldelim().ldelim()", index, ref); // can't be groups
             else gen

--- a/src/encoder.js
+++ b/src/encoder.js
@@ -48,7 +48,7 @@ function encoder(mtype) {
             gen
     ("if(%s!=null&&Object.hasOwnProperty.call(m,%j)){", ref, field.name) // !== undefined && !== null
         ("for(var ks=Object.keys(%s),i=0;i<ks.length;++i){", ref)
-            ("w.uint32(%i).fork().uint32(%i).%s(ks[i])", (field.id << 3 | 2) >>> 0, 8 | types.mapKey[field.keyType], field.keyType);
+            ("w.uint32(%i).fork().uint32(%i).%s(%s)", (field.id << 3 | 2) >>> 0, 8 | types.mapKey[field.keyType], field.keyType, field.keyType === "int64" ? "$util.longFromHash(keys[i], false)" : "ks[i]");
             if (wireType === undefined) gen
             ("types[%i].encode(%s[ks[i]],w.uint32(18).fork()).ldelim().ldelim()", index, ref); // can't be groups
             else gen


### PR DESCRIPTION
Fixes #1652 .

The int64 writer cannot handle the hash directly, because it interprets
it as a string representation of a Long number, instead of a hash.

This is obviously wrong, because the input at this point always contains the longbit hashes already. So the int64() writer fails inevitably.

I believe that the simplest solution is: Explicit conversion from hash to long is needed before writing.

Again (just like with the other PR I submitted) I believe that the tests are missing for the generated encode/decode functions. If there were such tests, it would be fairly straightforward to write a test case that exercises this problem, and proves that the fix, in fact, works. 