### PR TITLE
Use text decoder for utf-8 decoding

### DIFF
--- a/lib/utf8/index.js
+++ b/lib/utf8/index.js
@@ -7,6 +7,12 @@
  */
 var utf8 = exports;
 
+var decoder;
+
+if (global && global.TextDecoder) {
+    decoder = new TextDecoder('utf-8');
+}
+
 /**
  * Calculates the UTF8 byte length of a string.
  * @param {string} string String
@@ -40,6 +46,15 @@ utf8.length = function utf8_length(string) {
 utf8.read = function utf8_read(buffer, start, end) {
     if (end - start < 1) {
         return "";
+    }
+
+    if (decoder) {
+      var len = end - start;
+      try {
+        return decoder.decode(new global.Uint8Array(buffer.buffer, buffer.byteOffset + start, len));
+      } catch (e) {
+        return "";
+      }
     }
 
     var str = "";


### PR DESCRIPTION
Pull request to resolve [issue 811](https://github.com/protobufjs/protobuf.js/issues/811).
Faster decoding utf-8 with builtin TextDecoder.