### PR TITLE
fix(types): nested object can be a oneof

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -863,7 +863,7 @@ export interface INamespace {
 type AnyExtensionField = (IExtensionField|IExtensionMapField);
 
 /** Any nested object descriptor. */
-type AnyNestedObject = (IEnum|IType|IService|AnyExtensionField|INamespace);
+type AnyNestedObject = (IEnum|IType|IService|AnyExtensionField|INamespace|IOneOf);
 
 /** Base class of all reflection objects. */
 export abstract class ReflectionObject {

--- a/src/namespace.js
+++ b/src/namespace.js
@@ -143,9 +143,8 @@ Object.defineProperty(Namespace.prototype, "nestedArray", {
 /**
  * Any nested object descriptor.
  * @typedef AnyNestedObject
- * @type {IEnum|IType|IService|AnyExtensionField|INamespace}
+ * @type {IEnum|IType|IService|AnyExtensionField|INamespace|IOneOf}
  */
-// ^ BEWARE: VSCode hangs forever when using more than 5 types (that's why AnyExtensionField exists in the first place)
 
 /**
  * Converts this namespace to a namespace descriptor.


### PR DESCRIPTION
Fixing the type declaration to allow one very special case: a field extension that is a proto3 `optional` field. Internally, proto3 `optional` fields are represented as a single field `oneof`s, which makes it the first case ever when a `oneof` can be a `nested` object.

Example: [bigquery-storage](https://github.com/googleapis/googleapis/blob/fafd03f8da224663da0d83ee7c6ed1d84f3cb2e6/google/cloud/bigquery/storage/v1/annotations.proto#L14-L28)

```proto
extend google.protobuf.FieldOptions {
  optional string column_name = 454943157;
}
```

Related part of the JSON:

```json
                      "nested": {
                        "_columnName": {
                          "oneof": [       <--- this is not accepted without the fix
                            "columnName"
                          ]
                        },
                        "columnName": {
                          "type": "string",
                          "id": 454943157,
                          "extend": "google.protobuf.FieldOptions",
                          "options": {
                            "proto3_optional": true
                          }
                        },
```

Yeah, also, last but not least, VSCode does not hang anymore, so removing that comment. It was added 6 years ago, not true anymore.