### PR TITLE
fix: fix the unexpected case when listener be triggered

### DIFF
--- a/lib/eventemitter/index.js
+++ b/lib/eventemitter/index.js
@@ -74,11 +74,12 @@ EventEmitter.prototype.emit = function emit(evt) {
     var listeners = this._listeners[evt];
     if (listeners) {
         var args = [],
-            i = 1;
-        for (; i < arguments.length;)
-            args.push(arguments[i++]);
-        for (i = 0; i < listeners.length;)
-            listeners[i].fn.apply(listeners[i++].ctx, args);
+          i = 1,
+          _listeners = listeners.slice();
+
+        for (; i < arguments.length; ) args.push(arguments[i++]);
+        for (i = 0; i < _listeners.length; )
+          _listeners[i].fn.apply(_listeners[i++].ctx, args);
     }
     return this;
 };

--- a/lib/eventemitter/tests/index.js
+++ b/lib/eventemitter/tests/index.js
@@ -43,5 +43,38 @@ tape.test("eventemitter", function(test) {
         ee.off("a", fn);
     }, "should not throw if no such listener is found");
 
+
+    var fn1, fn2;
+    var count = 0;
+
+    ee.on(
+      "b",
+      (fn1 = function (arg1) {
+        count++;
+        test.equal(this, ctx, "should be called with this = ctx");
+        test.equal(arg1, 1, "should be called with arg1 = 1");
+        ee.off("b", fn1);
+      }),
+      ctx
+    );
+
+    ee.on(
+      "b",
+      (fn2 = function (arg1) {
+        count++;
+        test.equal(this, ctx, "should be called with this = ctx");
+        test.equal(arg1, 1, "should be called with arg1 = 1");
+      }),
+      ctx
+    );
+
+    ee.on("c", function (arg1) {
+      test.equal(arg1, 2, "should be called with arg1 = 2");
+    })
+      .emit("b", 1)
+      .emit("c", count);
+
+    
+
     test.end();
 });


### PR DESCRIPTION
Fix the unexpected case when listener be triggered. When I add two listeners of the same type to the event-emitter, and then I remove the first listener in the first listener's handler,  the second listener cannot be executed correctly.