### PR TITLE
fix: do not let setProperty change the prototype

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -176,7 +176,7 @@ util.decorateEnum = function decorateEnum(object) {
 util.setProperty = function setProperty(dst, path, value) {
     function setProp(dst, path, value) {
         var part = path.shift();
-        if (part === "__proto__") {
+        if (part === "__proto__" || part === "prototype") {
           return dst;
         }
         if (path.length > 0) {

--- a/tests/api_util.js
+++ b/tests/api_util.js
@@ -95,6 +95,15 @@ tape.test("util", function(test) {
 
         util.setProperty(o, 'prop.subprop', { subsub2: 7});
         test.same(o, {prop1: [5, 6], prop: {subprop: [{subsub: [5,6]}, {subsub2: 7}]}}, "should convert nested properties to array");
+        
+        util.setProperty({}, "__proto__.test", "value");
+        test.is({}.test, undefined);
+
+        util.setProperty({}, "prototype.test", "value");
+        test.is({}.test, undefined);
+
+        util.setProperty({}, "constructor.prototype.test", "value");
+        test.is({}.test, undefined);
 
         test.end();
     });


### PR DESCRIPTION
Follow up to #1731, fixes a bug introduced in #1256.