### PR TITLE
keep deprecated tag

### DIFF
--- a/cli/lib/tsd-jsdoc/publish.js
+++ b/cli/lib/tsd-jsdoc/publish.js
@@ -135,6 +135,7 @@ function writeln() {
 }
 
 var keepTags = [
+    "deprecated",
     "param",
     "returns",
     "throws",


### PR DESCRIPTION
Some entities in proto file can be marked as deprecated.
Let's keep deprecated tag for users to see it.
