### PR TITLE
fix: proto3 optional scalars should default to null in reflection API

### DIFF
--- a/src/field.js
+++ b/src/field.js
@@ -270,6 +270,9 @@ Field.prototype.resolve = function resolve() {
             this.typeDefault = null;
         else // instanceof Enum
             this.typeDefault = this.resolvedType.values[Object.keys(this.resolvedType.values)[0]]; // first defined
+    } else if (this.options && this.options.proto3_optional) {
+        // proto3 scalar value marked optional; should default to null
+        this.typeDefault = null;
     }
 
     // use explicitly set default value if present

--- a/tests/comp_optional.js
+++ b/tests/comp_optional.js
@@ -22,5 +22,9 @@ tape.test("proto3 optional", function(test) {
     test.equal(Message.oneofs._optionalInt32.name, '_optionalInt32');
     test.deepEqual(Message.oneofs._optionalInt32.oneof, ['optionalInt32']);
 
+    var m = Message.create({});
+    test.strictEqual(m.regularInt32, 0);
+    test.strictEqual(m.optionalInt32, null);
+
     test.end();
 });


### PR DESCRIPTION
https://github.com/protobufjs/protobuf.js/pull/1584 made proto3 optional
scalars default to null when using static/static-module, but the old
behaviour remained when using reflection (eg json-module). This PR
attempts to make the latter case behave the same way (would love to use
static code generation, but the resulting file sizes are too large).

This passes the existing tests, but I do not know the codebase well, so I
am not sure if this is the best approach or not.