### PR TITLE
fix(cli): fix relative path to Google pb files

### DIFF
--- a/cli/pbjs.js
+++ b/cli/pbjs.js
@@ -78,7 +78,7 @@ exports.main = function main(args, callback) {
     });
 
     // protobuf.js package directory contains additional, otherwise non-bundled google types
-    paths.push(path.relative(process.cwd(), path.join(__dirname, "..")) || ".");
+    paths.push(path.relative(process.cwd(), path.join(__dirname, "../protobufjs")) || ".");
 
     if (!files.length) {
         var descs = Object.keys(targets).filter(function(key) { return !targets[key].private; }).map(function(key) {


### PR DESCRIPTION
Upgrading from 6.7 to 7.0 we encountered a possible bug in resolving the paths to the included Google protobuf files. With the older version, when the CLI was bundled in the same library, on line 81 of `cli/pbjs.js`, `__dirname` was `[..]/node_modules/protobufjs/cli`, so `path.join(__dirname, "..")` evaluated to `[..]/node_modules/protobufjs`, but now `__dirname` is `[..]/node_modules/protobufjs-cli`, so `path.join(__dirname, "..")` is just `[..]/node_modules`, and later, on lines 198--200, protobuf files are searched from a non-existing folder, for example `[..]/node_modules/google/protobuf/descriptor.proto`.

This PR inserts the missing `protobufjs` directory to the search path.