### PR TITLE
Fix crash in comment parsing (fixes #1616)

### DIFF
--- a/src/tokenize.js
+++ b/src/tokenize.js
@@ -197,9 +197,7 @@ function tokenize(source, alternateCommentMode) {
 
         // see if remaining line matches comment pattern
         var lineText = source.substring(startOffset, endOffset);
-        // look for 1 or 2 slashes since startOffset would already point past
-        // the first slash that started the comment.
-        var isComment = /^\s*\/{1,2}/.test(lineText);
+        var isComment = /^\s*\/\//.test(lineText);
         return isComment;
     }
 
@@ -268,7 +266,7 @@ function tokenize(source, alternateCommentMode) {
                         // check for double-slash comments, consolidating consecutive lines
                         start = offset;
                         isDoc = false;
-                        if (isDoubleSlashCommentLine(offset)) {
+                        if (isDoubleSlashCommentLine(offset - 1)) {
                             isDoc = true;
                             do {
                                 offset = findEndOfLine(offset);

--- a/tests/data/comments-alternate-parse.proto
+++ b/tests/data/comments-alternate-parse.proto
@@ -79,6 +79,27 @@ enum Test3 {
     FIVE = 5; // Trailing comment for value with both types of comments after field with trailing comment.
 }
 
+// Single line comment,
+/*
+followed by a block comment, followed by a newline. (issue #1616)
+*/
+message Test4 {
+}
+
+                      // line comment with
+                      // whitespace in front
+message Test5 {
+}
+              
+// Multiple
+          // different
+    // comments
+    /*
+with strange whitespace
+*/
+message Test6 {
+}
+
 service ServiceTest {
     // My method does things
     rpc SingleLineMethod (MyRequest) returns (MyResponse);

--- a/tests/docs_comments_alternate_parse.js
+++ b/tests/docs_comments_alternate_parse.js
@@ -3,7 +3,7 @@ var tape = require("tape");
 var protobuf = require("..");
 
 tape.test("proto comments in alternate-parse mode", function(test) {
-    test.plan(24);
+    test.plan(27);
     var options = {alternateCommentMode: true};
     var root = new protobuf.Root();
     root.load("tests/data/comments-alternate-parse.proto", options, function(err, root) {
@@ -13,6 +13,9 @@ tape.test("proto comments in alternate-parse mode", function(test) {
         test.equal(root.lookup("Test1").comment, "Message with\na\nmulti-line comment.", "should parse double-slash multiline comment");
         test.equal(root.lookup("Test2").comment, "Message\nwith\na multiline plain slash-star\ncomment.", "should parse slash-star multiline comment");
         test.equal(root.lookup("Test3").comment, "Message\nwith\na\ncomment and stars.", "should parse doc-block multiline comment");
+        test.equal(root.lookup("Test4").comment, "followed by a block comment, followed by a newline. (issue #1616)", "should parse double slash comment followed by block comment");
+        test.equal(root.lookup("Test5").comment, "line comment with\nwhitespace in front", "should ignore leading whitespace when parsing line comments");
+        test.equal(root.lookup("Test6").comment, "with strange whitespace", "should parse block comment preceeded by double slash comments with leading whitespace");
 
         test.equal(root.lookup("Test1.field1").comment, "Field with a doc-block comment.", "should parse doc-block field comment");
         test.equal(root.lookup("Test1.field2").comment, "Field with a single-line comment starting with two slashes.", "should parse double-slash field comment");


### PR DESCRIPTION
This fixes a crash in parsing sequences of comments like the following:

```
//
/*
*/
```

The conditions to trigger the crash are:
1. alternateCommentMode is set to true
2. A single line comment is immediately followed by a block comment
3. The block comment spans at least two lines

The crash happens because `isDoubleSlashCommentLine` returns true for lines starting with `/*`. It only checks for one slash because in the first callsite, `offset` points to the second slash character and the character before it is guaranteed to also be a slash. But this is not true in the second callsite. The result is that it treats the line with `/*` as a single line comment.