### PR TITLE
fix: Revert "fix: 🐛 error should be thrown"

### DIFF
--- a/src/root.js
+++ b/src/root.js
@@ -98,10 +98,10 @@ Root.prototype.load = function load(filename, options, callback) {
         /* istanbul ignore if */
         if (!callback)
             return;
-        if (sync)
-            throw err;
         var cb = callback;
         callback = null;
+        if (sync)
+            throw err;
         cb(err, root);
     }
 


### PR DESCRIPTION
Reverts protobufjs/protobuf.js#1817

Cc: @binsee 

This breaks the well established logic of proto loading (see #1863, I also see the problem in `google-gax` package). I _suspect_ that the places that got broken are actually incorrect, but we cannot just break things like that even if we are making them work properly. So rolling back for now, we'll need to figure out the safer way of fixing the original problem.