### PR TITLE
Honor json_name option

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "protobufjs",
-  "version": "7.1.2",
+  "version": "7.1.3",
   "versionScheme": "~",
   "description": "Protocol Buffers for JavaScript (& TypeScript).",
   "author": "Daniel Wirtz <dcode+protobufjs@dcode.io>",
@@ -36,7 +36,7 @@
     "prof": "node bench/prof",
     "test": "npm run test:sources && npm run test:types",
     "test:sources": "tape -r ./lib/tape-adapter tests/*.js tests/node/*.js",
-    "test:types": "tsc tests/comp_typescript.ts --lib es2015 --esModuleInterop --strictNullChecks --experimentalDecorators --emitDecoratorMetadata && tsc tests/data/test.js.ts --lib es2015 --esModuleInterop --noEmit --strictNullChecks && tsc tests/data/*.ts --lib es2015 --esModuleInterop --noEmit --strictNullChecks",
+    "test:types": "tsc tests/comp_typescript.ts --lib es2015 --esModuleInterop --strictNullChecks --experimentalDecorators --emitDecoratorMetadata && tsc tests/data/test.js.ts --lib es2015 --esModuleInterop --noEmit --strictNullChecks && tsc --project tests/data/all_files.tsconfig.json --lib es2015 --esModuleInterop --noEmit --strictNullChecks",
     "make": "npm run lint:sources && npm run build && npm run lint:types && node ./scripts/gentests.js && npm test"
   },
   "dependencies": {

--- a/src/field.js
+++ b/src/field.js
@@ -221,6 +221,16 @@ Field.prototype.setOption = function setOption(name, value, ifNotSet) {
     return ReflectionObject.prototype.setOption.call(this, name, value, ifNotSet);
 };
 
+Field.prototype.applyParsedOptions = function applyParsedOptions() {
+    if(this.parsedOptions !== null) {
+        var opt = this.parsedOptions.find(function (opt) {
+            return Object.prototype.hasOwnProperty.call(opt, "json_name");
+        });
+        if(opt)
+            this.name = opt["json_name"];
+    }
+};
+
 /**
  * Field descriptor.
  * @interface IField

--- a/src/parse.js
+++ b/src/parse.js
@@ -388,6 +388,8 @@ function parse(source, root, options) {
             parseInlineOptions(field);
         });
 
+        field.applyParsedOptions();
+
         if (rule === "proto3_optional") {
             // for proto3 optional fields, we create a single-member Oneof to mimic "optional" behavior
             var oneof = new OneOf("_" + name);

--- a/tests/comp_options-parse.js
+++ b/tests/comp_options-parse.js
@@ -32,6 +32,8 @@ tape.test("Options", function (test) {
         test.equal(TestFieldOptionsMsg.fields.field2.options["(fo_single_msg).value"], 7, "should correctly parse single msg option");
         test.equal(TestFieldOptionsMsg.fields.field2.options["(fo_single_msg).rep_value"], 9, "should take second repeated int in single msg option");
         test.same(TestFieldOptionsMsg.fields.field2.parsedOptions, [{"(fo_single_msg)": {value: 7, rep_value: [8,9]}}], "should take all repeated message option");
+        test.equal(TestFieldOptionsMsg.fields.Field_Three.options["json_name"], "Field_Three", "should correctly parse json_name option");
+        test.equal(TestFieldOptionsMsg.fields.field3, undefined, "json_name option should change field name");
         test.end();
     });
 

--- a/tests/data/all_files.tsconfig.json
+++ b/tests/data/all_files.tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["*.ts"]
+}

--- a/tests/data/options_test.proto
+++ b/tests/data/options_test.proto
@@ -61,6 +61,7 @@ extend google.protobuf.MethodOptions {
 message TestFieldOptionsMsg {
     string field1 = 1 [(fo_rep_msg) = {value: 1 rep_value: 2 rep_value: 3}, (fo_rep_msg) = {value: 4 rep_value: 5 rep_value: 6}];
     string field2 = 2 [(fo_single_msg).value = 7, (fo_single_msg).rep_value = 8, (fo_single_msg).rep_value = 9];
+    string field3 = 3 [json_name = "Field_Three"];
 }
 
 message TestMessageOptionsMsg {


### PR DESCRIPTION
Honor the json_name option.  This is useful when a .proto file is compiled for multiple languages, to conform to whatever random casing rules were chosen for the project:
- The .proto convention is to use lower_snake_case for field names, and UPPER_SNAKE_CASE for enum names
- C++ (via protoc) simply uses lower_snake_case for field names
- C# (via protobuf-net) uses PascalCase for both field and enum names, and has [options for customizing the names](https://github.com/protobuf-net/protobuf-net/blob/main/src/Tools/protogen.proto)
- JavaScript (via protobuf.js) uses camelCase for field names, and the json_name attribute can now be used to customize the name

Example:
```
message NetworkAdapter {
  string get_ip_address = 1 [json_name = "getIPAddress", (.protobuf_net.fieldopt).name ="GetIPAddress"];
}
```

Default names without the options:
- C++: get_ip_address (unchanged)
- C#: GetIpAddress
- JS: getIpAddress

Fixes #992, fixes #1245, fixes #1775