### PR TITLE
feat: support message verify unsigned int

### DIFF
--- a/src/util/minimal.js
+++ b/src/util/minimal.js
@@ -419,3 +419,13 @@ util._configure = function() {
             return new Buffer(size);
         };
 };
+
+/**
+ * Tests if the specified value is an unsigned number.
+ * @function
+ * @param {*} value Value to test
+ * @returns {boolean} `true` if the value is an unsigned number
+ */
+util.isUnsignedNumber  = function(value){
+    return util.isInteger(value) && value >= 0
+}

--- a/src/verifier.js
+++ b/src/verifier.js
@@ -4,6 +4,8 @@ module.exports = verifier;
 var Enum      = require("./enum"),
     util      = require("./util");
 
+var UNSIGNED_KEY = ['uint32','uint64','fixed32','fixed64'];
+
 function invalid(field, expected) {
     return field.name + ": " + expected + (field.repeated && expected !== "array" ? "[]" : field.map && expected !== "object" ? "{k:"+field.keyType+"}" : "") + " expected";
 }
@@ -38,6 +40,11 @@ function genVerifyValue(gen, field, fieldIndex, ref) {
             ("}");
         }
     } else {
+        if(UNSIGNED_KEY.includes(field.type)){
+            gen("if(!util.isUnsignedNumber(%s))", ref)
+                ("return%j", invalid(field, "unsigned number"))
+        }
+
         switch (field.type) {
             case "int32":
             case "uint32":


### PR DESCRIPTION
Message.verify is not sensitive for use negative number on uint32

```
package awesomepackage;
syntax = "proto3";

message AwesomeMessage {
    uint32 awesome_field = 1; // becomes awesomeField
}
```

```
protobuf.load(path.join(__dirname, "awesome.proto"), function (err, root) {
  if (err)
    throw err;

  // Obtain a message type
  const AwesomeMessage = root!.lookupType("awesomepackage.AwesomeMessage");

  // Exemplary payload
  const payload = { awesomeField: -1 };

  // Verify the payload if necessary (i.e. when possibly incomplete or invalid)
  const errMsg = AwesomeMessage.verify(payload);

  // errMsg equal null
  if (errMsg){
    throw Error(errMsg);
  }
});
```

The Behavior  make grpc service get incorrect value
eg:  send -1  get 4294967295