### PR TITLE
fix: type names can be split into multiple tokens

### DIFF
--- a/src/parse.js
+++ b/src/parse.js
@@ -360,6 +360,16 @@ function parse(source, root, options) {
             parseGroup(parent, rule);
             return;
         }
+        // Type names can consume multiple tokens, in multiple variants:
+        //    package.subpackage   field       tokens: "package.subpackage" [TYPE NAME ENDS HERE] "field"
+        //    package . subpackage field       tokens: "package" "." "subpackage" [TYPE NAME ENDS HERE] "field"
+        //    package.  subpackage field       tokens: "package." "subpackage" [TYPE NAME ENDS HERE] "field"
+        //    package  .subpackage field       tokens: "package" ".subpackage" [TYPE NAME ENDS HERE] "field"
+        // Keep reading tokens until we get a type name with no period at the end,
+        // and the next token does not start with a period.
+        while (type.endsWith(".") || peek().startsWith(".")) {
+            type += next();
+        }
 
         /* istanbul ignore if */
         if (!typeRefRe.test(type))

--- a/tests/comp_whitespace-in-type.js
+++ b/tests/comp_whitespace-in-type.js
@@ -1,0 +1,14 @@
+var tape = require("tape");
+var protobuf = require("..");
+
+tape.test("parsing line breaks", function (test) {
+
+    test.test(test.name + " - field options (Int)", function (test) {
+        var root = protobuf.loadSync("tests/data/whitespace-in-type.proto");
+        var message = root.lookupType('some.really.long.name.which.does.not.really.make.any.sense.but.sometimes.we.still.see.stuff.like.this.WouldYouParseThisForMePlease');
+        test.equal(message.fields.field.type, 'some.really.long.name.which.does.not.really.make.any.sense.but.sometimes.we.still.see.stuff.like.this.Test');
+        test.end();
+    });
+
+    test.end();
+});

--- a/tests/data/whitespace-in-type.proto
+++ b/tests/data/whitespace-in-type.proto
@@ -1,0 +1,16 @@
+syntax = "proto3";
+
+package some.really.long.name.which.does.not.really.make.any.sense.but.sometimes.we.still.see.stuff.like.this;
+
+message WouldYouParseThisForMePlease {
+  optional some.really.long. name . which . does .not
+    .really.make.any. sense.but.
+    sometimes.we.still
+    .
+    see.stuff .like.this
+    .Test field = 1;
+}
+
+message Test {
+  string field = 1;
+}


### PR DESCRIPTION
Some proto packages are pretty long, and some proto formatters might split them into multiple lines in a weird way, like here:

https://github.com/googleapis/googleapis/blob/master/google/ads/googleads/v13/common/asset_set_types.proto#L176-L177
```
  google.ads.googleads.v13.enums.LocationStringFilterTypeEnum
      .LocationStringFilterType filter_type = 2;
```

The parser expects the whole type name to be just one token, and fails to parse this. I'm fixing the parser to accept multiple tokens as the type name: keep glueing tokens together while there are periods that separate parts of the type name.