### PR TITLE
feat: allow message.getTypeUrl provide custom tyepUrlPrefix

### DIFF
--- a/cli/targets/static.js
+++ b/cli/targets/static.js
@@ -597,7 +597,7 @@ function buildType(ref, type) {
             "@function getTypeUrl",
             "@memberof " + exportName(type),
             "@static",
-            "@param {string|undefined} [typeUrlPrefix] your custom typeUrlPrefix(default \"type.googleapis.com\")",
+            "@param {string} [typeUrlPrefix] your custom typeUrlPrefix(default \"type.googleapis.com\")",
             "@returns {string} The default type url"
         ]);
         push(escapeName(type.name) + ".getTypeUrl = function getTypeUrl(typeUrlPrefix) {");

--- a/cli/targets/static.js
+++ b/cli/targets/static.js
@@ -597,11 +597,17 @@ function buildType(ref, type) {
             "@function getTypeUrl",
             "@memberof " + exportName(type),
             "@static",
+            "@param {string|undefined} [typeUrlPrefix] your custom typeUrlPrefix(default \"type.googleapis.com\")",
             "@returns {string} The default type url"
         ]);
-        push(escapeName(type.name) + ".getTypeUrl = function getTypeUrl() {");
+        push(escapeName(type.name) + ".getTypeUrl = function getTypeUrl(typeUrlPrefix) {");
         ++indent;
-            push("return \"type.googleapis.com/" + exportName(type) + "\";");
+            push("if (typeUrlPrefix === undefined) {");
+            ++indent;
+                push("typeUrlPrefix = \"type.googleapis.com\";");
+            --indent;
+            push("}");
+            push("return typeUrlPrefix + \"/" + exportName(type) + "\";");
         --indent;
         push("};");
     }


### PR DESCRIPTION
I noticed that in many other language implementations (such as [Java](https://github.com/protocolbuffers/protobuf/blob/f367bfb13d9ff5f097666bcdf7389aa8cef902b7/src/google/protobuf/compiler/java/java_message.cc#L1683-L1690), [CSharp](https://github.com/protocolbuffers/protobuf/blob/3f5fc4df1de8e12b2235c3006593e22d6993c3f5/csharp/src/Google.Protobuf/WellKnownTypes/AnyPartial.cs#L136-L145)), Google provides optional parameter `typeUrlPrefix` for the function `pack` or `getTypeUrl`

---

this pr is a re-request of #1665 , the original pr was mistakenly overwritten by the force push of the pull bot