### PR TITLE
feat(cli): generate static files at the granularity of proto messages

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -35,7 +35,8 @@
       }
     },
     "..": {
-      "version": "7.1.0",
+      "name": "protobufjs",
+      "version": "7.1.2",
       "dev": true,
       "hasInstallScript": true,
       "license": "BSD-3-Clause",

--- a/cli/pbjs.js
+++ b/cli/pbjs.js
@@ -99,7 +99,7 @@ exports.main = function main(args, callback) {
                 "  -p, --path       Adds a directory to the include path.",
                 "",
                 "  --filter         Set up a filter to configure only those messages you need and their dependencies to compile, this will effectively reduce the final file size",
-                "                   A json file, Example of file content: { rootName: mypackagename, messageNames:[messageName1, messageName2]} ",
+                "                   Set A json file path, Example of file content: {\"messageNames\":[\"mypackage.messageName1\", \"messageName2\"] } ",
                 "",
                 "  -o, --out        Saves to a file instead of writing to stdout.",
                 "",

--- a/cli/pbjs.js
+++ b/cli/pbjs.js
@@ -40,7 +40,7 @@ exports.main = function main(args, callback) {
             "force-long": "strict-long",
             "force-message": "strict-message"
         },
-        string: [ "target", "out", "path", "wrap", "dependency", "root", "lint", 'filter' ],
+        string: [ "target", "out", "path", "wrap", "dependency", "root", "lint", "filter" ],
         boolean: [ "create", "encode", "decode", "verify", "convert", "delimited", "typeurl", "beautify", "comments", "service", "es6", "sparse", "keep-case", "alt-comment", "force-long", "force-number", "force-enum-string", "force-message", "null-defaults" ],
         default: {
             target: "json",

--- a/cli/pbjs.js
+++ b/cli/pbjs.js
@@ -312,13 +312,13 @@ exports.main = function main(args, callback) {
     }
 
     function filterMessage() {
-        if (argv.filter && fs.existsSync(argv.filter)) {
+        if (argv.filter) {
             // This is a piece of degradable logic
             try {
                 const needMessage = JSON.parse(fs.readFileSync(argv.filter));
                 util.filterMessage(root, needMessage);
             } catch (error) {
-                process.stderr.write('The filter file parsing failed, please check whether the file format is correct.')
+                process.stderr.write(`The filter not work, please check whether the file is correct: ${error.message}\n`);
             }
         }
     }

--- a/cli/test.json
+++ b/cli/test.json
@@ -1,5 +1,0 @@
-{
-  "messageNames": [
-    "CashierResponse"
-  ]
-}

--- a/cli/test.json
+++ b/cli/test.json
@@ -1,0 +1,5 @@
+{
+  "messageNames": [
+    "CashierResponse"
+  ]
+}

--- a/cli/util.js
+++ b/cli/util.js
@@ -198,7 +198,7 @@ function doFilterMessage(root, needMessageConfig, filterMap, flatMap, currentPac
             }
             
             if (!message) {
-                throw new Error(`message not foud ${nsName}.${messageName}`);
+                throw new Error(`message not foud ${currentPackageName}.${messageName}`);
             }
 
             var set = filterMap.get(currentPackageName);

--- a/package.json
+++ b/package.json
@@ -11,6 +11,14 @@
   "engines": {
     "node": ">=12.0.0"
   },
+  "eslintConfig": {
+    "env": {
+      "es6": true
+    },
+    "parserOptions": {
+      "ecmaVersion": 6
+    }
+  },
   "keywords": [
     "protobuf",
     "protocol-buffers",

--- a/tests/cli.js
+++ b/tests/cli.js
@@ -4,6 +4,7 @@ var tape = require("tape");
 var path = require("path");
 var Module = require("module");
 var protobuf = require("..");
+var fs = require("fs");
 
 function cliTest(test, testFunc) {
     // pbjs does not seem to work with Node v4, so skip this test if we're running on it
@@ -157,6 +158,57 @@ tape.test("with null-defaults, absent optional fields have null values", functio
             test.equal(msg.a, null, "default submessage is null");
             test.equal(msg.b, null, "default string is null");
             test.equal(msg.c, null, "default integer is null");
+
+            test.end();
+        });
+    });
+});
+
+
+tape.test("pbjs generates static code with message filter", function (test) {
+    cliTest(test, function () {
+        var root = protobuf.loadSync("tests/data/cli/test-filter.proto");
+        root.resolveAll();
+
+        var staticTarget = require("../cli/targets/static");
+        var util = require("../cli/util");
+
+        const needMessageConfig = JSON.parse(fs.readFileSync("tests/data/cli/filter.json"));
+
+        util.filterMessage(root, needMessageConfig);
+
+        staticTarget(root, {
+            create: true,
+            decode: true,
+            encode: true,
+            convert: true,
+            "null-defaults": true,
+        }, function (err, jsCode) {
+            test.error(err, 'static code generation worked');
+
+            // jsCode is the generated code; we'll eval it
+            // (since this is what we normally does with the code, right?)
+            // This is a test code. Do not use this in production.
+            var $protobuf = protobuf;
+            eval(jsCode);
+
+            console.log(protobuf.roots);
+
+            var NeedMessage1 = protobuf.roots.default.filtertest.NeedMessage1;
+            var NeedMessage2 = protobuf.roots.default.filtertest.NeedMessage2;
+            var DependentMessage1 = protobuf.roots.default.filtertest.DependentMessage1;
+            var DependentMessageFromImport = protobuf.roots.default.DependentMessageFromImport;
+
+            var NotNeedMessageInRootFile = protobuf.roots.default.filtertest.NotNeedMessageInRootFile;
+            var NotNeedMessageInImportFile = protobuf.roots.default.NotNeedMessageInImportFile;
+            
+            test.ok(NeedMessage1, "NeedMessage1 is loaded");
+            test.ok(NeedMessage2, "NeedMessage2 is loaded");
+            test.ok(DependentMessage1, "DependentMessage1 is loaded");
+            test.ok(DependentMessageFromImport, "DependentMessageFromImport is loaded");
+
+            test.notOk(NotNeedMessageInImportFile, "NotNeedMessageInImportFile is not loaded");
+            test.notOk(NotNeedMessageInRootFile, "NotNeedMessageInRootFile is not loaded");
 
             test.end();
         });

--- a/tests/data/cli/filter.json
+++ b/tests/data/cli/filter.json
@@ -1,0 +1,3 @@
+{
+  "messageNames": ["filtertest.NeedMessage1", "filtertest.NeedMessage2"]
+}

--- a/tests/data/cli/test-filter-import.proto
+++ b/tests/data/cli/test-filter-import.proto
@@ -1,0 +1,8 @@
+
+message DependentMessageFromImport {
+  optional int32 test1 = 1;
+}
+
+message NotNeedMessageInImportFile {
+  optional int32 test1 = 1;
+}

--- a/tests/data/cli/test-filter.proto
+++ b/tests/data/cli/test-filter.proto
@@ -1,0 +1,21 @@
+package filtertest;
+import "./test-filter-import.proto";
+
+message NeedMessage1 {
+  optional uint32 test1 = 1;
+  optional NeedMessage2 needMessage2 = 2;
+  optional DependentMessage1 dependentMessage1 = 3;
+  optional DependentMessageFromImport dependentMessage2 = 4;
+}
+
+message NeedMessage2 {
+  optional uint32 test1 = 1;
+}
+
+message DependentMessage1 {
+  optional uint32 test1 = 1;
+}
+
+message NotNeedMessageInRootFile {
+  optional uint32 test1 = 1;
+}


### PR DESCRIPTION
I encountered a problem in the project I was working on: Due to the large size of my project and the complexity of the proto, the resulting js static code file was very large, nearly 100,000 lines before uncompression, about 5mb, and nearly 1mb even after compression , which causes my pages to load slower.

Later I found out the cause of the problem: my page only uses a few messages, but I still need to compile the entire file and all the messages, enums, etc. of all dependent files, and there is a huge waste here.

Finally, I found a solution: by adding a filter parameter to the cli, to filter those structures that we don't need at all, so that our files are greatly reduced, which will be very useful in a huge project. Eventually I cut it from 100,000 lines to 10,000.

example：
pbjs --target=static-module  --filter=/home/filter.json  --out=appsvr-source.js proto/appsvr.proto

/home/filter.json:
{ "messageName": ["mypackage.message1", "message2"]}

then, only  mypackage.message1 and message2  and their dependencies will gen in code.  

Hope this solution can help others.