### PR TITLE
use ECMAScript standard globalThis

### DIFF
--- a/config/eslint.json
+++ b/config/eslint.json
@@ -10,6 +10,7 @@
         "Float64Array": true,
         "define": true,
         "global": true,
+        "globalThis": false,
         "XMLHttpRequest": true,
         "Promise": true
     },

--- a/src/util/minimal.js
+++ b/src/util/minimal.js
@@ -44,6 +44,7 @@ util.isNode = Boolean(typeof global !== "undefined"
 util.global = util.isNode && global
            || typeof window !== "undefined" && window
            || typeof self   !== "undefined" && self
+           || globalThis
            || this; // eslint-disable-line no-invalid-this
 
 /**


### PR DESCRIPTION
`globalThis` is ready for ECMAScript standard. In strict mode `this` will be `undefined`, use globalThis the code will work in window and non-window contexts.