### PR TITLE
fix: use bundled filename to fix common pb includes

### DIFF
--- a/cli/pbjs.js
+++ b/cli/pbjs.js
@@ -78,7 +78,7 @@ exports.main = function main(args, callback) {
     });
 
     // protobuf.js package directory contains additional, otherwise non-bundled google types
-    paths.push(path.relative(process.cwd(), path.join(__dirname, "../protobufjs")) || ".");
+    paths.push(path.relative(process.cwd(), path.join(__dirname, "..")) || ".");
 
     if (!files.length) {
         var descs = Object.keys(targets).filter(function(key) { return !targets[key].private; }).map(function(key) {

--- a/cli/pbjs.js
+++ b/cli/pbjs.js
@@ -78,7 +78,7 @@ exports.main = function main(args, callback) {
     });
 
     // protobuf.js package directory contains additional, otherwise non-bundled google types
-    paths.push(path.relative(process.cwd(), path.join(__dirname, "..")) || ".");
+    paths.push(path.relative(process.cwd(), path.join(__dirname, "../protobufjs")) || ".");
 
     if (!files.length) {
         var descs = Object.keys(targets).filter(function(key) { return !targets[key].private; }).map(function(key) {

--- a/src/root.js
+++ b/src/root.js
@@ -145,6 +145,7 @@ Root.prototype.load = function load(filename, options, callback) {
 
     // Fetches a single file
     function fetch(filename, weak) {
+        filename = getBundledFileName(filename) || filename;
 
         // Skip if already loaded / attempted
         if (self.files.indexOf(filename) > -1)


### PR DESCRIPTION
Upgrading from 6.7 to 7.0, we ran into the following issue, using the CLI: If the `.proto` files given as arguments contain some `google/protobuf/*.proto` files, as well as `import` statements importing them in other files, the CLI command terminates with error "duplicate name '..' in Namespace .google.protobuf". Basically it didn't recognize that a common file had already been fetched and parsed. Interestingly this only happened if we used the absolute paths of the `.proto` files.

We found that enforcing the use of the bundled filename in the `fetch` function fixes the issue, and this PR does just that. In an older version the bundled filename was used here, but it was dropped in [this commit](https://github.com/protobufjs/protobuf.js/commit/15ee83ffa6cfd755ea04208110ddb5003adf98b1). Note that after that commit, the bundled filename is used only when fetching imports.

This PR does not depend on my [previous PR](https://github.com/protobufjs/protobuf.js/pull/1859).