### PR TITLE
build: run tests if ci label added

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,7 @@ on:
     branches:
     - master
   pull_request:
+    types: [assigned, opened, synchronize, reopened, labeled]
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Our release PRs don't have tests run, because they're opened by an action themselves.

This will allow us to add a `ci` label to kick off tests.