### PR TITLE
Don't include `@exports` for enums

### DIFF
--- a/cli/targets/static.js
+++ b/cli/targets/static.js
@@ -702,7 +702,7 @@ function buildEnum(ref, enm) {
     push("");
     var comment = [
         enm.comment || enm.name + " enum.",
-        enm.parent instanceof protobuf.Root ? "@exports " + escapeName(enm.name) : "@name " + exportName(enm),
+        "@name " + exportName(enm),
         config.forceEnumString ? "@enum {string}" : "@enum {number}",
     ];
     Object.keys(enm.values).forEach(function(key) {


### PR DESCRIPTION
jsdoc states :

> Use the @exports tag when documenting JavaScript modules that export anything"
> other than the "exports" object or the "module.exports" property.

It is not intended to be used to specify an export name. TLDR: There should be only one `@exports` per file. Maybe $root for non-es6 modules.
ES6 modules should use `@module`

The other `@exports` don't appear to be causing problems. However, they are incorrect as well.

Fixes #1414