### PR TITLE
fix: generate valid js code for aliased enum values

### DIFF
--- a/src/converter.js
+++ b/src/converter.js
@@ -18,18 +18,20 @@ var Enum = require("./enum"),
  * @ignore
  */
 function genValuePartial_fromObject(gen, field, fieldIndex, prop) {
+    var defaultAlreadyEmitted = false;
     /* eslint-disable no-unexpected-multiline, block-scoped-var, no-redeclare */
     if (field.resolvedType) {
         if (field.resolvedType instanceof Enum) { gen
             ("switch(d%s){", prop);
             for (var values = field.resolvedType.values, keys = Object.keys(values), i = 0; i < keys.length; ++i) {
                 // enum unknown values passthrough
-                if (values[keys[i]] === field.typeDefault) { gen
+                if (values[keys[i]] === field.typeDefault && !defaultAlreadyEmitted) { gen
                     ("default:")
                         ("if(typeof(d%s)===\"number\"){m%s=d%s;break}", prop, prop, prop);
                     if (!field.repeated) gen // fallback to default value only for
                                              // arrays, to avoid leaving holes.
                         ("break");           // for non-repeated fields, just ignore
+                    defaultAlreadyEmitted = true;
                 }
                 gen
                 ("case%j:", keys[i])

--- a/tests/cli.js
+++ b/tests/cli.js
@@ -65,6 +65,7 @@ tape.test("pbjs generates static code", function(test) {
                     value: 42,
                 },
                 regularField: "abc",
+                enumField: 0,
             };
             var obj1 = OneofContainer.toObject(OneofContainer.fromObject(obj));
             test.deepEqual(obj, obj1, "fromObject and toObject work for plain object");
@@ -76,6 +77,7 @@ tape.test("pbjs generates static code", function(test) {
             instance.messageInOneof = new Message();
             instance.messageInOneof.value = 42;
             instance.regularField = "abc";
+            instance.enumField = 0;
             var instance1 = OneofContainerDynamic.toObject(OneofContainerDynamic.fromObject(instance));
             test.deepEqual(instance, instance1, "fromObject and toObject work for instance of the static type");
 

--- a/tests/data/cli/test.proto
+++ b/tests/data/cli/test.proto
@@ -4,10 +4,19 @@ message Message {
   int32 value = 1;
 }
 
+enum Enum {
+  option allow_alias = true;
+
+  UNSPECIFIED = 0;
+  DEFAULT = 0; // checking that an alias does not break things
+  SOMETHING = 1;
+}
+
 message OneofContainer {
   oneof some_oneof {
     string string_in_oneof = 1;
     Message message_in_oneof = 2;
   }
   string regular_field = 3;
+  Enum enum_field = 4;
 }


### PR DESCRIPTION
Having an aliased default value in an enum now breaks the generated JS static code:

```
SyntaxError: Multiple default clauses
    at Espree.raise (/Users/fenster/repos/nodejs-appengine-admin/node_modules/protobufjs-cli/node_modules/espree/dist/espree.cjs:675:25)
    at Espree.raiseRecoverable (/Users/fenster/repos/nodejs-appengine-admin/node_modules/protobufjs-cli/node_modules/espree/dist/espree.cjs:691:18)
    at Espree.pp$8.parseSwitchStatement (/Users/fenster/repos/nodejs-appengine-admin/node_modules/protobufjs-cli/node_modules/acorn/dist/acorn.js:1107:34)
    at Espree.pp$8.parseStatement (/Users/fenster/repos/nodejs-appengine-admin/node_modules/protobufjs-cli/node_modules/acorn/dist/acorn.js:909:39)
    at Espree.pp$8.parseBlock (/Users/fenster/repos/nodejs-appengine-admin/node_modules/protobufjs-cli/node_modules/acorn/dist/acorn.js:1236:23)
    at Espree.pp$5.parseFunctionBody (/Users/fenster/repos/nodejs-appengine-admin/node_modules/protobufjs-cli/node_modules/acorn/dist/acorn.js:3285:24)
    at Espree.pp$8.parseFunction (/Users/fenster/repos/nodejs-appengine-admin/node_modules/protobufjs-cli/node_modules/acorn/dist/acorn.js:1358:10)
    at Espree.pp$8.parseFunctionStatement (/Users/fenster/repos/nodejs-appengine-admin/node_modules/protobufjs-cli/node_modules/acorn/dist/acorn.js:1058:17)
    at Espree.pp$8.parseStatement (/Users/fenster/repos/nodejs-appengine-admin/node_modules/protobufjs-cli/node_modules/acorn/dist/acorn.js:903:19)
    at Espree.pp$8.parseTopLevel (/Users/fenster/repos/nodejs-appengine-admin/node_modules/protobufjs-cli/node_modules/acorn/dist/acorn.js:817:23) {
  index: 1011,
  lineNumber: 54,
  column: 3
}
```

Fixing that by making sure that the `default:` clause is emitted only once. Updating the tests accordingly.