### PR TITLE
fix: support for nested messages and enums within group blocks

### DIFF
--- a/src/parse.js
+++ b/src/parse.js
@@ -443,6 +443,14 @@ function parse(source, root, options) {
                     }
                     break;
 
+                case "message":
+                    parseType(type, token);
+                    break;
+
+                case "enum":
+                    parseEnum(type, token);
+                    break;
+
                 /* istanbul ignore next */
                 default:
                     throw illegal(token); // there are no groups with proto3 semantics


### PR DESCRIPTION
This fixes support for proto files that have nested messages or enums declared within groups, like this:

```proto
syntax = "proto2";

message Foo {
  repeated group Field = 1 {
    message Bar {
      optional bool my_bool = 2;
    }

    optional string my_string = 3;
    optional Bar my_bar = 4;
  }
}

```