### PR TITLE
fix: remove unused `@types/long`

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -51,7 +51,6 @@
         "@protobufjs/path": "^1.1.2",
         "@protobufjs/pool": "^1.1.0",
         "@protobufjs/utf8": "^1.1.0",
-        "@types/long": "^4.0.1",
         "@types/node": ">=13.7.0",
         "long": "^5.0.0"
       },
@@ -738,11 +737,6 @@
     },
     "../node_modules/@types/linkify-it": {
       "version": "3.0.2",
-      "dev": true,
-      "license": "MIT"
-    },
-    "../node_modules/@types/long": {
-      "version": "4.0.2",
       "dev": true,
       "license": "MIT"
     },
@@ -10126,7 +10120,6 @@
         "@protobufjs/path": "^1.1.2",
         "@protobufjs/pool": "^1.1.0",
         "@protobufjs/utf8": "^1.1.0",
-        "@types/long": "^4.0.1",
         "@types/node": ">=13.7.0",
         "benchmark": "^2.1.4",
         "browserify": "^17.0.0",
@@ -10613,10 +10606,6 @@
         },
         "@types/linkify-it": {
           "version": "3.0.2",
-          "dev": true
-        },
-        "@types/long": {
-          "version": "4.0.2",
           "dev": true
         },
         "@types/markdown-it": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,6 @@
         "@protobufjs/path": "^1.1.2",
         "@protobufjs/pool": "^1.1.0",
         "@protobufjs/utf8": "^1.1.0",
-        "@types/long": "^4.0.1",
         "@types/node": ">=13.7.0",
         "long": "^5.0.0"
       },
@@ -737,11 +736,6 @@
       "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-3.0.2.tgz",
       "integrity": "sha512-HZQYqbiFVWufzCwexrvh694SOim8z2d+xJl5UNamcvQFejLY/2YUtzXHYi3cHdI7PMlS8ejH2slRAOJQ32aNbA==",
       "dev": true
-    },
-    "node_modules/@types/long": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
-      "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA=="
     },
     "node_modules/@types/markdown-it": {
       "version": "12.2.3",
@@ -10626,11 +10620,6 @@
       "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-3.0.2.tgz",
       "integrity": "sha512-HZQYqbiFVWufzCwexrvh694SOim8z2d+xJl5UNamcvQFejLY/2YUtzXHYi3cHdI7PMlS8ejH2slRAOJQ32aNbA==",
       "dev": true
-    },
-    "@types/long": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
-      "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA=="
     },
     "@types/markdown-it": {
       "version": "12.2.3",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "@protobufjs/path": "^1.1.2",
     "@protobufjs/pool": "^1.1.0",
     "@protobufjs/utf8": "^1.1.0",
-    "@types/long": "^4.0.1",
     "@types/node": ">=13.7.0",
     "long": "^5.0.0"
   },


### PR DESCRIPTION
#1751 updated to v5 which ships with types. However, the `Long` type used here seems to be custom and not imported, so this was never used anyways?

https://github.com/protobufjs/protobuf.js/blob/6f0806ddef408647fbaed049dbd8929ad9f5c10c/index.d.ts#L1848-L1862