### PR TITLE
fix: support for nested messages and enums within group blocks

### DIFF
--- a/src/parse.js
+++ b/src/parse.js
@@ -443,6 +443,14 @@ function parse(source, root, options) {
                     }
                     break;
 
+                case "message":
+                    parseType(type, token);
+                    break;
+
+                case "enum":
+                    parseEnum(type, token);
+                    break;
+
                 /* istanbul ignore next */
                 default:
                     throw illegal(token); // there are no groups with proto3 semantics

--- a/tests/data/test.json
+++ b/tests/data/test.json
@@ -412,18 +412,26 @@
                   "type": "OptionalGroup",
                   "id": 3
                 },
+                "messageInGroup": {
+                  "type": "MessageInGroup",
+                  "id": 4
+                },
+                "enumInGroup": {
+                  "type": "EnumInGroup",
+                  "id": 5
+                },
                 "id": {
                   "type": "string",
-                  "id": 4
+                  "id": 6
                 },
                 "requiredSimple": {
                   "rule": "required",
                   "type": "Simple2",
-                  "id": 5
+                  "id": 7
                 },
                 "optionalSimple": {
                   "type": "Simple2",
-                  "id": 6
+                  "id": 8
                 }
               },
               "nested": {
@@ -461,6 +469,45 @@
                       "rule": "required",
                       "type": "string",
                       "id": 1
+                    }
+                  },
+                  "group": true
+                },
+                "MessageInGroup": {
+                  "fields": {
+                    "id": {
+                      "rule": "required",
+                      "type": "NetedMessage",
+                      "id": 1
+                    }
+                  },
+                  "nested": {
+                    "NetedMessage": {
+                      "fields": {
+                        "id": {
+                          "rule": "optional",
+                          "type": "string",
+                          "id": 1
+                        }
+                      }
+                    }
+                  },
+                  "group": true
+                },
+                "EnumInGroup": {
+                  "fields": {
+                    "id": {
+                      "rule": "required",
+                      "type": "NestedEnum",
+                      "id": 1
+                    }
+                  },
+                  "nested": {
+                    "NestedEnum": {
+                      "values": {
+                        "first": 0,
+                        "second": 1
+                      }
                     }
                   },
                   "group": true

--- a/tests/data/test.proto
+++ b/tests/data/test.proto
@@ -182,9 +182,22 @@ message TestGroup {
   optional group OptionalGroup = 3 {
     required string id = 1;
   }
-  optional string id = 4;
-  required Simple2 required_simple = 5;
-  optional Simple2 optional_simple = 6;
+  optional group MessageInGroup = 4 {
+    message NestedMessage {
+      optional string id = 1;
+    }
+    required NestedMessage id = 1;
+  }
+  optional group EnumInGroup = 5 {
+    enum NestedEnum {
+      first = 0;
+      second = 1;
+    }
+    required NestedEnum id = 1;
+  }
+  optional string id = 6;
+  required Simple2 required_simple = 7;
+  optional Simple2 optional_simple = 8;
 }
 
 message TestGroup1 {


### PR DESCRIPTION
This fixes support for proto files that have nested messages or enums declared within groups, like this:

```proto
syntax = "proto2";

message Foo {
  repeated group Field = 1 {
    message Bar {
      optional bool my_bool = 2;
    }

    optional string my_string = 3;
    optional Bar my_bar = 4;
  }
}

```