### PR TITLE
implement Message#equals

### DIFF
--- a/src/message.js
+++ b/src/message.js
@@ -117,6 +117,18 @@ Message.fromObject = function fromObject(object) {
 };
 
 /**
+ * Returns whether one Message's fields have values equal to those of another Message
+ * @param {T} b Message instance
+ * @returns {Boolean}
+ * @template T extends Message<T>
+ * @this Constructor<T>
+ */
+Message.prototype.equals = function equals(b) {
+    return this.$type == b.$type &&
+        this.$type.fieldsArray.every(f => this[f.name] == b[f.name]);
+};
+
+/**
  * Creates a plain object from a message of this type. Also converts values to other types if specified.
  * @param {T} message Message instance
  * @param {IConversionOptions} [options] Conversion options


### PR DESCRIPTION
Is there any appetite to add a function like this? I've seen this was requested in https://github.com/protobufjs/protobuf.js/issues/216 but it doesn't look like anything like this exists. Just want to see if there's any desire for it before I write tests.

Intended to fill the same role as e.g. [Message#equals](https://www.javadoc.io/static/com.google.protobuf/protobuf-java/2.3.0/com/google/protobuf/Message.html#equals(java.lang.Object)) in the Java classes generated by protoc.