### PR TITLE
feat: accept unknown enum values in fromObject

### DIFF
--- a/src/converter.js
+++ b/src/converter.js
@@ -23,8 +23,14 @@ function genValuePartial_fromObject(gen, field, fieldIndex, prop) {
         if (field.resolvedType instanceof Enum) { gen
             ("switch(d%s){", prop);
             for (var values = field.resolvedType.values, keys = Object.keys(values), i = 0; i < keys.length; ++i) {
-                if (field.repeated && values[keys[i]] === field.typeDefault) gen
-                ("default:");
+                // enum unknown values passthrough
+                if (values[keys[i]] === field.typeDefault) { gen
+                    ("default:")
+                        ("if(typeof(d%s)===\"number\"){m%s=d%s;break}", prop, prop, prop);
+                    if (!field.repeated) gen // fallback to default value only for
+                                             // arrays, to avoid leaving holes.
+                        ("break")            // for non-repeated fields, just ignore
+                }
                 gen
                 ("case%j:", keys[i])
                 ("case %i:", values[keys[i]])
@@ -156,7 +162,7 @@ function genValuePartial_toObject(gen, field, fieldIndex, prop) {
     /* eslint-disable no-unexpected-multiline, block-scoped-var, no-redeclare */
     if (field.resolvedType) {
         if (field.resolvedType instanceof Enum) gen
-            ("d%s=o.enums===String?types[%i].values[m%s]:m%s", prop, fieldIndex, prop, prop);
+            ("d%s=o.enums===String?(types[%i].values[m%s]===undefined?m%s:types[%i].values[m%s]):m%s", prop, fieldIndex, prop, prop, fieldIndex, prop, prop);
         else gen
             ("d%s=types[%i].toObject(m%s,o)", prop, fieldIndex, prop);
     } else {

--- a/src/converter.js
+++ b/src/converter.js
@@ -29,7 +29,7 @@ function genValuePartial_fromObject(gen, field, fieldIndex, prop) {
                         ("if(typeof(d%s)===\"number\"){m%s=d%s;break}", prop, prop, prop);
                     if (!field.repeated) gen // fallback to default value only for
                                              // arrays, to avoid leaving holes.
-                        ("break")            // for non-repeated fields, just ignore
+                        ("break");           // for non-repeated fields, just ignore
                 }
                 gen
                 ("case%j:", keys[i])

--- a/tests/api_converters.js
+++ b/tests/api_converters.js
@@ -103,7 +103,7 @@ tape.test("converters", function(test) {
                     bytesVal: buf,
                     bytesRepeated: [buf, buf],
                     enumVal: 2,
-                    enumRepeated: [1, 2],
+                    enumRepeated: [1, 100, 2],
                     int64Map: {
                         a: protobuf.util.Long.fromNumber(2),
                         b: protobuf.util.Long.fromNumber(3)
@@ -127,6 +127,7 @@ tape.test("converters", function(test) {
                     test.ok(Buffer.isBuffer(Message.toObject(msg, { bytes: Buffer }).bytesVal), "bytes to buffers");
 
                 test.equal(Message.toObject(msg, { enums: String }).enumVal, "TWO", "enums to strings");
+                test.equal(Message.toObject(msg, { enums: String }).enumRepeated[1], 100, "enums to strings does not change unknown values");
 
                 test.end();
             });
@@ -157,7 +158,7 @@ tape.test("converters", function(test) {
                 bytesVal: "MTEx",
                 bytesRepeated: ["MTEx", [49, 49, 49]],
                 enumVal: "ONE",
-                enumRepeated: [2, "TWO"],
+                enumRepeated: [2, "TWO", 100],
                 int64Map: {
                     a: 2,
                     b: "3"
@@ -176,7 +177,7 @@ tape.test("converters", function(test) {
             test.same(msg.bytesVal, buf, "should set bytesVal from a base64 string");
             test.same(msg.bytesRepeated, [ buf, buf ], "should set bytesRepeated from a base64 string and a plain array");
             test.equal(msg.enumVal, 1, "should set enumVal from a string");
-            test.same(msg.enumRepeated, [ 2, 2 ], "should set enumRepeated from a number and a string");
+            test.same(msg.enumRepeated, [ 2, 2, 100 ], "should set enumRepeated from a number and a string and preserve unknown value");
             test.same(msg.int64Map, { a: { low: 2, high: 0, unsigned: false }, b: { low: 3, high: 0, unsigned: false } }, "should set int64Map from a number and a string");
 
             test.end();


### PR DESCRIPTION
In official protobuf implementations unknown numeric enum values are accepted and not discarded. Changing the behavior of `fromObject` to store unknown enum values. `toObject` will also dump them as is (without converting to a string, because it does not know the string representation for an unknown enum value).

I'm not changing `verify` which still won't accept unknown values.

Since the changes in the code generators are hard to read, here are some examples.

Imagine this proto:

```proto
syntax = "proto3";

enum E {
  DEFAULT = 0;
  KNOWN = 1;
}

message M {
  E a = 1;
  repeated E b = 2;
}
```

This is the diff in the generated code for `fromObject` and `toObject`, explanations are below.
```diff
--- original.js	2022-08-26 16:51:09.932392333 +0000
+++ changed.js	2022-08-26 17:23:27.797270346 +0000
@@ -3,6 +3,9 @@
   return d
   var m=new this.ctor
   switch(d.a){
+  default:
+  if(typeof(d.a)==="number"){m.a=d.a;break}
+  break
   case"DEFAULT":
   case 0:
   m.a=0
@@ -19,6 +22,7 @@
   for(var i=0;i<d.b.length;++i){
   switch(d.b[i]){
   default:
+  if(typeof(d.b[i])==="number"){m.b[i]=d.b[i];break}
   case"DEFAULT":
   case 0:
   m.b[i]=0
@@ -43,12 +47,12 @@
   d.a=o.enums===String?"DEFAULT":0
   }
   if(m.a!=null&&m.hasOwnProperty("a")){
-  d.a=o.enums===String?types[0].values[m.a]:m.a
+  d.a=o.enums===String?(types[0].values[m.a]===undefined?m.a:types[0].values[m.a]):m.a
   }
   if(m.b&&m.b.length){
   d.b=[]
   for(var j=0;j<m.b.length;++j){
-  d.b[j]=o.enums===String?types[1].values[m.b[j]]:m.b[j]
+  d.b[j]=o.enums===String?(types[1].values[m.b[j]]===undefined?m.b[j]:types[1].values[m.b[j]]):m.b[j]
   }
   }
   return d
```

Previously, this was the code generated for `fromObject` and `toObject` (comments added):

```js
function M$fromObject(d){
  if(d instanceof this.ctor)
  return d
  var m=new this.ctor
  switch(d.a){      // for single enum values, there's no "default:" clause, it ignores unknown values
  case"DEFAULT":
  case 0:
  m.a=0
  break
  case"KNOWN":
  case 1:
  m.a=1
  break
  }
  if(d.b){
  if(!Array.isArray(d.b))
  throw TypeError(".M.b: array expected")
  m.b=[]
  for(var i=0;i<d.b.length;++i){
  switch(d.b[i]){
  default:
  case"DEFAULT":    // for repeated enum values, it replaces unknown values with default values
                    // to avoid having holes in array
  case 0:
  m.b[i]=0
  break
  case"KNOWN":
  case 1:
  m.b[i]=1
  break
  }
  }
  }
  return m
}
function M$toObject(m,o){
  if(!o)
  o={}
  var d={}
  if(o.arrays||o.defaults){
  d.b=[]
  }
  if(o.defaults){
  d.a=o.enums===String?"DEFAULT":0
  }
  if(m.a!=null&&m.hasOwnProperty("a")){
  d.a=o.enums===String?types[0].values[m.a]:m.a // will put undefined for unknown value
  }
  if(m.b&&m.b.length){
  d.b=[]
  for(var j=0;j<m.b.length;++j){
  d.b[j]=o.enums===String?types[1].values[m.b[j]]:m.b[j] // same here
  }
  }
  return d
}
```

With the changes, the following code will be produced:

```js
function M$fromObject(d){
  if(d instanceof this.ctor)
  return d
  var m=new this.ctor
  switch(d.a){
  default:
  if(typeof(d.a)==="number"){m.a=d.a;break} // if an unknown value is a number, use it as is,
  break                                     // otherwise, ignore it since it's not an array
  case"DEFAULT":
  case 0:
  m.a=0
  break
  case"KNOWN":
  case 1:
  m.a=1
  break
  }
  if(d.b){
  if(!Array.isArray(d.b))
  throw TypeError(".M.b: array expected")
  m.b=[]
  for(var i=0;i<d.b.length;++i){
  switch(d.b[i]){
  default:
  if(typeof(d.b[i])==="number"){m.b[i]=d.b[i];break} // for arrays, use unknown numbers as is, but
  case"DEFAULT":                                     // don't leave holes
  case 0:
  m.b[i]=0
  break
  case"KNOWN":
  case 1:
  m.b[i]=1
  break
  }
  }
  }
  return m
}
function M$toObject(m,o){
  if(!o)
  o={}
  var d={}
  if(o.arrays||o.defaults){
  d.b=[]
  }
  if(o.defaults){
  d.a=o.enums===String?"DEFAULT":0
  }
  if(m.a!=null&&m.hasOwnProperty("a")){
  d.a=o.enums===String?(types[0].values[m.a]===undefined?m.a:types[0].values[m.a]):m.a
  // will put a number for unknown value
  }
  if(m.b&&m.b.length){
  d.b=[]
  for(var j=0;j<m.b.length;++j){
  d.b[j]=o.enums===String?(types[1].values[m.b[j]]===undefined?m.b[j]:types[1].values[m.b[j]]):m.b[j]
  // same here
  }
  }
  return d
}
```