### PR TITLE
avoid util.Long is not a constructor error

### DIFF
--- a/src/util/longbits.js
+++ b/src/util/longbits.js
@@ -112,8 +112,8 @@ LongBits.prototype.toNumber = function toNumber(unsigned) {
  * @returns {Long} Long
  */
 LongBits.prototype.toLong = function toLong(unsigned) {
-    return util.Long
-        ? new util.Long(this.lo | 0, this.hi | 0, Boolean(unsigned))
+    return (util.Long && util.Long.default)
+        ? new util.Long.default(this.lo | 0, this.hi | 0, Boolean(unsigned))
         /* istanbul ignore next */
         : { low: this.lo | 0, high: this.hi | 0, unsigned: Boolean(unsigned) };
 };


### PR DESCRIPTION
when using protobufjs with cosmjs i got an error that i was able to solve with this hack.

i have 
"long": "^5.2.0",

where as you have
"long": "^4.0.0"

i suppose that is the root of the problem 
but i open the PR as a start of a discussion