### PR TITLE
fix: use ES5 style function syntax

### DIFF
--- a/src/util/minimal.js
+++ b/src/util/minimal.js
@@ -288,7 +288,7 @@ function newError(name) {
             configurable: true,
         },
         name: {
-            get() { return name; },
+            get: function get() { return name; },
             set: undefined,
             enumerable: false,
             // configurable: false would accurately preserve the behavior of
@@ -298,7 +298,7 @@ function newError(name) {
             configurable: true,
         },
         toString: {
-            value() { return this.name + ": " + this.message; },
+            value: function value() { return this.name + ": " + this.message; },
             writable: true,
             enumerable: false,
             configurable: true,


### PR DESCRIPTION
This solves the compilation errors when importing protobuf.js in duktape Javscript engine.
Issues: https://github.com/protobufjs/protobuf.js/issues/1829