### PR TITLE
Fixed deprecation warning for new Buffer

### DIFF
--- a/src/reader.js
+++ b/src/reader.js
@@ -312,9 +312,14 @@ Reader.prototype.bytes = function read_bytes() {
     this.pos += length;
     if (Array.isArray(this.buf)) // plain array
         return this.buf.slice(start, end);
-    return start === end // fix for IE 10/Win8 and others' subarray returning array of size 1
-        ? new this.buf.constructor(0)
-        : this._slice.call(this.buf, start, end);
+
+    if (start === end) { // fix for IE 10/Win8 and others' subarray returning array of size 1
+        var nativeBuffer = util.Buffer;
+        return nativeBuffer
+            ? nativeBuffer.alloc(0)
+            : new this.buf.constructor(0);
+    }
+    return this._slice.call(this.buf, start, end);
 };
 
 /**


### PR DESCRIPTION
Used `Buffer.alloc` if it's available.

#1411