### PR TITLE
bugfix: unexpected output when decoding maps with long keys

### DIFF
--- a/src/decoder.js
+++ b/src/decoder.js
@@ -72,7 +72,7 @@ function decoder(mtype) {
                 ("}");
 
             if (types.long[field.keyType] !== undefined) gen
-                ("%s[typeof k===\"object\"?util.longToHash(k):k]=value", ref);
+                ("%s[k.toString()]=value", ref);
             else gen
                 ("%s[k]=value", ref);
 

--- a/tests/comp_maps-long-key.js
+++ b/tests/comp_maps-long-key.js
@@ -1,0 +1,37 @@
+var tape = require("tape");
+
+var protobuf = require("..");
+var long = require("long")
+
+tape.test("maps long key", function(test) {
+    var root = protobuf.Root.fromJSON({
+        nested: {
+            Test: {
+                fields: {
+                    foo: {
+                        keyType: "uint64",
+                        type: "uint64",
+                        id: 1
+                    }
+                }
+            }
+        }
+    });
+
+    var Test = root.lookup("Test");
+    var input = {
+        "1": new long(2, 0, true)
+    };
+    var buffer = Test.encode({foo: input}).finish();
+    var decoded = Test.decode(buffer);
+    test.deepEqual(decoded.foo, input, "should decode back to the original map");
+
+    var altInput = {
+        "1": "2"
+    };
+    buffer = Test.encode({foo: altInput}).finish();
+    decoded = Test.decode(buffer);
+    test.deepEqual(decoded.foo, input, "alt input should decode")
+
+    test.end();
+});


### PR DESCRIPTION
protobuf.js version: 7.2.2

Resolves https://github.com/protobufjs/protobuf.js/issues/1203

As illustrated in the attached test, `{"1":"2"}` is transformed into `{"\x01\x00\x00\x00\x00\x00\x00\x00":2}` without the decoder fix. Applying `util.longToHash` to the long key value here isn't necessary