### PR TITLE
Work around missing interfaces with jsdoc >3.5.5 (fixes #1414)

### DIFF
--- a/cli/pbts.js
+++ b/cli/pbts.js
@@ -93,6 +93,22 @@ exports.main = function(args, callback) {
     }
 
     function callJsdoc() {
+        // Workaround for jsdoc >3.5.5
+        for (var i = 0; i < files.length; i++) {
+            var file = files[i];
+            var fileTmp = file + '.pbts-tmp.js';
+
+            fs.writeFileSync(
+                fileTmp,
+                fs.readFileSync(file).toString().replace(
+                    /((^|\n) *\* )@exports/g,
+                    '$1@name'
+                )
+            );
+
+            files[i] = fileTmp;
+            cleanup.push(fileTmp);
+        }
 
         // There is no proper API for jsdoc, so this executes the CLI and pipes the output
         var basedir = path.join(__dirname, ".");


### PR DESCRIPTION
Credit for this solution goes to @jolting: https://github.com/protobufjs/protobuf.js/issues/1414#issuecomment-1290725151

I've also confirmed that this works with the latest jsdoc (4.0.0), so please merge #1833 as well.