### PR TITLE
feat: support $unknownFields

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,4 +1,5 @@
 **/node_modules/*
+bench/data/static_pbjs.js
 bin/*
 cli/wrappers/*
 coverage/*

--- a/bench/data/static_pbjs.js
+++ b/bench/data/static_pbjs.js
@@ -24,6 +24,15 @@ $root.Test = (function() {
     Test.encode = function encode(message, writer) {
         if (!writer)
             writer = $Writer.create();
+        var fullyUnknown = [];
+        if (message.$unknownFields && $root.Test.decode)
+            for (var i = 0; i < message.$unknownFields.length; ++i)
+                try {
+                    var known = $root.Test.decode(message.$unknownFields[i]);
+                    fullyUnknown = fullyUnknown.concat(known.$unknownFields || []);
+                    message = Object.assign(known, message);
+                } catch (_) {
+                }
         if (message.string != null && Object.hasOwnProperty.call(message, "string"))
             writer.uint32(10).string(message.string);
         if (message.uint32 != null && Object.hasOwnProperty.call(message, "uint32"))
@@ -32,6 +41,8 @@ $root.Test = (function() {
             $root.Test.Inner.encode(message.inner, writer.uint32(26).fork()).ldelim();
         if (message.float != null && Object.hasOwnProperty.call(message, "float"))
             writer.uint32(37).float(message.float);
+        for (var i = 0; i < fullyUnknown.length; ++i)
+            writer._unknownField(fullyUnknown[i]);
         return writer;
     };
 
@@ -40,22 +51,30 @@ $root.Test = (function() {
             reader = $Reader.create(reader);
         var end = length === undefined ? reader.len : reader.pos + length, message = new $root.Test();
         while (reader.pos < end) {
+            var unknownStartPos = reader.pos;
             var tag = reader.uint32();
             switch (tag >>> 3) {
-            case 1:
-                message.string = reader.string();
-                break;
-            case 2:
-                message.uint32 = reader.uint32();
-                break;
-            case 3:
-                message.inner = $root.Test.Inner.decode(reader, reader.uint32());
-                break;
-            case 4:
-                message.float = reader.float();
-                break;
+            case 1: {
+                    message.string = reader.string();
+                    break;
+                }
+            case 2: {
+                    message.uint32 = reader.uint32();
+                    break;
+                }
+            case 3: {
+                    message.inner = $root.Test.Inner.decode(reader, reader.uint32());
+                    break;
+                }
+            case 4: {
+                    message.float = reader.float();
+                    break;
+                }
             default:
                 reader.skipType(tag & 7);
+                if (!message.$unknownFields)
+                    message.$unknownFields = [];
+                message.$unknownFields.push(reader.buf.slice(unknownStartPos, reader.pos));
                 break;
             }
         }
@@ -78,12 +97,23 @@ $root.Test = (function() {
         Inner.encode = function encode(message, writer) {
             if (!writer)
                 writer = $Writer.create();
+            var fullyUnknown = [];
+            if (message.$unknownFields && $root.Test.Inner.decode)
+                for (var i = 0; i < message.$unknownFields.length; ++i)
+                    try {
+                        var known = $root.Test.Inner.decode(message.$unknownFields[i]);
+                        fullyUnknown = fullyUnknown.concat(known.$unknownFields || []);
+                        message = Object.assign(known, message);
+                    } catch (_) {
+                    }
             if (message.int32 != null && Object.hasOwnProperty.call(message, "int32"))
                 writer.uint32(8).int32(message.int32);
             if (message.innerInner != null && Object.hasOwnProperty.call(message, "innerInner"))
                 $root.Test.Inner.InnerInner.encode(message.innerInner, writer.uint32(18).fork()).ldelim();
             if (message.outer != null && Object.hasOwnProperty.call(message, "outer"))
                 $root.Outer.encode(message.outer, writer.uint32(26).fork()).ldelim();
+            for (var i = 0; i < fullyUnknown.length; ++i)
+                writer._unknownField(fullyUnknown[i]);
             return writer;
         };
 
@@ -92,19 +122,26 @@ $root.Test = (function() {
                 reader = $Reader.create(reader);
             var end = length === undefined ? reader.len : reader.pos + length, message = new $root.Test.Inner();
             while (reader.pos < end) {
+                var unknownStartPos = reader.pos;
                 var tag = reader.uint32();
                 switch (tag >>> 3) {
-                case 1:
-                    message.int32 = reader.int32();
-                    break;
-                case 2:
-                    message.innerInner = $root.Test.Inner.InnerInner.decode(reader, reader.uint32());
-                    break;
-                case 3:
-                    message.outer = $root.Outer.decode(reader, reader.uint32());
-                    break;
+                case 1: {
+                        message.int32 = reader.int32();
+                        break;
+                    }
+                case 2: {
+                        message.innerInner = $root.Test.Inner.InnerInner.decode(reader, reader.uint32());
+                        break;
+                    }
+                case 3: {
+                        message.outer = $root.Outer.decode(reader, reader.uint32());
+                        break;
+                    }
                 default:
                     reader.skipType(tag & 7);
+                    if (!message.$unknownFields)
+                        message.$unknownFields = [];
+                    message.$unknownFields.push(reader.buf.slice(unknownStartPos, reader.pos));
                     break;
                 }
             }
@@ -127,12 +164,23 @@ $root.Test = (function() {
             InnerInner.encode = function encode(message, writer) {
                 if (!writer)
                     writer = $Writer.create();
+                var fullyUnknown = [];
+                if (message.$unknownFields && $root.Test.Inner.InnerInner.decode)
+                    for (var i = 0; i < message.$unknownFields.length; ++i)
+                        try {
+                            var known = $root.Test.Inner.InnerInner.decode(message.$unknownFields[i]);
+                            fullyUnknown = fullyUnknown.concat(known.$unknownFields || []);
+                            message = Object.assign(known, message);
+                        } catch (_) {
+                        }
                 if (message.long != null && Object.hasOwnProperty.call(message, "long"))
                     writer.uint32(8).int64(message.long);
                 if (message["enum"] != null && Object.hasOwnProperty.call(message, "enum"))
                     writer.uint32(16).int32(message["enum"]);
                 if (message.sint32 != null && Object.hasOwnProperty.call(message, "sint32"))
                     writer.uint32(24).sint32(message.sint32);
+                for (var i = 0; i < fullyUnknown.length; ++i)
+                    writer._unknownField(fullyUnknown[i]);
                 return writer;
             };
 
@@ -141,19 +189,26 @@ $root.Test = (function() {
                     reader = $Reader.create(reader);
                 var end = length === undefined ? reader.len : reader.pos + length, message = new $root.Test.Inner.InnerInner();
                 while (reader.pos < end) {
+                    var unknownStartPos = reader.pos;
                     var tag = reader.uint32();
                     switch (tag >>> 3) {
-                    case 1:
-                        message.long = reader.int64();
-                        break;
-                    case 2:
-                        message["enum"] = reader.int32();
-                        break;
-                    case 3:
-                        message.sint32 = reader.sint32();
-                        break;
+                    case 1: {
+                            message.long = reader.int64();
+                            break;
+                        }
+                    case 2: {
+                            message["enum"] = reader.int32();
+                            break;
+                        }
+                    case 3: {
+                            message.sint32 = reader.sint32();
+                            break;
+                        }
                     default:
                         reader.skipType(tag & 7);
+                        if (!message.$unknownFields)
+                            message.$unknownFields = [];
+                        message.$unknownFields.push(reader.buf.slice(unknownStartPos, reader.pos));
                         break;
                     }
                 }
@@ -195,6 +250,15 @@ $root.Outer = (function() {
     Outer.encode = function encode(message, writer) {
         if (!writer)
             writer = $Writer.create();
+        var fullyUnknown = [];
+        if (message.$unknownFields && $root.Outer.decode)
+            for (var i = 0; i < message.$unknownFields.length; ++i)
+                try {
+                    var known = $root.Outer.decode(message.$unknownFields[i]);
+                    fullyUnknown = fullyUnknown.concat(known.$unknownFields || []);
+                    message = Object.assign(known, message);
+                } catch (_) {
+                }
         if (message.bool != null && message.bool.length) {
             writer.uint32(10).fork();
             for (var i = 0; i < message.bool.length; ++i)
@@ -203,6 +267,8 @@ $root.Outer = (function() {
         }
         if (message.double != null && Object.hasOwnProperty.call(message, "double"))
             writer.uint32(17).double(message.double);
+        for (var i = 0; i < fullyUnknown.length; ++i)
+            writer._unknownField(fullyUnknown[i]);
         return writer;
     };
 
@@ -211,23 +277,29 @@ $root.Outer = (function() {
             reader = $Reader.create(reader);
         var end = length === undefined ? reader.len : reader.pos + length, message = new $root.Outer();
         while (reader.pos < end) {
+            var unknownStartPos = reader.pos;
             var tag = reader.uint32();
             switch (tag >>> 3) {
-            case 1:
-                if (!(message.bool && message.bool.length))
-                    message.bool = [];
-                if ((tag & 7) === 2) {
-                    var end2 = reader.uint32() + reader.pos;
-                    while (reader.pos < end2)
+            case 1: {
+                    if (!(message.bool && message.bool.length))
+                        message.bool = [];
+                    if ((tag & 7) === 2) {
+                        var end2 = reader.uint32() + reader.pos;
+                        while (reader.pos < end2)
+                            message.bool.push(reader.bool());
+                    } else
                         message.bool.push(reader.bool());
-                } else
-                    message.bool.push(reader.bool());
-                break;
-            case 2:
-                message.double = reader.double();
-                break;
+                    break;
+                }
+            case 2: {
+                    message.double = reader.double();
+                    break;
+                }
             default:
                 reader.skipType(tag & 7);
+                if (!message.$unknownFields)
+                    message.$unknownFields = [];
+                message.$unknownFields.push(reader.buf.slice(unknownStartPos, reader.pos));
                 break;
             }
         }

--- a/cli/lib/tsd-jsdoc/publish.js
+++ b/cli/lib/tsd-jsdoc/publish.js
@@ -558,6 +558,13 @@ function handleClass(element, parent) {
         handleElement(child, element);
     });
 
+    writeln();
+    if (is_interface) {
+        writeln("$unknownFields?: ReadonlyArray<Uint8Array>;");
+    } else {
+        writeln("public $unknownFields?: ReadonlyArray<Uint8Array>;");
+    }
+
     --indent;
     writeln("}");
 

--- a/ext/descriptor/index.d.ts
+++ b/ext/descriptor/index.d.ts
@@ -1,4 +1,5 @@
 import * as $protobuf from "../..";
+import Long = require("long");
 export const FileDescriptorSet: $protobuf.Type;
 
 export const FileDescriptorProto: $protobuf.Type;
@@ -58,6 +59,8 @@ export const GeneratedCodeInfo: $protobuf.Type & {
 
 export interface IFileDescriptorSet {
     file: IFileDescriptorProto[];
+
+    $unknownFields?: ReadonlyArray<Uint8Array>;
 }
 
 export interface IFileDescriptorProto {
@@ -73,6 +76,8 @@ export interface IFileDescriptorProto {
     options?: IFileOptions;
     sourceCodeInfo?: any;
     syntax?: string;
+
+    $unknownFields?: ReadonlyArray<Uint8Array>;
 }
 
 export interface IFileOptions {
@@ -90,6 +95,8 @@ export interface IFileOptions {
     ccEnableArenas?: boolean;
     objcClassPrefix?: string;
     csharpNamespace?: string;
+
+    $unknownFields?: ReadonlyArray<Uint8Array>;
 }
 
 type IFileOptionsOptimizeMode = number;
@@ -105,20 +112,28 @@ export interface IDescriptorProto {
     options?: IMessageOptions;
     reservedRange?: IDescriptorProtoReservedRange[];
     reservedName?: string[];
+
+    $unknownFields?: ReadonlyArray<Uint8Array>;
 }
 
 export interface IMessageOptions {
     mapEntry?: boolean;
+
+    $unknownFields?: ReadonlyArray<Uint8Array>;
 }
 
 export interface IDescriptorProtoExtensionRange {
     start?: number;
     end?: number;
+
+    $unknownFields?: ReadonlyArray<Uint8Array>;
 }
 
 export interface IDescriptorProtoReservedRange {
     start?: number;
     end?: number;
+
+    $unknownFields?: ReadonlyArray<Uint8Array>;
 }
 
 export interface IFieldDescriptorProto {
@@ -132,6 +147,8 @@ export interface IFieldDescriptorProto {
     oneofIndex?: number;
     jsonName?: any;
     options?: IFieldOptions;
+
+    $unknownFields?: ReadonlyArray<Uint8Array>;
 }
 
 type IFieldDescriptorProtoLabel = number;
@@ -141,6 +158,8 @@ type IFieldDescriptorProtoType = number;
 export interface IFieldOptions {
     packed?: boolean;
     jstype?: IFieldOptionsJSType;
+
+    $unknownFields?: ReadonlyArray<Uint8Array>;
 }
 
 type IFieldOptionsJSType = number;
@@ -149,32 +168,44 @@ export interface IEnumDescriptorProto {
     name?: string;
     value?: IEnumValueDescriptorProto[];
     options?: IEnumOptions;
+
+    $unknownFields?: ReadonlyArray<Uint8Array>;
 }
 
 export interface IEnumValueDescriptorProto {
     name?: string;
     number?: number;
     options?: any;
+
+    $unknownFields?: ReadonlyArray<Uint8Array>;
 }
 
 export interface IEnumOptions {
     allowAlias?: boolean;
     deprecated?: boolean;
+
+    $unknownFields?: ReadonlyArray<Uint8Array>;
 }
 
 export interface IOneofDescriptorProto {
     name?: string;
     options?: any;
+
+    $unknownFields?: ReadonlyArray<Uint8Array>;
 }
 
 export interface IServiceDescriptorProto {
     name?: string;
     method?: IMethodDescriptorProto[];
     options?: IServiceOptions;
+
+    $unknownFields?: ReadonlyArray<Uint8Array>;
 }
 
 export interface IServiceOptions {
     deprecated?: boolean;
+
+    $unknownFields?: ReadonlyArray<Uint8Array>;
 }
 
 export interface IMethodDescriptorProto {
@@ -184,8 +215,12 @@ export interface IMethodDescriptorProto {
     options?: IMethodOptions;
     clientStreaming?: boolean;
     serverStreaming?: boolean;
+
+    $unknownFields?: ReadonlyArray<Uint8Array>;
 }
 
 export interface IMethodOptions {
     deprecated?: boolean;
+
+    $unknownFields?: ReadonlyArray<Uint8Array>;
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -16,27 +16,37 @@ export namespace common {
     interface IAny {
         typeUrl?: string;
         bytes?: Uint8Array;
+
+        $unknownFields?: ReadonlyArray<Uint8Array>;
     }
 
     /** Properties of a google.protobuf.Duration message. */
     interface IDuration {
         seconds?: (number|Long);
         nanos?: number;
+
+        $unknownFields?: ReadonlyArray<Uint8Array>;
     }
 
     /** Properties of a google.protobuf.Timestamp message. */
     interface ITimestamp {
         seconds?: (number|Long);
         nanos?: number;
+
+        $unknownFields?: ReadonlyArray<Uint8Array>;
     }
 
     /** Properties of a google.protobuf.Empty message. */
     interface IEmpty {
+
+        $unknownFields?: ReadonlyArray<Uint8Array>;
     }
 
     /** Properties of a google.protobuf.Struct message. */
     interface IStruct {
         fields?: { [k: string]: IValue };
+
+        $unknownFields?: ReadonlyArray<Uint8Array>;
     }
 
     /** Properties of a google.protobuf.Value message. */
@@ -48,56 +58,78 @@ export namespace common {
         boolValue?: boolean;
         structValue?: IStruct;
         listValue?: IListValue;
+
+        $unknownFields?: ReadonlyArray<Uint8Array>;
     }
 
     /** Properties of a google.protobuf.ListValue message. */
     interface IListValue {
         values?: IValue[];
+
+        $unknownFields?: ReadonlyArray<Uint8Array>;
     }
 
     /** Properties of a google.protobuf.DoubleValue message. */
     interface IDoubleValue {
         value?: number;
+
+        $unknownFields?: ReadonlyArray<Uint8Array>;
     }
 
     /** Properties of a google.protobuf.FloatValue message. */
     interface IFloatValue {
         value?: number;
+
+        $unknownFields?: ReadonlyArray<Uint8Array>;
     }
 
     /** Properties of a google.protobuf.Int64Value message. */
     interface IInt64Value {
         value?: (number|Long);
+
+        $unknownFields?: ReadonlyArray<Uint8Array>;
     }
 
     /** Properties of a google.protobuf.UInt64Value message. */
     interface IUInt64Value {
         value?: (number|Long);
+
+        $unknownFields?: ReadonlyArray<Uint8Array>;
     }
 
     /** Properties of a google.protobuf.Int32Value message. */
     interface IInt32Value {
         value?: number;
+
+        $unknownFields?: ReadonlyArray<Uint8Array>;
     }
 
     /** Properties of a google.protobuf.UInt32Value message. */
     interface IUInt32Value {
         value?: number;
+
+        $unknownFields?: ReadonlyArray<Uint8Array>;
     }
 
     /** Properties of a google.protobuf.BoolValue message. */
     interface IBoolValue {
         value?: boolean;
+
+        $unknownFields?: ReadonlyArray<Uint8Array>;
     }
 
     /** Properties of a google.protobuf.StringValue message. */
     interface IStringValue {
         value?: string;
+
+        $unknownFields?: ReadonlyArray<Uint8Array>;
     }
 
     /** Properties of a google.protobuf.BytesValue message. */
     interface IBytesValue {
         value?: Uint8Array;
+
+        $unknownFields?: ReadonlyArray<Uint8Array>;
     }
 
     /**
@@ -232,6 +264,8 @@ export class Enum extends ReflectionObject {
      * @returns `true` if reserved, otherwise `false`
      */
     public isReservedName(name: string): boolean;
+
+    public $unknownFields?: ReadonlyArray<Uint8Array>;
 }
 
 /** Enum descriptor. */
@@ -242,6 +276,8 @@ export interface IEnum {
 
     /** Enum options */
     options?: { [k: string]: any };
+
+    $unknownFields?: ReadonlyArray<Uint8Array>;
 }
 
 /** Reflected message field. */
@@ -288,6 +324,8 @@ export class Field extends FieldBase {
      * @returns Decorator function
      */
     public static d<T extends Message<T>>(fieldId: number, fieldType: (Constructor<T>|string), fieldRule?: ("optional"|"required"|"repeated")): FieldDecorator;
+
+    public $unknownFields?: ReadonlyArray<Uint8Array>;
 }
 
 /** Base class of all reflected message fields. This is not an actual class but here for the sake of having consistent type definitions. */
@@ -369,6 +407,8 @@ export class FieldBase extends ReflectionObject {
      * @throws {Error} If any reference cannot be resolved
      */
     public resolve(): Field;
+
+    public $unknownFields?: ReadonlyArray<Uint8Array>;
 }
 
 /** Field descriptor. */
@@ -385,6 +425,8 @@ export interface IField {
 
     /** Field options */
     options?: { [k: string]: any };
+
+    $unknownFields?: ReadonlyArray<Uint8Array>;
 }
 
 /** Extension field descriptor. */
@@ -392,6 +434,8 @@ export interface IExtensionField extends IField {
 
     /** Extended type */
     extend: string;
+
+    $unknownFields?: ReadonlyArray<Uint8Array>;
 }
 
 /**
@@ -494,6 +538,8 @@ export class MapField extends FieldBase {
      * @returns Decorator function
      */
     public static d<T extends { [key: string]: number | Long | string | boolean | Uint8Array | Buffer | number[] | Message<{}> }>(fieldId: number, fieldKeyType: ("int32"|"uint32"|"sint32"|"fixed32"|"sfixed32"|"int64"|"uint64"|"sint64"|"fixed64"|"sfixed64"|"bool"|"string"), fieldValueType: ("double"|"float"|"int32"|"uint32"|"sint32"|"fixed32"|"sfixed32"|"int64"|"uint64"|"sint64"|"fixed64"|"sfixed64"|"bool"|"string"|"bytes"|object|Constructor<{}>)): FieldDecorator;
+
+    public $unknownFields?: ReadonlyArray<Uint8Array>;
 }
 
 /** Map field descriptor. */
@@ -501,6 +547,8 @@ export interface IMapField extends IField {
 
     /** Key type */
     keyType: string;
+
+    $unknownFields?: ReadonlyArray<Uint8Array>;
 }
 
 /** Extension map field descriptor. */
@@ -508,6 +556,8 @@ export interface IExtensionMapField extends IMapField {
 
     /** Extended type */
     extend: string;
+
+    $unknownFields?: ReadonlyArray<Uint8Array>;
 }
 
 /** Abstract runtime message. */
@@ -589,6 +639,8 @@ export class Message<T extends object = object> {
      * @returns JSON object
      */
     public toJSON(): { [k: string]: any };
+
+    public $unknownFields?: ReadonlyArray<Uint8Array>;
 }
 
 /** Reflected service method. */
@@ -650,6 +702,8 @@ export class Method extends ReflectionObject {
      * @returns Method descriptor
      */
     public toJSON(toJSONOptions?: IToJSONOptions): IMethod;
+
+    public $unknownFields?: ReadonlyArray<Uint8Array>;
 }
 
 /** Method descriptor. */
@@ -678,6 +732,8 @@ export interface IMethod {
 
     /** Method options properly parsed into an object */
     parsedOptions?: { [k: string]: any };
+
+    $unknownFields?: ReadonlyArray<Uint8Array>;
 }
 
 /** Reflected namespace. */
@@ -722,6 +778,8 @@ export class Namespace extends NamespaceBase {
      * @returns `true` if reserved, otherwise `false`
      */
     public static isReservedName(reserved: ((number[]|string)[]|undefined), name: string): boolean;
+
+    public $unknownFields?: ReadonlyArray<Uint8Array>;
 }
 
 /** Base class of all reflection objects containing nested objects. This is not an actual class but here for the sake of having consistent type definitions. */
@@ -847,6 +905,8 @@ export abstract class NamespaceBase extends ReflectionObject {
      * @throws {Error} If `path` does not point to a service
      */
     public lookupService(path: (string|string[])): Service;
+
+    public $unknownFields?: ReadonlyArray<Uint8Array>;
 }
 
 /** Namespace descriptor. */
@@ -857,6 +917,8 @@ export interface INamespace {
 
     /** Nested object descriptors */
     nested?: { [k: string]: AnyNestedObject };
+
+    $unknownFields?: ReadonlyArray<Uint8Array>;
 }
 
 /** Any extension field descriptor. */
@@ -957,6 +1019,8 @@ export abstract class ReflectionObject {
      * @returns Class name[, space, full name]
      */
     public toString(): string;
+
+    public $unknownFields?: ReadonlyArray<Uint8Array>;
 }
 
 /** Reflected oneof. */
@@ -1016,6 +1080,8 @@ export class OneOf extends ReflectionObject {
      * @returns Decorator function
      */
     public static d<T extends string>(...fieldNames: string[]): OneOfDecorator;
+
+    public $unknownFields?: ReadonlyArray<Uint8Array>;
 }
 
 /** Oneof descriptor. */
@@ -1026,6 +1092,8 @@ export interface IOneOf {
 
     /** Oneof options */
     options?: { [k: string]: any };
+
+    $unknownFields?: ReadonlyArray<Uint8Array>;
 }
 
 /**
@@ -1060,6 +1128,8 @@ export interface IParserResult {
 
     /** Populated root instance */
     root: Root;
+
+    $unknownFields?: ReadonlyArray<Uint8Array>;
 }
 
 /** Options modifying the behavior of {@link parse}. */
@@ -1073,6 +1143,8 @@ export interface IParseOptions {
 
     /** Use trailing comment when both leading comment and trailing comment exist. */
     preferTrailingComment?: boolean;
+
+    $unknownFields?: ReadonlyArray<Uint8Array>;
 }
 
 /** Options modifying the behavior of JSON serialization. */
@@ -1080,6 +1152,8 @@ export interface IToJSONOptions {
 
     /** Serializes comments. */
     keepComments?: boolean;
+
+    $unknownFields?: ReadonlyArray<Uint8Array>;
 }
 
 /**
@@ -1220,6 +1294,8 @@ export class Reader {
      * @returns `this`
      */
     public skipType(wireType: number): Reader;
+
+    public $unknownFields?: ReadonlyArray<Uint8Array>;
 }
 
 /** Wire format reader using node buffers. */
@@ -1236,6 +1312,8 @@ export class BufferReader extends Reader {
      * @returns Value read
      */
     public bytes(): Buffer;
+
+    public $unknownFields?: ReadonlyArray<Uint8Array>;
 }
 
 /** Root namespace wrapping all types, enums, services, sub-namespaces etc. that belong together. */
@@ -1309,6 +1387,8 @@ export class Root extends NamespaceBase {
      * @throws {Error} If synchronous fetching is not supported (i.e. in browsers) or if a file's syntax is invalid
      */
     public loadSync(filename: (string|string[]), options?: IParseOptions): Root;
+
+    public $unknownFields?: ReadonlyArray<Uint8Array>;
 }
 
 /**
@@ -1374,6 +1454,8 @@ export namespace rpc {
          * @returns `this`
          */
         public end(endedByRPC?: boolean): rpc.Service;
+
+        public $unknownFields?: ReadonlyArray<Uint8Array>;
     }
 }
 
@@ -1433,6 +1515,8 @@ export class Service extends NamespaceBase {
      * @returns RPC service. Useful where requests and/or responses are streamed.
      */
     public create(rpcImpl: RPCImpl, requestDelimited?: boolean, responseDelimited?: boolean): rpc.Service;
+
+    public $unknownFields?: ReadonlyArray<Uint8Array>;
 }
 
 /** Service descriptor. */
@@ -1440,6 +1524,8 @@ export interface IService extends INamespace {
 
     /** Method descriptors */
     methods: { [k: string]: IMethod };
+
+    $unknownFields?: ReadonlyArray<Uint8Array>;
 }
 
 /**
@@ -1496,6 +1582,8 @@ export interface ITokenizerHandle {
 
     /** Current line number */
     line: number;
+
+    $unknownFields?: ReadonlyArray<Uint8Array>;
 }
 
 /**
@@ -1683,6 +1771,8 @@ export class Type extends NamespaceBase {
      * @returns Decorator function
      */
     public static d<T extends Message<T>>(typeName?: string): TypeDecorator<T>;
+
+    public $unknownFields?: ReadonlyArray<Uint8Array>;
 }
 
 /** Message type descriptor. */
@@ -1702,6 +1792,8 @@ export interface IType extends INamespace {
 
     /** Whether a legacy group or not */
     group?: boolean;
+
+    $unknownFields?: ReadonlyArray<Uint8Array>;
 }
 
 /** Conversion options as used by {@link Type#toObject} and {@link Message.toObject}. */
@@ -1742,6 +1834,8 @@ export interface IConversionOptions {
 
     /** Performs additional JSON compatibility conversions, i.e. NaN and Infinity to strings */
     json?: boolean;
+
+    $unknownFields?: ReadonlyArray<Uint8Array>;
 }
 
 /**
@@ -1838,6 +1932,8 @@ export namespace types {
 /** Constructor type. */
 export interface Constructor<T> extends Function {
     new(...params: any[]): T; prototype: T;
+
+    $unknownFields?: ReadonlyArray<Uint8Array>;
 }
 
 /** Properties type. */
@@ -1848,6 +1944,8 @@ type Properties<T> = { [P in keyof T]?: T[P] };
  * This is a minimal stand-alone definition of a Buffer instance. The actual type is that exported by node's typings.
  */
 export interface Buffer extends Uint8Array {
+
+    $unknownFields?: ReadonlyArray<Uint8Array>;
 }
 
 /**
@@ -1864,6 +1962,8 @@ export interface Long {
 
     /** Whether unsigned or not */
     unsigned: boolean;
+
+    $unknownFields?: ReadonlyArray<Uint8Array>;
 }
 
 /**
@@ -1961,6 +2061,8 @@ export namespace util {
          * @returns Length
          */
         public length(): number;
+
+        public $unknownFields?: ReadonlyArray<Uint8Array>;
     }
 
     /** Whether running within node or not. */
@@ -2088,6 +2190,8 @@ export namespace util {
 
         /** So far decoded message instance. */
         public instance: Message<T>;
+
+        public $unknownFields?: ReadonlyArray<Uint8Array>;
     }
 
     /**
@@ -2298,6 +2402,8 @@ export namespace util {
          * @returns `this`
          */
         public emit(evt: string, ...args: any[]): this;
+
+        public $unknownFields?: ReadonlyArray<Uint8Array>;
     }
 
     /** Reads / writes floats / doubles from / to buffers. */
@@ -2497,6 +2603,8 @@ export interface IWrapper {
 
     /** To object converter */
     toObject?: WrapperToObjectConverter;
+
+    $unknownFields?: ReadonlyArray<Uint8Array>;
 }
 
 /** Wire format writer using `Uint8Array` if available, otherwise `Array`. */
@@ -2664,6 +2772,8 @@ export class Writer {
      * @returns Finished buffer
      */
     public finish(): Uint8Array;
+
+    public $unknownFields?: ReadonlyArray<Uint8Array>;
 }
 
 /** Wire format writer using node buffers. */
@@ -2684,6 +2794,8 @@ export class BufferWriter extends Writer {
      * @returns Finished buffer
      */
     public finish(): Buffer;
+
+    public $unknownFields?: ReadonlyArray<Uint8Array>;
 }
 
 /**
@@ -2723,6 +2835,8 @@ export interface IFetchOptions {
 
     /** If `true`, forces the use of XMLHttpRequest */
     xhr?: boolean;
+
+    $unknownFields?: ReadonlyArray<Uint8Array>;
 }
 
 /**

--- a/src/decoder.js
+++ b/src/decoder.js
@@ -21,12 +21,15 @@ function decoder(mtype) {
         ("r=Reader.create(r)")
     ("var c=l===undefined?r.len:r.pos+l,m=new this.ctor" + (mtype.fieldsArray.filter(function(field) { return field.map; }).length ? ",k,value" : ""))
     ("while(r.pos<c){")
+        ("var unknownStartPos = r.pos")
         ("var t=r.uint32()");
     if (mtype.group) gen
         ("if((t&7)===4)")
             ("break");
     gen
         ("switch(t>>>3){");
+
+    var unknownRef = "m" + util.safeProp("$unknownFields");
 
     var i = 0;
     for (; i < /* initializes */ mtype.fieldsArray.length; ++i) {
@@ -110,6 +113,11 @@ function decoder(mtype) {
     } gen
             ("default:")
                 ("r.skipType(t&7)")
+                ("if (!(%s)) {", unknownRef)
+                    ("%s = []", unknownRef)
+                ("}")
+
+                ("%s.push(r.buf.slice(unknownStartPos, r.pos))", unknownRef)
                 ("break")
 
         ("}")

--- a/src/writer.js
+++ b/src/writer.js
@@ -383,6 +383,11 @@ Writer.prototype.bytes = function write_bytes(value) {
     return this.uint32(len)._push(writeBytes, len, value);
 };
 
+
+Writer.prototype._unknownField = function __unknownField(field) {
+    return this._push(writeBytes, field.length, field);
+};
+
 /**
  * Writes a string.
  * @param {string} value Value to write

--- a/tests/data/comments.d.ts
+++ b/tests/data/comments.d.ts
@@ -1,8 +1,11 @@
 import * as $protobuf from "../..";
+import Long = require("long");
 export interface ITest1 {
     field1?: (string|null);
     field2?: (number|null);
     field3?: (boolean|null);
+
+    $unknownFields?: ReadonlyArray<Uint8Array>;
 }
 
 export class Test1 implements ITest1 {
@@ -20,9 +23,13 @@ export class Test1 implements ITest1 {
     public static toObject(message: Test1, options?: $protobuf.IConversionOptions): { [k: string]: any };
     public toJSON(): { [k: string]: any };
     public static getTypeUrl(typeUrlPrefix?: string): string;
+
+    public $unknownFields?: ReadonlyArray<Uint8Array>;
 }
 
 export interface ITest2 {
+
+    $unknownFields?: ReadonlyArray<Uint8Array>;
 }
 
 export class Test2 implements ITest2 {
@@ -37,6 +44,8 @@ export class Test2 implements ITest2 {
     public static toObject(message: Test2, options?: $protobuf.IConversionOptions): { [k: string]: any };
     public toJSON(): { [k: string]: any };
     public static getTypeUrl(typeUrlPrefix?: string): string;
+
+    public $unknownFields?: ReadonlyArray<Uint8Array>;
 }
 
 export enum Test3 {

--- a/tests/data/comments.js
+++ b/tests/data/comments.js
@@ -86,12 +86,23 @@ $root.Test1 = (function() {
     Test1.encode = function encode(message, writer) {
         if (!writer)
             writer = $Writer.create();
+        var fullyUnknown = [];
+        if (message.$unknownFields && $root.Test1.decode)
+            for (var i = 0; i < message.$unknownFields.length; ++i)
+                try {
+                    var known = $root.Test1.decode(message.$unknownFields[i]);
+                    fullyUnknown = fullyUnknown.concat(known.$unknownFields || []);
+                    message = Object.assign(known, message);
+                } catch (_) {
+                }
         if (message.field1 != null && Object.hasOwnProperty.call(message, "field1"))
             writer.uint32(/* id 1, wireType 2 =*/10).string(message.field1);
         if (message.field2 != null && Object.hasOwnProperty.call(message, "field2"))
             writer.uint32(/* id 2, wireType 0 =*/16).uint32(message.field2);
         if (message.field3 != null && Object.hasOwnProperty.call(message, "field3"))
             writer.uint32(/* id 3, wireType 0 =*/24).bool(message.field3);
+        for (var i = 0; i < fullyUnknown.length; ++i)
+            writer._unknownField(fullyUnknown[i]);
         return writer;
     };
 
@@ -124,19 +135,26 @@ $root.Test1 = (function() {
             reader = $Reader.create(reader);
         var end = length === undefined ? reader.len : reader.pos + length, message = new $root.Test1();
         while (reader.pos < end) {
+            var unknownStartPos = reader.pos;
             var tag = reader.uint32();
             switch (tag >>> 3) {
-            case 1:
-                message.field1 = reader.string();
-                break;
-            case 2:
-                message.field2 = reader.uint32();
-                break;
-            case 3:
-                message.field3 = reader.bool();
-                break;
+            case 1: {
+                    message.field1 = reader.string();
+                    break;
+                }
+            case 2: {
+                    message.field2 = reader.uint32();
+                    break;
+                }
+            case 3: {
+                    message.field3 = reader.bool();
+                    break;
+                }
             default:
                 reader.skipType(tag & 7);
+                if (!message.$unknownFields)
+                    message.$unknownFields = [];
+                message.$unknownFields.push(reader.buf.slice(unknownStartPos, reader.pos));
                 break;
             }
         }
@@ -306,6 +324,17 @@ $root.Test2 = (function() {
     Test2.encode = function encode(message, writer) {
         if (!writer)
             writer = $Writer.create();
+        var fullyUnknown = [];
+        if (message.$unknownFields && $root.Test2.decode)
+            for (var i = 0; i < message.$unknownFields.length; ++i)
+                try {
+                    var known = $root.Test2.decode(message.$unknownFields[i]);
+                    fullyUnknown = fullyUnknown.concat(known.$unknownFields || []);
+                    message = Object.assign(known, message);
+                } catch (_) {
+                }
+        for (var i = 0; i < fullyUnknown.length; ++i)
+            writer._unknownField(fullyUnknown[i]);
         return writer;
     };
 
@@ -338,10 +367,14 @@ $root.Test2 = (function() {
             reader = $Reader.create(reader);
         var end = length === undefined ? reader.len : reader.pos + length, message = new $root.Test2();
         while (reader.pos < end) {
+            var unknownStartPos = reader.pos;
             var tag = reader.uint32();
             switch (tag >>> 3) {
             default:
                 reader.skipType(tag & 7);
+                if (!message.$unknownFields)
+                    message.$unknownFields = [];
+                message.$unknownFields.push(reader.buf.slice(unknownStartPos, reader.pos));
                 break;
             }
         }

--- a/tests/data/convert.d.ts
+++ b/tests/data/convert.d.ts
@@ -1,6 +1,5 @@
 import * as $protobuf from "../..";
-import Long from "long";
-
+import Long = require("long");
 export interface IMessage {
     stringVal?: (string|null);
     stringRepeated?: (string[]|null);
@@ -11,6 +10,8 @@ export interface IMessage {
     enumVal?: (Message.SomeEnum|null);
     enumRepeated?: (Message.SomeEnum[]|null);
     int64Map?: ({ [k: string]: (number|Long) }|null);
+
+    $unknownFields?: ReadonlyArray<Uint8Array>;
 }
 
 export class Message implements IMessage {
@@ -34,6 +35,8 @@ export class Message implements IMessage {
     public static toObject(message: Message, options?: $protobuf.IConversionOptions): { [k: string]: any };
     public toJSON(): { [k: string]: any };
     public static getTypeUrl(typeUrlPrefix?: string): string;
+
+    public $unknownFields?: ReadonlyArray<Uint8Array>;
 }
 
 export namespace Message {

--- a/tests/data/convert.js
+++ b/tests/data/convert.js
@@ -142,6 +142,15 @@ $root.Message = (function() {
     Message.encode = function encode(message, writer) {
         if (!writer)
             writer = $Writer.create();
+        var fullyUnknown = [];
+        if (message.$unknownFields && $root.Message.decode)
+            for (var i = 0; i < message.$unknownFields.length; ++i)
+                try {
+                    var known = $root.Message.decode(message.$unknownFields[i]);
+                    fullyUnknown = fullyUnknown.concat(known.$unknownFields || []);
+                    message = Object.assign(known, message);
+                } catch (_) {
+                }
         if (message.stringVal != null && Object.hasOwnProperty.call(message, "stringVal"))
             writer.uint32(/* id 1, wireType 2 =*/10).string(message.stringVal);
         if (message.stringRepeated != null && message.stringRepeated.length)
@@ -171,6 +180,8 @@ $root.Message = (function() {
         if (message.int64Map != null && Object.hasOwnProperty.call(message, "int64Map"))
             for (var keys = Object.keys(message.int64Map), i = 0; i < keys.length; ++i)
                 writer.uint32(/* id 9, wireType 2 =*/74).fork().uint32(/* id 1, wireType 2 =*/10).string(keys[i]).uint32(/* id 2, wireType 0 =*/16).int64(message.int64Map[keys[i]]).ldelim();
+        for (var i = 0; i < fullyUnknown.length; ++i)
+            writer._unknownField(fullyUnknown[i]);
         return writer;
     };
 
@@ -203,74 +214,87 @@ $root.Message = (function() {
             reader = $Reader.create(reader);
         var end = length === undefined ? reader.len : reader.pos + length, message = new $root.Message(), key, value;
         while (reader.pos < end) {
+            var unknownStartPos = reader.pos;
             var tag = reader.uint32();
             switch (tag >>> 3) {
-            case 1:
-                message.stringVal = reader.string();
-                break;
-            case 2:
-                if (!(message.stringRepeated && message.stringRepeated.length))
-                    message.stringRepeated = [];
-                message.stringRepeated.push(reader.string());
-                break;
-            case 3:
-                message.uint64Val = reader.uint64();
-                break;
-            case 4:
-                if (!(message.uint64Repeated && message.uint64Repeated.length))
-                    message.uint64Repeated = [];
-                if ((tag & 7) === 2) {
-                    var end2 = reader.uint32() + reader.pos;
-                    while (reader.pos < end2)
-                        message.uint64Repeated.push(reader.uint64());
-                } else
-                    message.uint64Repeated.push(reader.uint64());
-                break;
-            case 5:
-                message.bytesVal = reader.bytes();
-                break;
-            case 6:
-                if (!(message.bytesRepeated && message.bytesRepeated.length))
-                    message.bytesRepeated = [];
-                message.bytesRepeated.push(reader.bytes());
-                break;
-            case 7:
-                message.enumVal = reader.int32();
-                break;
-            case 8:
-                if (!(message.enumRepeated && message.enumRepeated.length))
-                    message.enumRepeated = [];
-                if ((tag & 7) === 2) {
-                    var end2 = reader.uint32() + reader.pos;
-                    while (reader.pos < end2)
-                        message.enumRepeated.push(reader.int32());
-                } else
-                    message.enumRepeated.push(reader.int32());
-                break;
-            case 9:
-                if (message.int64Map === $util.emptyObject)
-                    message.int64Map = {};
-                var end2 = reader.uint32() + reader.pos;
-                key = "";
-                value = 0;
-                while (reader.pos < end2) {
-                    var tag2 = reader.uint32();
-                    switch (tag2 >>> 3) {
-                    case 1:
-                        key = reader.string();
-                        break;
-                    case 2:
-                        value = reader.int64();
-                        break;
-                    default:
-                        reader.skipType(tag2 & 7);
-                        break;
-                    }
+            case 1: {
+                    message.stringVal = reader.string();
+                    break;
                 }
-                message.int64Map[key] = value;
-                break;
+            case 2: {
+                    if (!(message.stringRepeated && message.stringRepeated.length))
+                        message.stringRepeated = [];
+                    message.stringRepeated.push(reader.string());
+                    break;
+                }
+            case 3: {
+                    message.uint64Val = reader.uint64();
+                    break;
+                }
+            case 4: {
+                    if (!(message.uint64Repeated && message.uint64Repeated.length))
+                        message.uint64Repeated = [];
+                    if ((tag & 7) === 2) {
+                        var end2 = reader.uint32() + reader.pos;
+                        while (reader.pos < end2)
+                            message.uint64Repeated.push(reader.uint64());
+                    } else
+                        message.uint64Repeated.push(reader.uint64());
+                    break;
+                }
+            case 5: {
+                    message.bytesVal = reader.bytes();
+                    break;
+                }
+            case 6: {
+                    if (!(message.bytesRepeated && message.bytesRepeated.length))
+                        message.bytesRepeated = [];
+                    message.bytesRepeated.push(reader.bytes());
+                    break;
+                }
+            case 7: {
+                    message.enumVal = reader.int32();
+                    break;
+                }
+            case 8: {
+                    if (!(message.enumRepeated && message.enumRepeated.length))
+                        message.enumRepeated = [];
+                    if ((tag & 7) === 2) {
+                        var end2 = reader.uint32() + reader.pos;
+                        while (reader.pos < end2)
+                            message.enumRepeated.push(reader.int32());
+                    } else
+                        message.enumRepeated.push(reader.int32());
+                    break;
+                }
+            case 9: {
+                    if (message.int64Map === $util.emptyObject)
+                        message.int64Map = {};
+                    var end2 = reader.uint32() + reader.pos;
+                    key = "";
+                    value = 0;
+                    while (reader.pos < end2) {
+                        var tag2 = reader.uint32();
+                        switch (tag2 >>> 3) {
+                        case 1:
+                            key = reader.string();
+                            break;
+                        case 2:
+                            value = reader.int64();
+                            break;
+                        default:
+                            reader.skipType(tag2 & 7);
+                            break;
+                        }
+                    }
+                    message.int64Map[key] = value;
+                    break;
+                }
             default:
                 reader.skipType(tag & 7);
+                if (!message.$unknownFields)
+                    message.$unknownFields = [];
+                message.$unknownFields.push(reader.buf.slice(unknownStartPos, reader.pos));
                 break;
             }
         }
@@ -425,6 +449,12 @@ $root.Message = (function() {
                     message.bytesRepeated[i] = object.bytesRepeated[i];
         }
         switch (object.enumVal) {
+        default:
+            if (typeof object.enumVal === "number") {
+                message.enumVal = object.enumVal;
+                break;
+            }
+            break;
         case "ONE":
         case 1:
             message.enumVal = 1;
@@ -441,6 +471,10 @@ $root.Message = (function() {
             for (var i = 0; i < object.enumRepeated.length; ++i)
                 switch (object.enumRepeated[i]) {
                 default:
+                    if (typeof object.enumRepeated[i] === "number") {
+                        message.enumRepeated[i] = object.enumRepeated[i];
+                        break;
+                    }
                 case "ONE":
                 case 1:
                     message.enumRepeated[i] = 1;
@@ -533,11 +567,11 @@ $root.Message = (function() {
                 object.bytesRepeated[j] = options.bytes === String ? $util.base64.encode(message.bytesRepeated[j], 0, message.bytesRepeated[j].length) : options.bytes === Array ? Array.prototype.slice.call(message.bytesRepeated[j]) : message.bytesRepeated[j];
         }
         if (message.enumVal != null && message.hasOwnProperty("enumVal"))
-            object.enumVal = options.enums === String ? $root.Message.SomeEnum[message.enumVal] : message.enumVal;
+            object.enumVal = options.enums === String ? $root.Message.SomeEnum[message.enumVal] === undefined ? message.enumVal : $root.Message.SomeEnum[message.enumVal] : message.enumVal;
         if (message.enumRepeated && message.enumRepeated.length) {
             object.enumRepeated = [];
             for (var j = 0; j < message.enumRepeated.length; ++j)
-                object.enumRepeated[j] = options.enums === String ? $root.Message.SomeEnum[message.enumRepeated[j]] : message.enumRepeated[j];
+                object.enumRepeated[j] = options.enums === String ? $root.Message.SomeEnum[message.enumRepeated[j]] === undefined ? message.enumRepeated[j] : $root.Message.SomeEnum[message.enumRepeated[j]] : message.enumRepeated[j];
         }
         var keys2;
         if (message.int64Map && (keys2 = Object.keys(message.int64Map)).length) {

--- a/tests/data/mapbox/vector_tile.d.ts
+++ b/tests/data/mapbox/vector_tile.d.ts
@@ -1,10 +1,11 @@
 import * as $protobuf from "../../..";
-import Long from "long";
-
+import Long = require("long");
 export namespace vector_tile {
 
     interface ITile {
         layers?: (vector_tile.Tile.ILayer[]|null);
+
+        $unknownFields?: ReadonlyArray<Uint8Array>;
     }
 
     class Tile implements ITile {
@@ -20,6 +21,8 @@ export namespace vector_tile {
         public static toObject(message: vector_tile.Tile, options?: $protobuf.IConversionOptions): { [k: string]: any };
         public toJSON(): { [k: string]: any };
         public static getTypeUrl(typeUrlPrefix?: string): string;
+
+        public $unknownFields?: ReadonlyArray<Uint8Array>;
     }
 
     namespace Tile {
@@ -39,6 +42,8 @@ export namespace vector_tile {
             uintValue?: (number|Long|null);
             sintValue?: (number|Long|null);
             boolValue?: (boolean|null);
+
+            $unknownFields?: ReadonlyArray<Uint8Array>;
         }
 
         class Value implements IValue {
@@ -60,6 +65,8 @@ export namespace vector_tile {
             public static toObject(message: vector_tile.Tile.Value, options?: $protobuf.IConversionOptions): { [k: string]: any };
             public toJSON(): { [k: string]: any };
             public static getTypeUrl(typeUrlPrefix?: string): string;
+
+            public $unknownFields?: ReadonlyArray<Uint8Array>;
         }
 
         interface IFeature {
@@ -67,6 +74,8 @@ export namespace vector_tile {
             tags?: (number[]|null);
             type?: (vector_tile.Tile.GeomType|null);
             geometry?: (number[]|null);
+
+            $unknownFields?: ReadonlyArray<Uint8Array>;
         }
 
         class Feature implements IFeature {
@@ -85,6 +94,8 @@ export namespace vector_tile {
             public static toObject(message: vector_tile.Tile.Feature, options?: $protobuf.IConversionOptions): { [k: string]: any };
             public toJSON(): { [k: string]: any };
             public static getTypeUrl(typeUrlPrefix?: string): string;
+
+            public $unknownFields?: ReadonlyArray<Uint8Array>;
         }
 
         interface ILayer {
@@ -94,6 +105,8 @@ export namespace vector_tile {
             keys?: (string[]|null);
             values?: (vector_tile.Tile.IValue[]|null);
             extent?: (number|null);
+
+            $unknownFields?: ReadonlyArray<Uint8Array>;
         }
 
         class Layer implements ILayer {
@@ -114,6 +127,8 @@ export namespace vector_tile {
             public static toObject(message: vector_tile.Tile.Layer, options?: $protobuf.IConversionOptions): { [k: string]: any };
             public toJSON(): { [k: string]: any };
             public static getTypeUrl(typeUrlPrefix?: string): string;
+
+            public $unknownFields?: ReadonlyArray<Uint8Array>;
         }
     }
 }

--- a/tests/data/mapbox/vector_tile.js
+++ b/tests/data/mapbox/vector_tile.js
@@ -75,9 +75,20 @@ $root.vector_tile = (function() {
         Tile.encode = function encode(message, writer) {
             if (!writer)
                 writer = $Writer.create();
+            var fullyUnknown = [];
+            if (message.$unknownFields && $root.vector_tile.Tile.decode)
+                for (var i = 0; i < message.$unknownFields.length; ++i)
+                    try {
+                        var known = $root.vector_tile.Tile.decode(message.$unknownFields[i]);
+                        fullyUnknown = fullyUnknown.concat(known.$unknownFields || []);
+                        message = Object.assign(known, message);
+                    } catch (_) {
+                    }
             if (message.layers != null && message.layers.length)
                 for (var i = 0; i < message.layers.length; ++i)
                     $root.vector_tile.Tile.Layer.encode(message.layers[i], writer.uint32(/* id 3, wireType 2 =*/26).fork()).ldelim();
+            for (var i = 0; i < fullyUnknown.length; ++i)
+                writer._unknownField(fullyUnknown[i]);
             return writer;
         };
 
@@ -110,15 +121,20 @@ $root.vector_tile = (function() {
                 reader = $Reader.create(reader);
             var end = length === undefined ? reader.len : reader.pos + length, message = new $root.vector_tile.Tile();
             while (reader.pos < end) {
+                var unknownStartPos = reader.pos;
                 var tag = reader.uint32();
                 switch (tag >>> 3) {
-                case 3:
-                    if (!(message.layers && message.layers.length))
-                        message.layers = [];
-                    message.layers.push($root.vector_tile.Tile.Layer.decode(reader, reader.uint32()));
-                    break;
+                case 3: {
+                        if (!(message.layers && message.layers.length))
+                            message.layers = [];
+                        message.layers.push($root.vector_tile.Tile.Layer.decode(reader, reader.uint32()));
+                        break;
+                    }
                 default:
                     reader.skipType(tag & 7);
+                    if (!message.$unknownFields)
+                        message.$unknownFields = [];
+                    message.$unknownFields.push(reader.buf.slice(unknownStartPos, reader.pos));
                     break;
                 }
             }
@@ -366,6 +382,15 @@ $root.vector_tile = (function() {
             Value.encode = function encode(message, writer) {
                 if (!writer)
                     writer = $Writer.create();
+                var fullyUnknown = [];
+                if (message.$unknownFields && $root.vector_tile.Tile.Value.decode)
+                    for (var i = 0; i < message.$unknownFields.length; ++i)
+                        try {
+                            var known = $root.vector_tile.Tile.Value.decode(message.$unknownFields[i]);
+                            fullyUnknown = fullyUnknown.concat(known.$unknownFields || []);
+                            message = Object.assign(known, message);
+                        } catch (_) {
+                        }
                 if (message.stringValue != null && Object.hasOwnProperty.call(message, "stringValue"))
                     writer.uint32(/* id 1, wireType 2 =*/10).string(message.stringValue);
                 if (message.floatValue != null && Object.hasOwnProperty.call(message, "floatValue"))
@@ -380,6 +405,8 @@ $root.vector_tile = (function() {
                     writer.uint32(/* id 6, wireType 0 =*/48).sint64(message.sintValue);
                 if (message.boolValue != null && Object.hasOwnProperty.call(message, "boolValue"))
                     writer.uint32(/* id 7, wireType 0 =*/56).bool(message.boolValue);
+                for (var i = 0; i < fullyUnknown.length; ++i)
+                    writer._unknownField(fullyUnknown[i]);
                 return writer;
             };
 
@@ -412,31 +439,42 @@ $root.vector_tile = (function() {
                     reader = $Reader.create(reader);
                 var end = length === undefined ? reader.len : reader.pos + length, message = new $root.vector_tile.Tile.Value();
                 while (reader.pos < end) {
+                    var unknownStartPos = reader.pos;
                     var tag = reader.uint32();
                     switch (tag >>> 3) {
-                    case 1:
-                        message.stringValue = reader.string();
-                        break;
-                    case 2:
-                        message.floatValue = reader.float();
-                        break;
-                    case 3:
-                        message.doubleValue = reader.double();
-                        break;
-                    case 4:
-                        message.intValue = reader.int64();
-                        break;
-                    case 5:
-                        message.uintValue = reader.uint64();
-                        break;
-                    case 6:
-                        message.sintValue = reader.sint64();
-                        break;
-                    case 7:
-                        message.boolValue = reader.bool();
-                        break;
+                    case 1: {
+                            message.stringValue = reader.string();
+                            break;
+                        }
+                    case 2: {
+                            message.floatValue = reader.float();
+                            break;
+                        }
+                    case 3: {
+                            message.doubleValue = reader.double();
+                            break;
+                        }
+                    case 4: {
+                            message.intValue = reader.int64();
+                            break;
+                        }
+                    case 5: {
+                            message.uintValue = reader.uint64();
+                            break;
+                        }
+                    case 6: {
+                            message.sintValue = reader.sint64();
+                            break;
+                        }
+                    case 7: {
+                            message.boolValue = reader.bool();
+                            break;
+                        }
                     default:
                         reader.skipType(tag & 7);
+                        if (!message.$unknownFields)
+                            message.$unknownFields = [];
+                        message.$unknownFields.push(reader.buf.slice(unknownStartPos, reader.pos));
                         break;
                     }
                 }
@@ -718,6 +756,15 @@ $root.vector_tile = (function() {
             Feature.encode = function encode(message, writer) {
                 if (!writer)
                     writer = $Writer.create();
+                var fullyUnknown = [];
+                if (message.$unknownFields && $root.vector_tile.Tile.Feature.decode)
+                    for (var i = 0; i < message.$unknownFields.length; ++i)
+                        try {
+                            var known = $root.vector_tile.Tile.Feature.decode(message.$unknownFields[i]);
+                            fullyUnknown = fullyUnknown.concat(known.$unknownFields || []);
+                            message = Object.assign(known, message);
+                        } catch (_) {
+                        }
                 if (message.id != null && Object.hasOwnProperty.call(message, "id"))
                     writer.uint32(/* id 1, wireType 0 =*/8).uint64(message.id);
                 if (message.tags != null && message.tags.length) {
@@ -734,6 +781,8 @@ $root.vector_tile = (function() {
                         writer.uint32(message.geometry[i]);
                     writer.ldelim();
                 }
+                for (var i = 0; i < fullyUnknown.length; ++i)
+                    writer._unknownField(fullyUnknown[i]);
                 return writer;
             };
 
@@ -766,36 +815,44 @@ $root.vector_tile = (function() {
                     reader = $Reader.create(reader);
                 var end = length === undefined ? reader.len : reader.pos + length, message = new $root.vector_tile.Tile.Feature();
                 while (reader.pos < end) {
+                    var unknownStartPos = reader.pos;
                     var tag = reader.uint32();
                     switch (tag >>> 3) {
-                    case 1:
-                        message.id = reader.uint64();
-                        break;
-                    case 2:
-                        if (!(message.tags && message.tags.length))
-                            message.tags = [];
-                        if ((tag & 7) === 2) {
-                            var end2 = reader.uint32() + reader.pos;
-                            while (reader.pos < end2)
+                    case 1: {
+                            message.id = reader.uint64();
+                            break;
+                        }
+                    case 2: {
+                            if (!(message.tags && message.tags.length))
+                                message.tags = [];
+                            if ((tag & 7) === 2) {
+                                var end2 = reader.uint32() + reader.pos;
+                                while (reader.pos < end2)
+                                    message.tags.push(reader.uint32());
+                            } else
                                 message.tags.push(reader.uint32());
-                        } else
-                            message.tags.push(reader.uint32());
-                        break;
-                    case 3:
-                        message.type = reader.int32();
-                        break;
-                    case 4:
-                        if (!(message.geometry && message.geometry.length))
-                            message.geometry = [];
-                        if ((tag & 7) === 2) {
-                            var end2 = reader.uint32() + reader.pos;
-                            while (reader.pos < end2)
+                            break;
+                        }
+                    case 3: {
+                            message.type = reader.int32();
+                            break;
+                        }
+                    case 4: {
+                            if (!(message.geometry && message.geometry.length))
+                                message.geometry = [];
+                            if ((tag & 7) === 2) {
+                                var end2 = reader.uint32() + reader.pos;
+                                while (reader.pos < end2)
+                                    message.geometry.push(reader.uint32());
+                            } else
                                 message.geometry.push(reader.uint32());
-                        } else
-                            message.geometry.push(reader.uint32());
-                        break;
+                            break;
+                        }
                     default:
                         reader.skipType(tag & 7);
+                        if (!message.$unknownFields)
+                            message.$unknownFields = [];
+                        message.$unknownFields.push(reader.buf.slice(unknownStartPos, reader.pos));
                         break;
                     }
                 }
@@ -888,6 +945,12 @@ $root.vector_tile = (function() {
                         message.tags[i] = object.tags[i] >>> 0;
                 }
                 switch (object.type) {
+                default:
+                    if (typeof object.type === "number") {
+                        message.type = object.type;
+                        break;
+                    }
+                    break;
                 case "UNKNOWN":
                 case 0:
                     message.type = 0;
@@ -951,7 +1014,7 @@ $root.vector_tile = (function() {
                         object.tags[j] = message.tags[j];
                 }
                 if (message.type != null && message.hasOwnProperty("type"))
-                    object.type = options.enums === String ? $root.vector_tile.Tile.GeomType[message.type] : message.type;
+                    object.type = options.enums === String ? $root.vector_tile.Tile.GeomType[message.type] === undefined ? message.type : $root.vector_tile.Tile.GeomType[message.type] : message.type;
                 if (message.geometry && message.geometry.length) {
                     object.geometry = [];
                     for (var j = 0; j < message.geometry.length; ++j)
@@ -1093,6 +1156,15 @@ $root.vector_tile = (function() {
             Layer.encode = function encode(message, writer) {
                 if (!writer)
                     writer = $Writer.create();
+                var fullyUnknown = [];
+                if (message.$unknownFields && $root.vector_tile.Tile.Layer.decode)
+                    for (var i = 0; i < message.$unknownFields.length; ++i)
+                        try {
+                            var known = $root.vector_tile.Tile.Layer.decode(message.$unknownFields[i]);
+                            fullyUnknown = fullyUnknown.concat(known.$unknownFields || []);
+                            message = Object.assign(known, message);
+                        } catch (_) {
+                        }
                 writer.uint32(/* id 1, wireType 2 =*/10).string(message.name);
                 if (message.features != null && message.features.length)
                     for (var i = 0; i < message.features.length; ++i)
@@ -1106,6 +1178,8 @@ $root.vector_tile = (function() {
                 if (message.extent != null && Object.hasOwnProperty.call(message, "extent"))
                     writer.uint32(/* id 5, wireType 0 =*/40).uint32(message.extent);
                 writer.uint32(/* id 15, wireType 0 =*/120).uint32(message.version);
+                for (var i = 0; i < fullyUnknown.length; ++i)
+                    writer._unknownField(fullyUnknown[i]);
                 return writer;
             };
 
@@ -1138,34 +1212,44 @@ $root.vector_tile = (function() {
                     reader = $Reader.create(reader);
                 var end = length === undefined ? reader.len : reader.pos + length, message = new $root.vector_tile.Tile.Layer();
                 while (reader.pos < end) {
+                    var unknownStartPos = reader.pos;
                     var tag = reader.uint32();
                     switch (tag >>> 3) {
-                    case 15:
-                        message.version = reader.uint32();
-                        break;
-                    case 1:
-                        message.name = reader.string();
-                        break;
-                    case 2:
-                        if (!(message.features && message.features.length))
-                            message.features = [];
-                        message.features.push($root.vector_tile.Tile.Feature.decode(reader, reader.uint32()));
-                        break;
-                    case 3:
-                        if (!(message.keys && message.keys.length))
-                            message.keys = [];
-                        message.keys.push(reader.string());
-                        break;
-                    case 4:
-                        if (!(message.values && message.values.length))
-                            message.values = [];
-                        message.values.push($root.vector_tile.Tile.Value.decode(reader, reader.uint32()));
-                        break;
-                    case 5:
-                        message.extent = reader.uint32();
-                        break;
+                    case 15: {
+                            message.version = reader.uint32();
+                            break;
+                        }
+                    case 1: {
+                            message.name = reader.string();
+                            break;
+                        }
+                    case 2: {
+                            if (!(message.features && message.features.length))
+                                message.features = [];
+                            message.features.push($root.vector_tile.Tile.Feature.decode(reader, reader.uint32()));
+                            break;
+                        }
+                    case 3: {
+                            if (!(message.keys && message.keys.length))
+                                message.keys = [];
+                            message.keys.push(reader.string());
+                            break;
+                        }
+                    case 4: {
+                            if (!(message.values && message.values.length))
+                                message.values = [];
+                            message.values.push($root.vector_tile.Tile.Value.decode(reader, reader.uint32()));
+                            break;
+                        }
+                    case 5: {
+                            message.extent = reader.uint32();
+                            break;
+                        }
                     default:
                         reader.skipType(tag & 7);
+                        if (!message.$unknownFields)
+                            message.$unknownFields = [];
+                        message.$unknownFields.push(reader.buf.slice(unknownStartPos, reader.pos));
                         break;
                     }
                 }

--- a/tests/data/package.d.ts
+++ b/tests/data/package.d.ts
@@ -1,4 +1,5 @@
 import * as $protobuf from "../..";
+import Long = require("long");
 export interface IPackage {
     name?: (string|null);
     version?: (string|null);
@@ -17,6 +18,8 @@ export interface IPackage {
     devDependencies?: ({ [k: string]: string }|null);
     types?: (string|null);
     cliDependencies?: (string[]|null);
+
+    $unknownFields?: ReadonlyArray<Uint8Array>;
 }
 
 export class Package implements IPackage {
@@ -48,6 +51,8 @@ export class Package implements IPackage {
     public static toObject(message: Package, options?: $protobuf.IConversionOptions): { [k: string]: any };
     public toJSON(): { [k: string]: any };
     public static getTypeUrl(typeUrlPrefix?: string): string;
+
+    public $unknownFields?: ReadonlyArray<Uint8Array>;
 }
 
 export namespace Package {
@@ -55,6 +60,8 @@ export namespace Package {
     interface IRepository {
         type?: (string|null);
         url?: (string|null);
+
+        $unknownFields?: ReadonlyArray<Uint8Array>;
     }
 
     class Repository implements IRepository {
@@ -71,5 +78,7 @@ export namespace Package {
         public static toObject(message: Package.Repository, options?: $protobuf.IConversionOptions): { [k: string]: any };
         public toJSON(): { [k: string]: any };
         public static getTypeUrl(typeUrlPrefix?: string): string;
+
+        public $unknownFields?: ReadonlyArray<Uint8Array>;
     }
 }

--- a/tests/data/package.js
+++ b/tests/data/package.js
@@ -215,6 +215,15 @@ $root.Package = (function() {
     Package.encode = function encode(message, writer) {
         if (!writer)
             writer = $Writer.create();
+        var fullyUnknown = [];
+        if (message.$unknownFields && $root.Package.decode)
+            for (var i = 0; i < message.$unknownFields.length; ++i)
+                try {
+                    var known = $root.Package.decode(message.$unknownFields[i]);
+                    fullyUnknown = fullyUnknown.concat(known.$unknownFields || []);
+                    message = Object.assign(known, message);
+                } catch (_) {
+                }
         if (message.name != null && Object.hasOwnProperty.call(message, "name"))
             writer.uint32(/* id 1, wireType 2 =*/10).string(message.name);
         if (message.version != null && Object.hasOwnProperty.call(message, "version"))
@@ -255,6 +264,8 @@ $root.Package = (function() {
                 writer.uint32(/* id 18, wireType 2 =*/146).string(message.cliDependencies[i]);
         if (message.versionScheme != null && Object.hasOwnProperty.call(message, "versionScheme"))
             writer.uint32(/* id 19, wireType 2 =*/154).string(message.versionScheme);
+        for (var i = 0; i < fullyUnknown.length; ++i)
+            writer._unknownField(fullyUnknown[i]);
         return writer;
     };
 
@@ -287,141 +298,162 @@ $root.Package = (function() {
             reader = $Reader.create(reader);
         var end = length === undefined ? reader.len : reader.pos + length, message = new $root.Package(), key, value;
         while (reader.pos < end) {
+            var unknownStartPos = reader.pos;
             var tag = reader.uint32();
             switch (tag >>> 3) {
-            case 1:
-                message.name = reader.string();
-                break;
-            case 2:
-                message.version = reader.string();
-                break;
-            case 19:
-                message.versionScheme = reader.string();
-                break;
-            case 3:
-                message.description = reader.string();
-                break;
-            case 4:
-                message.author = reader.string();
-                break;
-            case 5:
-                message.license = reader.string();
-                break;
-            case 6:
-                message.repository = $root.Package.Repository.decode(reader, reader.uint32());
-                break;
-            case 7:
-                message.bugs = reader.string();
-                break;
-            case 8:
-                message.homepage = reader.string();
-                break;
-            case 9:
-                if (!(message.keywords && message.keywords.length))
-                    message.keywords = [];
-                message.keywords.push(reader.string());
-                break;
-            case 10:
-                message.main = reader.string();
-                break;
-            case 11:
-                if (message.bin === $util.emptyObject)
-                    message.bin = {};
-                var end2 = reader.uint32() + reader.pos;
-                key = "";
-                value = "";
-                while (reader.pos < end2) {
-                    var tag2 = reader.uint32();
-                    switch (tag2 >>> 3) {
-                    case 1:
-                        key = reader.string();
-                        break;
-                    case 2:
-                        value = reader.string();
-                        break;
-                    default:
-                        reader.skipType(tag2 & 7);
-                        break;
-                    }
+            case 1: {
+                    message.name = reader.string();
+                    break;
                 }
-                message.bin[key] = value;
-                break;
-            case 12:
-                if (message.scripts === $util.emptyObject)
-                    message.scripts = {};
-                var end2 = reader.uint32() + reader.pos;
-                key = "";
-                value = "";
-                while (reader.pos < end2) {
-                    var tag2 = reader.uint32();
-                    switch (tag2 >>> 3) {
-                    case 1:
-                        key = reader.string();
-                        break;
-                    case 2:
-                        value = reader.string();
-                        break;
-                    default:
-                        reader.skipType(tag2 & 7);
-                        break;
-                    }
+            case 2: {
+                    message.version = reader.string();
+                    break;
                 }
-                message.scripts[key] = value;
-                break;
-            case 13:
-                if (message.dependencies === $util.emptyObject)
-                    message.dependencies = {};
-                var end2 = reader.uint32() + reader.pos;
-                key = "";
-                value = "";
-                while (reader.pos < end2) {
-                    var tag2 = reader.uint32();
-                    switch (tag2 >>> 3) {
-                    case 1:
-                        key = reader.string();
-                        break;
-                    case 2:
-                        value = reader.string();
-                        break;
-                    default:
-                        reader.skipType(tag2 & 7);
-                        break;
-                    }
+            case 19: {
+                    message.versionScheme = reader.string();
+                    break;
                 }
-                message.dependencies[key] = value;
-                break;
-            case 15:
-                if (message.devDependencies === $util.emptyObject)
-                    message.devDependencies = {};
-                var end2 = reader.uint32() + reader.pos;
-                key = "";
-                value = "";
-                while (reader.pos < end2) {
-                    var tag2 = reader.uint32();
-                    switch (tag2 >>> 3) {
-                    case 1:
-                        key = reader.string();
-                        break;
-                    case 2:
-                        value = reader.string();
-                        break;
-                    default:
-                        reader.skipType(tag2 & 7);
-                        break;
-                    }
+            case 3: {
+                    message.description = reader.string();
+                    break;
                 }
-                message.devDependencies[key] = value;
-                break;
-            case 17:
-                message.types = reader.string();
-                break;
-            case 18:
-                if (!(message.cliDependencies && message.cliDependencies.length))
-                    message.cliDependencies = [];
-                message.cliDependencies.push(reader.string());
-                break;
+            case 4: {
+                    message.author = reader.string();
+                    break;
+                }
+            case 5: {
+                    message.license = reader.string();
+                    break;
+                }
+            case 6: {
+                    message.repository = $root.Package.Repository.decode(reader, reader.uint32());
+                    break;
+                }
+            case 7: {
+                    message.bugs = reader.string();
+                    break;
+                }
+            case 8: {
+                    message.homepage = reader.string();
+                    break;
+                }
+            case 9: {
+                    if (!(message.keywords && message.keywords.length))
+                        message.keywords = [];
+                    message.keywords.push(reader.string());
+                    break;
+                }
+            case 10: {
+                    message.main = reader.string();
+                    break;
+                }
+            case 11: {
+                    if (message.bin === $util.emptyObject)
+                        message.bin = {};
+                    var end2 = reader.uint32() + reader.pos;
+                    key = "";
+                    value = "";
+                    while (reader.pos < end2) {
+                        var tag2 = reader.uint32();
+                        switch (tag2 >>> 3) {
+                        case 1:
+                            key = reader.string();
+                            break;
+                        case 2:
+                            value = reader.string();
+                            break;
+                        default:
+                            reader.skipType(tag2 & 7);
+                            break;
+                        }
+                    }
+                    message.bin[key] = value;
+                    break;
+                }
+            case 12: {
+                    if (message.scripts === $util.emptyObject)
+                        message.scripts = {};
+                    var end2 = reader.uint32() + reader.pos;
+                    key = "";
+                    value = "";
+                    while (reader.pos < end2) {
+                        var tag2 = reader.uint32();
+                        switch (tag2 >>> 3) {
+                        case 1:
+                            key = reader.string();
+                            break;
+                        case 2:
+                            value = reader.string();
+                            break;
+                        default:
+                            reader.skipType(tag2 & 7);
+                            break;
+                        }
+                    }
+                    message.scripts[key] = value;
+                    break;
+                }
+            case 13: {
+                    if (message.dependencies === $util.emptyObject)
+                        message.dependencies = {};
+                    var end2 = reader.uint32() + reader.pos;
+                    key = "";
+                    value = "";
+                    while (reader.pos < end2) {
+                        var tag2 = reader.uint32();
+                        switch (tag2 >>> 3) {
+                        case 1:
+                            key = reader.string();
+                            break;
+                        case 2:
+                            value = reader.string();
+                            break;
+                        default:
+                            reader.skipType(tag2 & 7);
+                            break;
+                        }
+                    }
+                    message.dependencies[key] = value;
+                    break;
+                }
+            case 15: {
+                    if (message.devDependencies === $util.emptyObject)
+                        message.devDependencies = {};
+                    var end2 = reader.uint32() + reader.pos;
+                    key = "";
+                    value = "";
+                    while (reader.pos < end2) {
+                        var tag2 = reader.uint32();
+                        switch (tag2 >>> 3) {
+                        case 1:
+                            key = reader.string();
+                            break;
+                        case 2:
+                            value = reader.string();
+                            break;
+                        default:
+                            reader.skipType(tag2 & 7);
+                            break;
+                        }
+                    }
+                    message.devDependencies[key] = value;
+                    break;
+                }
+            case 17: {
+                    message.types = reader.string();
+                    break;
+                }
+            case 18: {
+                    if (!(message.cliDependencies && message.cliDependencies.length))
+                        message.cliDependencies = [];
+                    message.cliDependencies.push(reader.string());
+                    break;
+                }
             default:
                 reader.skipType(tag & 7);
+                if (!message.$unknownFields)
+                    message.$unknownFields = [];
+                message.$unknownFields.push(reader.buf.slice(unknownStartPos, reader.pos));
                 break;
             }
         }
@@ -804,10 +836,21 @@ $root.Package = (function() {
         Repository.encode = function encode(message, writer) {
             if (!writer)
                 writer = $Writer.create();
+            var fullyUnknown = [];
+            if (message.$unknownFields && $root.Package.Repository.decode)
+                for (var i = 0; i < message.$unknownFields.length; ++i)
+                    try {
+                        var known = $root.Package.Repository.decode(message.$unknownFields[i]);
+                        fullyUnknown = fullyUnknown.concat(known.$unknownFields || []);
+                        message = Object.assign(known, message);
+                    } catch (_) {
+                    }
             if (message.type != null && Object.hasOwnProperty.call(message, "type"))
                 writer.uint32(/* id 1, wireType 2 =*/10).string(message.type);
             if (message.url != null && Object.hasOwnProperty.call(message, "url"))
                 writer.uint32(/* id 2, wireType 2 =*/18).string(message.url);
+            for (var i = 0; i < fullyUnknown.length; ++i)
+                writer._unknownField(fullyUnknown[i]);
             return writer;
         };
 
@@ -840,16 +883,22 @@ $root.Package = (function() {
                 reader = $Reader.create(reader);
             var end = length === undefined ? reader.len : reader.pos + length, message = new $root.Package.Repository();
             while (reader.pos < end) {
+                var unknownStartPos = reader.pos;
                 var tag = reader.uint32();
                 switch (tag >>> 3) {
-                case 1:
-                    message.type = reader.string();
-                    break;
-                case 2:
-                    message.url = reader.string();
-                    break;
+                case 1: {
+                        message.type = reader.string();
+                        break;
+                    }
+                case 2: {
+                        message.url = reader.string();
+                        break;
+                    }
                 default:
                     reader.skipType(tag & 7);
+                    if (!message.$unknownFields)
+                        message.$unknownFields = [];
+                    message.$unknownFields.push(reader.buf.slice(unknownStartPos, reader.pos));
                     break;
                 }
             }

--- a/tests/data/rpc-es6.d.ts
+++ b/tests/data/rpc-es6.d.ts
@@ -1,9 +1,12 @@
 import * as $protobuf from "../..";
+import Long = require("long");
 export class MyService extends $protobuf.rpc.Service {
     constructor(rpcImpl: $protobuf.RPCImpl, requestDelimited?: boolean, responseDelimited?: boolean);
     public static create(rpcImpl: $protobuf.RPCImpl, requestDelimited?: boolean, responseDelimited?: boolean): MyService;
     public myMethod(request: IMyRequest, callback: MyService.MyMethodCallback): void;
     public myMethod(request: IMyRequest): Promise<MyResponse>;
+
+    public $unknownFields?: ReadonlyArray<Uint8Array>;
 }
 
 export namespace MyService {
@@ -13,6 +16,8 @@ export namespace MyService {
 
 export interface IMyRequest {
     path?: (string|null);
+
+    $unknownFields?: ReadonlyArray<Uint8Array>;
 }
 
 export class MyRequest implements IMyRequest {
@@ -28,10 +33,14 @@ export class MyRequest implements IMyRequest {
     public static toObject(message: MyRequest, options?: $protobuf.IConversionOptions): { [k: string]: any };
     public toJSON(): { [k: string]: any };
     public static getTypeUrl(typeUrlPrefix?: string): string;
+
+    public $unknownFields?: ReadonlyArray<Uint8Array>;
 }
 
 export interface IMyResponse {
     status?: (number|null);
+
+    $unknownFields?: ReadonlyArray<Uint8Array>;
 }
 
 export class MyResponse implements IMyResponse {
@@ -47,4 +56,6 @@ export class MyResponse implements IMyResponse {
     public static toObject(message: MyResponse, options?: $protobuf.IConversionOptions): { [k: string]: any };
     public toJSON(): { [k: string]: any };
     public static getTypeUrl(typeUrlPrefix?: string): string;
+
+    public $unknownFields?: ReadonlyArray<Uint8Array>;
 }

--- a/tests/data/rpc-es6.js
+++ b/tests/data/rpc-es6.js
@@ -131,8 +131,19 @@ export const MyRequest = $root.MyRequest = (() => {
     MyRequest.encode = function encode(message, writer) {
         if (!writer)
             writer = $Writer.create();
+        let fullyUnknown = [];
+        if (message.$unknownFields && $root.MyRequest.decode)
+            for (let i = 0; i < message.$unknownFields.length; ++i)
+                try {
+                    let known = $root.MyRequest.decode(message.$unknownFields[i]);
+                    fullyUnknown = fullyUnknown.concat(known.$unknownFields || []);
+                    message = Object.assign(known, message);
+                } catch (_) {
+                }
         if (message.path != null && Object.hasOwnProperty.call(message, "path"))
             writer.uint32(/* id 1, wireType 2 =*/10).string(message.path);
+        for (let i = 0; i < fullyUnknown.length; ++i)
+            writer._unknownField(fullyUnknown[i]);
         return writer;
     };
 
@@ -165,13 +176,18 @@ export const MyRequest = $root.MyRequest = (() => {
             reader = $Reader.create(reader);
         let end = length === undefined ? reader.len : reader.pos + length, message = new $root.MyRequest();
         while (reader.pos < end) {
+            let unknownStartPos = reader.pos;
             let tag = reader.uint32();
             switch (tag >>> 3) {
-            case 1:
-                message.path = reader.string();
-                break;
+            case 1: {
+                    message.path = reader.string();
+                    break;
+                }
             default:
                 reader.skipType(tag & 7);
+                if (!message.$unknownFields)
+                    message.$unknownFields = [];
+                message.$unknownFields.push(reader.buf.slice(unknownStartPos, reader.pos));
                 break;
             }
         }
@@ -333,8 +349,19 @@ export const MyResponse = $root.MyResponse = (() => {
     MyResponse.encode = function encode(message, writer) {
         if (!writer)
             writer = $Writer.create();
+        let fullyUnknown = [];
+        if (message.$unknownFields && $root.MyResponse.decode)
+            for (let i = 0; i < message.$unknownFields.length; ++i)
+                try {
+                    let known = $root.MyResponse.decode(message.$unknownFields[i]);
+                    fullyUnknown = fullyUnknown.concat(known.$unknownFields || []);
+                    message = Object.assign(known, message);
+                } catch (_) {
+                }
         if (message.status != null && Object.hasOwnProperty.call(message, "status"))
             writer.uint32(/* id 2, wireType 0 =*/16).int32(message.status);
+        for (let i = 0; i < fullyUnknown.length; ++i)
+            writer._unknownField(fullyUnknown[i]);
         return writer;
     };
 
@@ -367,13 +394,18 @@ export const MyResponse = $root.MyResponse = (() => {
             reader = $Reader.create(reader);
         let end = length === undefined ? reader.len : reader.pos + length, message = new $root.MyResponse();
         while (reader.pos < end) {
+            let unknownStartPos = reader.pos;
             let tag = reader.uint32();
             switch (tag >>> 3) {
-            case 2:
-                message.status = reader.int32();
-                break;
+            case 2: {
+                    message.status = reader.int32();
+                    break;
+                }
             default:
                 reader.skipType(tag & 7);
+                if (!message.$unknownFields)
+                    message.$unknownFields = [];
+                message.$unknownFields.push(reader.buf.slice(unknownStartPos, reader.pos));
                 break;
             }
         }

--- a/tests/data/rpc-reserved.d.ts
+++ b/tests/data/rpc-reserved.d.ts
@@ -1,9 +1,12 @@
 import * as $protobuf from "../..";
+import Long = require("long");
 export class MyService extends $protobuf.rpc.Service {
     constructor(rpcImpl: $protobuf.RPCImpl, requestDelimited?: boolean, responseDelimited?: boolean);
     public static create(rpcImpl: $protobuf.RPCImpl, requestDelimited?: boolean, responseDelimited?: boolean): MyService;
     public delete(request: IMyRequest, callback: MyService.DeleteCallback): void;
     public delete(request: IMyRequest): Promise<MyResponse>;
+
+    public $unknownFields?: ReadonlyArray<Uint8Array>;
 }
 
 export namespace MyService {
@@ -13,6 +16,8 @@ export namespace MyService {
 
 export interface IMyRequest {
     path?: (string|null);
+
+    $unknownFields?: ReadonlyArray<Uint8Array>;
 }
 
 export class MyRequest implements IMyRequest {
@@ -28,10 +33,14 @@ export class MyRequest implements IMyRequest {
     public static toObject(message: MyRequest, options?: $protobuf.IConversionOptions): { [k: string]: any };
     public toJSON(): { [k: string]: any };
     public static getTypeUrl(typeUrlPrefix?: string): string;
+
+    public $unknownFields?: ReadonlyArray<Uint8Array>;
 }
 
 export interface IMyResponse {
     status?: (number|null);
+
+    $unknownFields?: ReadonlyArray<Uint8Array>;
 }
 
 export class MyResponse implements IMyResponse {
@@ -47,4 +56,6 @@ export class MyResponse implements IMyResponse {
     public static toObject(message: MyResponse, options?: $protobuf.IConversionOptions): { [k: string]: any };
     public toJSON(): { [k: string]: any };
     public static getTypeUrl(typeUrlPrefix?: string): string;
+
+    public $unknownFields?: ReadonlyArray<Uint8Array>;
 }

--- a/tests/data/rpc-reserved.js
+++ b/tests/data/rpc-reserved.js
@@ -133,8 +133,19 @@ $root.MyRequest = (function() {
     MyRequest.encode = function encode(message, writer) {
         if (!writer)
             writer = $Writer.create();
+        var fullyUnknown = [];
+        if (message.$unknownFields && $root.MyRequest.decode)
+            for (var i = 0; i < message.$unknownFields.length; ++i)
+                try {
+                    var known = $root.MyRequest.decode(message.$unknownFields[i]);
+                    fullyUnknown = fullyUnknown.concat(known.$unknownFields || []);
+                    message = Object.assign(known, message);
+                } catch (_) {
+                }
         if (message.path != null && Object.hasOwnProperty.call(message, "path"))
             writer.uint32(/* id 1, wireType 2 =*/10).string(message.path);
+        for (var i = 0; i < fullyUnknown.length; ++i)
+            writer._unknownField(fullyUnknown[i]);
         return writer;
     };
 
@@ -167,13 +178,18 @@ $root.MyRequest = (function() {
             reader = $Reader.create(reader);
         var end = length === undefined ? reader.len : reader.pos + length, message = new $root.MyRequest();
         while (reader.pos < end) {
+            var unknownStartPos = reader.pos;
             var tag = reader.uint32();
             switch (tag >>> 3) {
-            case 1:
-                message.path = reader.string();
-                break;
+            case 1: {
+                    message.path = reader.string();
+                    break;
+                }
             default:
                 reader.skipType(tag & 7);
+                if (!message.$unknownFields)
+                    message.$unknownFields = [];
+                message.$unknownFields.push(reader.buf.slice(unknownStartPos, reader.pos));
                 break;
             }
         }
@@ -335,8 +351,19 @@ $root.MyResponse = (function() {
     MyResponse.encode = function encode(message, writer) {
         if (!writer)
             writer = $Writer.create();
+        var fullyUnknown = [];
+        if (message.$unknownFields && $root.MyResponse.decode)
+            for (var i = 0; i < message.$unknownFields.length; ++i)
+                try {
+                    var known = $root.MyResponse.decode(message.$unknownFields[i]);
+                    fullyUnknown = fullyUnknown.concat(known.$unknownFields || []);
+                    message = Object.assign(known, message);
+                } catch (_) {
+                }
         if (message.status != null && Object.hasOwnProperty.call(message, "status"))
             writer.uint32(/* id 2, wireType 0 =*/16).int32(message.status);
+        for (var i = 0; i < fullyUnknown.length; ++i)
+            writer._unknownField(fullyUnknown[i]);
         return writer;
     };
 
@@ -369,13 +396,18 @@ $root.MyResponse = (function() {
             reader = $Reader.create(reader);
         var end = length === undefined ? reader.len : reader.pos + length, message = new $root.MyResponse();
         while (reader.pos < end) {
+            var unknownStartPos = reader.pos;
             var tag = reader.uint32();
             switch (tag >>> 3) {
-            case 2:
-                message.status = reader.int32();
-                break;
+            case 2: {
+                    message.status = reader.int32();
+                    break;
+                }
             default:
                 reader.skipType(tag & 7);
+                if (!message.$unknownFields)
+                    message.$unknownFields = [];
+                message.$unknownFields.push(reader.buf.slice(unknownStartPos, reader.pos));
                 break;
             }
         }

--- a/tests/data/rpc.d.ts
+++ b/tests/data/rpc.d.ts
@@ -1,9 +1,12 @@
 import * as $protobuf from "../..";
+import Long = require("long");
 export class MyService extends $protobuf.rpc.Service {
     constructor(rpcImpl: $protobuf.RPCImpl, requestDelimited?: boolean, responseDelimited?: boolean);
     public static create(rpcImpl: $protobuf.RPCImpl, requestDelimited?: boolean, responseDelimited?: boolean): MyService;
     public myMethod(request: IMyRequest, callback: MyService.MyMethodCallback): void;
     public myMethod(request: IMyRequest): Promise<MyResponse>;
+
+    public $unknownFields?: ReadonlyArray<Uint8Array>;
 }
 
 export namespace MyService {
@@ -13,6 +16,8 @@ export namespace MyService {
 
 export interface IMyRequest {
     path?: (string|null);
+
+    $unknownFields?: ReadonlyArray<Uint8Array>;
 }
 
 export class MyRequest implements IMyRequest {
@@ -28,10 +33,14 @@ export class MyRequest implements IMyRequest {
     public static toObject(message: MyRequest, options?: $protobuf.IConversionOptions): { [k: string]: any };
     public toJSON(): { [k: string]: any };
     public static getTypeUrl(typeUrlPrefix?: string): string;
+
+    public $unknownFields?: ReadonlyArray<Uint8Array>;
 }
 
 export interface IMyResponse {
     status?: (number|null);
+
+    $unknownFields?: ReadonlyArray<Uint8Array>;
 }
 
 export class MyResponse implements IMyResponse {
@@ -47,4 +56,6 @@ export class MyResponse implements IMyResponse {
     public static toObject(message: MyResponse, options?: $protobuf.IConversionOptions): { [k: string]: any };
     public toJSON(): { [k: string]: any };
     public static getTypeUrl(typeUrlPrefix?: string): string;
+
+    public $unknownFields?: ReadonlyArray<Uint8Array>;
 }

--- a/tests/data/rpc.js
+++ b/tests/data/rpc.js
@@ -133,8 +133,19 @@ $root.MyRequest = (function() {
     MyRequest.encode = function encode(message, writer) {
         if (!writer)
             writer = $Writer.create();
+        var fullyUnknown = [];
+        if (message.$unknownFields && $root.MyRequest.decode)
+            for (var i = 0; i < message.$unknownFields.length; ++i)
+                try {
+                    var known = $root.MyRequest.decode(message.$unknownFields[i]);
+                    fullyUnknown = fullyUnknown.concat(known.$unknownFields || []);
+                    message = Object.assign(known, message);
+                } catch (_) {
+                }
         if (message.path != null && Object.hasOwnProperty.call(message, "path"))
             writer.uint32(/* id 1, wireType 2 =*/10).string(message.path);
+        for (var i = 0; i < fullyUnknown.length; ++i)
+            writer._unknownField(fullyUnknown[i]);
         return writer;
     };
 
@@ -167,13 +178,18 @@ $root.MyRequest = (function() {
             reader = $Reader.create(reader);
         var end = length === undefined ? reader.len : reader.pos + length, message = new $root.MyRequest();
         while (reader.pos < end) {
+            var unknownStartPos = reader.pos;
             var tag = reader.uint32();
             switch (tag >>> 3) {
-            case 1:
-                message.path = reader.string();
-                break;
+            case 1: {
+                    message.path = reader.string();
+                    break;
+                }
             default:
                 reader.skipType(tag & 7);
+                if (!message.$unknownFields)
+                    message.$unknownFields = [];
+                message.$unknownFields.push(reader.buf.slice(unknownStartPos, reader.pos));
                 break;
             }
         }
@@ -335,8 +351,19 @@ $root.MyResponse = (function() {
     MyResponse.encode = function encode(message, writer) {
         if (!writer)
             writer = $Writer.create();
+        var fullyUnknown = [];
+        if (message.$unknownFields && $root.MyResponse.decode)
+            for (var i = 0; i < message.$unknownFields.length; ++i)
+                try {
+                    var known = $root.MyResponse.decode(message.$unknownFields[i]);
+                    fullyUnknown = fullyUnknown.concat(known.$unknownFields || []);
+                    message = Object.assign(known, message);
+                } catch (_) {
+                }
         if (message.status != null && Object.hasOwnProperty.call(message, "status"))
             writer.uint32(/* id 2, wireType 0 =*/16).int32(message.status);
+        for (var i = 0; i < fullyUnknown.length; ++i)
+            writer._unknownField(fullyUnknown[i]);
         return writer;
     };
 
@@ -369,13 +396,18 @@ $root.MyResponse = (function() {
             reader = $Reader.create(reader);
         var end = length === undefined ? reader.len : reader.pos + length, message = new $root.MyResponse();
         while (reader.pos < end) {
+            var unknownStartPos = reader.pos;
             var tag = reader.uint32();
             switch (tag >>> 3) {
-            case 2:
-                message.status = reader.int32();
-                break;
+            case 2: {
+                    message.status = reader.int32();
+                    break;
+                }
             default:
                 reader.skipType(tag & 7);
+                if (!message.$unknownFields)
+                    message.$unknownFields = [];
+                message.$unknownFields.push(reader.buf.slice(unknownStartPos, reader.pos));
                 break;
             }
         }

--- a/tests/data/test.d.ts
+++ b/tests/data/test.d.ts
@@ -1,11 +1,12 @@
 import * as $protobuf from "../..";
-import Long from "long";
-
+import Long = require("long");
 export namespace jspb {
 
     namespace test {
 
         interface IEmpty {
+
+            $unknownFields?: ReadonlyArray<Uint8Array>;
         }
 
         class Empty implements IEmpty {
@@ -20,6 +21,8 @@ export namespace jspb {
             public static toObject(message: jspb.test.Empty, options?: $protobuf.IConversionOptions): { [k: string]: any };
             public toJSON(): { [k: string]: any };
             public static getTypeUrl(typeUrlPrefix?: string): string;
+
+            public $unknownFields?: ReadonlyArray<Uint8Array>;
         }
 
         enum OuterEnum {
@@ -29,6 +32,8 @@ export namespace jspb {
 
         interface IEnumContainer {
             outerEnum?: (jspb.test.OuterEnum|null);
+
+            $unknownFields?: ReadonlyArray<Uint8Array>;
         }
 
         class EnumContainer implements IEnumContainer {
@@ -44,12 +49,16 @@ export namespace jspb {
             public static toObject(message: jspb.test.EnumContainer, options?: $protobuf.IConversionOptions): { [k: string]: any };
             public toJSON(): { [k: string]: any };
             public static getTypeUrl(typeUrlPrefix?: string): string;
+
+            public $unknownFields?: ReadonlyArray<Uint8Array>;
         }
 
         interface ISimple1 {
             aString: string;
             aRepeatedString?: (string[]|null);
             aBoolean?: (boolean|null);
+
+            $unknownFields?: ReadonlyArray<Uint8Array>;
         }
 
         class Simple1 implements ISimple1 {
@@ -67,11 +76,15 @@ export namespace jspb {
             public static toObject(message: jspb.test.Simple1, options?: $protobuf.IConversionOptions): { [k: string]: any };
             public toJSON(): { [k: string]: any };
             public static getTypeUrl(typeUrlPrefix?: string): string;
+
+            public $unknownFields?: ReadonlyArray<Uint8Array>;
         }
 
         interface ISimple2 {
             aString: string;
             aRepeatedString?: (string[]|null);
+
+            $unknownFields?: ReadonlyArray<Uint8Array>;
         }
 
         class Simple2 implements ISimple2 {
@@ -88,6 +101,8 @@ export namespace jspb {
             public static toObject(message: jspb.test.Simple2, options?: $protobuf.IConversionOptions): { [k: string]: any };
             public toJSON(): { [k: string]: any };
             public static getTypeUrl(typeUrlPrefix?: string): string;
+
+            public $unknownFields?: ReadonlyArray<Uint8Array>;
         }
 
         interface ISpecialCases {
@@ -95,6 +110,8 @@ export namespace jspb {
             "default": string;
             "function": string;
             "var": string;
+
+            $unknownFields?: ReadonlyArray<Uint8Array>;
         }
 
         class SpecialCases implements ISpecialCases {
@@ -113,6 +130,8 @@ export namespace jspb {
             public static toObject(message: jspb.test.SpecialCases, options?: $protobuf.IConversionOptions): { [k: string]: any };
             public toJSON(): { [k: string]: any };
             public static getTypeUrl(typeUrlPrefix?: string): string;
+
+            public $unknownFields?: ReadonlyArray<Uint8Array>;
         }
 
         interface IOptionalFields {
@@ -121,6 +140,8 @@ export namespace jspb {
             aNestedMessage?: (jspb.test.OptionalFields.INested|null);
             aRepeatedMessage?: (jspb.test.OptionalFields.INested[]|null);
             aRepeatedString?: (string[]|null);
+
+            $unknownFields?: ReadonlyArray<Uint8Array>;
         }
 
         class OptionalFields implements IOptionalFields {
@@ -140,12 +161,16 @@ export namespace jspb {
             public static toObject(message: jspb.test.OptionalFields, options?: $protobuf.IConversionOptions): { [k: string]: any };
             public toJSON(): { [k: string]: any };
             public static getTypeUrl(typeUrlPrefix?: string): string;
+
+            public $unknownFields?: ReadonlyArray<Uint8Array>;
         }
 
         namespace OptionalFields {
 
             interface INested {
                 anInt?: (number|null);
+
+                $unknownFields?: ReadonlyArray<Uint8Array>;
             }
 
             class Nested implements INested {
@@ -161,6 +186,8 @@ export namespace jspb {
                 public static toObject(message: jspb.test.OptionalFields.Nested, options?: $protobuf.IConversionOptions): { [k: string]: any };
                 public toJSON(): { [k: string]: any };
                 public static getTypeUrl(typeUrlPrefix?: string): string;
+
+                public $unknownFields?: ReadonlyArray<Uint8Array>;
             }
         }
 
@@ -174,6 +201,8 @@ export namespace jspb {
             ".jspb.test.IndirectExtension.repeatedStr"?: (string[]|null);
             ".jspb.test.IndirectExtension.repeatedSimple"?: (jspb.test.ISimple1[]|null);
             ".jspb.test.simple1"?: (jspb.test.ISimple1|null);
+
+            $unknownFields?: ReadonlyArray<Uint8Array>;
         }
 
         class HasExtensions implements IHasExtensions {
@@ -191,6 +220,8 @@ export namespace jspb {
             public static toObject(message: jspb.test.HasExtensions, options?: $protobuf.IConversionOptions): { [k: string]: any };
             public toJSON(): { [k: string]: any };
             public static getTypeUrl(typeUrlPrefix?: string): string;
+
+            public $unknownFields?: ReadonlyArray<Uint8Array>;
         }
 
         interface IComplex {
@@ -199,6 +230,8 @@ export namespace jspb {
             aNestedMessage?: (jspb.test.Complex.INested|null);
             aRepeatedMessage?: (jspb.test.Complex.INested[]|null);
             aRepeatedString?: (string[]|null);
+
+            $unknownFields?: ReadonlyArray<Uint8Array>;
         }
 
         class Complex implements IComplex {
@@ -218,12 +251,16 @@ export namespace jspb {
             public static toObject(message: jspb.test.Complex, options?: $protobuf.IConversionOptions): { [k: string]: any };
             public toJSON(): { [k: string]: any };
             public static getTypeUrl(typeUrlPrefix?: string): string;
+
+            public $unknownFields?: ReadonlyArray<Uint8Array>;
         }
 
         namespace Complex {
 
             interface INested {
                 anInt: number;
+
+                $unknownFields?: ReadonlyArray<Uint8Array>;
             }
 
             class Nested implements INested {
@@ -239,10 +276,14 @@ export namespace jspb {
                 public static toObject(message: jspb.test.Complex.Nested, options?: $protobuf.IConversionOptions): { [k: string]: any };
                 public toJSON(): { [k: string]: any };
                 public static getTypeUrl(typeUrlPrefix?: string): string;
+
+                public $unknownFields?: ReadonlyArray<Uint8Array>;
             }
         }
 
         interface IOuterMessage {
+
+            $unknownFields?: ReadonlyArray<Uint8Array>;
         }
 
         class OuterMessage implements IOuterMessage {
@@ -257,12 +298,16 @@ export namespace jspb {
             public static toObject(message: jspb.test.OuterMessage, options?: $protobuf.IConversionOptions): { [k: string]: any };
             public toJSON(): { [k: string]: any };
             public static getTypeUrl(typeUrlPrefix?: string): string;
+
+            public $unknownFields?: ReadonlyArray<Uint8Array>;
         }
 
         namespace OuterMessage {
 
             interface IComplex {
                 innerComplexField?: (number|null);
+
+                $unknownFields?: ReadonlyArray<Uint8Array>;
             }
 
             class Complex implements IComplex {
@@ -278,11 +323,15 @@ export namespace jspb {
                 public static toObject(message: jspb.test.OuterMessage.Complex, options?: $protobuf.IConversionOptions): { [k: string]: any };
                 public toJSON(): { [k: string]: any };
                 public static getTypeUrl(typeUrlPrefix?: string): string;
+
+                public $unknownFields?: ReadonlyArray<Uint8Array>;
             }
         }
 
         interface IIsExtension {
             ext1?: (string|null);
+
+            $unknownFields?: ReadonlyArray<Uint8Array>;
         }
 
         class IsExtension implements IIsExtension {
@@ -298,9 +347,13 @@ export namespace jspb {
             public static toObject(message: jspb.test.IsExtension, options?: $protobuf.IConversionOptions): { [k: string]: any };
             public toJSON(): { [k: string]: any };
             public static getTypeUrl(typeUrlPrefix?: string): string;
+
+            public $unknownFields?: ReadonlyArray<Uint8Array>;
         }
 
         interface IIndirectExtension {
+
+            $unknownFields?: ReadonlyArray<Uint8Array>;
         }
 
         class IndirectExtension implements IIndirectExtension {
@@ -315,6 +368,8 @@ export namespace jspb {
             public static toObject(message: jspb.test.IndirectExtension, options?: $protobuf.IConversionOptions): { [k: string]: any };
             public toJSON(): { [k: string]: any };
             public static getTypeUrl(typeUrlPrefix?: string): string;
+
+            public $unknownFields?: ReadonlyArray<Uint8Array>;
         }
 
         interface IDefaultValues {
@@ -324,6 +379,8 @@ export namespace jspb {
             enumField?: (jspb.test.DefaultValues.Enum|null);
             emptyField?: (string|null);
             bytesField?: (Uint8Array|null);
+
+            $unknownFields?: ReadonlyArray<Uint8Array>;
         }
 
         class DefaultValues implements IDefaultValues {
@@ -344,6 +401,8 @@ export namespace jspb {
             public static toObject(message: jspb.test.DefaultValues, options?: $protobuf.IConversionOptions): { [k: string]: any };
             public toJSON(): { [k: string]: any };
             public static getTypeUrl(typeUrlPrefix?: string): string;
+
+            public $unknownFields?: ReadonlyArray<Uint8Array>;
         }
 
         namespace DefaultValues {
@@ -363,6 +422,8 @@ export namespace jspb {
             requiredDoubleField: number;
             repeatedDoubleField?: (number[]|null);
             defaultDoubleField?: (number|null);
+
+            $unknownFields?: ReadonlyArray<Uint8Array>;
         }
 
         class FloatingPointFields implements IFloatingPointFields {
@@ -385,6 +446,8 @@ export namespace jspb {
             public static toObject(message: jspb.test.FloatingPointFields, options?: $protobuf.IConversionOptions): { [k: string]: any };
             public toJSON(): { [k: string]: any };
             public static getTypeUrl(typeUrlPrefix?: string): string;
+
+            public $unknownFields?: ReadonlyArray<Uint8Array>;
         }
 
         interface ITestClone {
@@ -394,6 +457,8 @@ export namespace jspb {
             bytesField?: (Uint8Array|null);
             unused?: (string|null);
             ".jspb.test.CloneExtension.extField"?: (jspb.test.ICloneExtension|null);
+
+            $unknownFields?: ReadonlyArray<Uint8Array>;
         }
 
         class TestClone implements ITestClone {
@@ -413,10 +478,14 @@ export namespace jspb {
             public static toObject(message: jspb.test.TestClone, options?: $protobuf.IConversionOptions): { [k: string]: any };
             public toJSON(): { [k: string]: any };
             public static getTypeUrl(typeUrlPrefix?: string): string;
+
+            public $unknownFields?: ReadonlyArray<Uint8Array>;
         }
 
         interface ICloneExtension {
             ext?: (string|null);
+
+            $unknownFields?: ReadonlyArray<Uint8Array>;
         }
 
         class CloneExtension implements ICloneExtension {
@@ -432,15 +501,21 @@ export namespace jspb {
             public static toObject(message: jspb.test.CloneExtension, options?: $protobuf.IConversionOptions): { [k: string]: any };
             public toJSON(): { [k: string]: any };
             public static getTypeUrl(typeUrlPrefix?: string): string;
+
+            public $unknownFields?: ReadonlyArray<Uint8Array>;
         }
 
         interface ITestGroup {
             repeatedGroup?: (jspb.test.TestGroup.IRepeatedGroup[]|null);
             requiredGroup: jspb.test.TestGroup.IRequiredGroup;
             optionalGroup?: (jspb.test.TestGroup.IOptionalGroup|null);
+            messageInGroup?: (jspb.test.TestGroup.IMessageInGroup|null);
+            enumInGroup?: (jspb.test.TestGroup.IEnumInGroup|null);
             id?: (string|null);
             requiredSimple: jspb.test.ISimple2;
             optionalSimple?: (jspb.test.ISimple2|null);
+
+            $unknownFields?: ReadonlyArray<Uint8Array>;
         }
 
         class TestGroup implements ITestGroup {
@@ -448,6 +523,8 @@ export namespace jspb {
             public repeatedGroup: jspb.test.TestGroup.IRepeatedGroup[];
             public requiredGroup: jspb.test.TestGroup.IRequiredGroup;
             public optionalGroup?: (jspb.test.TestGroup.IOptionalGroup|null);
+            public messageInGroup?: (jspb.test.TestGroup.IMessageInGroup|null);
+            public enumInGroup?: (jspb.test.TestGroup.IEnumInGroup|null);
             public id: string;
             public requiredSimple: jspb.test.ISimple2;
             public optionalSimple?: (jspb.test.ISimple2|null);
@@ -461,6 +538,8 @@ export namespace jspb {
             public static toObject(message: jspb.test.TestGroup, options?: $protobuf.IConversionOptions): { [k: string]: any };
             public toJSON(): { [k: string]: any };
             public static getTypeUrl(typeUrlPrefix?: string): string;
+
+            public $unknownFields?: ReadonlyArray<Uint8Array>;
         }
 
         namespace TestGroup {
@@ -468,6 +547,8 @@ export namespace jspb {
             interface IRepeatedGroup {
                 id: string;
                 someBool?: (boolean[]|null);
+
+                $unknownFields?: ReadonlyArray<Uint8Array>;
             }
 
             class RepeatedGroup implements IRepeatedGroup {
@@ -484,10 +565,14 @@ export namespace jspb {
                 public static toObject(message: jspb.test.TestGroup.RepeatedGroup, options?: $protobuf.IConversionOptions): { [k: string]: any };
                 public toJSON(): { [k: string]: any };
                 public static getTypeUrl(typeUrlPrefix?: string): string;
+
+                public $unknownFields?: ReadonlyArray<Uint8Array>;
             }
 
             interface IRequiredGroup {
                 id: string;
+
+                $unknownFields?: ReadonlyArray<Uint8Array>;
             }
 
             class RequiredGroup implements IRequiredGroup {
@@ -503,10 +588,14 @@ export namespace jspb {
                 public static toObject(message: jspb.test.TestGroup.RequiredGroup, options?: $protobuf.IConversionOptions): { [k: string]: any };
                 public toJSON(): { [k: string]: any };
                 public static getTypeUrl(typeUrlPrefix?: string): string;
+
+                public $unknownFields?: ReadonlyArray<Uint8Array>;
             }
 
             interface IOptionalGroup {
                 id: string;
+
+                $unknownFields?: ReadonlyArray<Uint8Array>;
             }
 
             class OptionalGroup implements IOptionalGroup {
@@ -522,11 +611,95 @@ export namespace jspb {
                 public static toObject(message: jspb.test.TestGroup.OptionalGroup, options?: $protobuf.IConversionOptions): { [k: string]: any };
                 public toJSON(): { [k: string]: any };
                 public static getTypeUrl(typeUrlPrefix?: string): string;
+
+                public $unknownFields?: ReadonlyArray<Uint8Array>;
+            }
+
+            interface IMessageInGroup {
+                id: jspb.test.TestGroup.MessageInGroup.INestedMessage;
+
+                $unknownFields?: ReadonlyArray<Uint8Array>;
+            }
+
+            class MessageInGroup implements IMessageInGroup {
+                constructor(properties?: jspb.test.TestGroup.IMessageInGroup);
+                public id: jspb.test.TestGroup.MessageInGroup.INestedMessage;
+                public static create(properties?: jspb.test.TestGroup.IMessageInGroup): jspb.test.TestGroup.MessageInGroup;
+                public static encode(message: jspb.test.TestGroup.IMessageInGroup, writer?: $protobuf.Writer): $protobuf.Writer;
+                public static encodeDelimited(message: jspb.test.TestGroup.IMessageInGroup, writer?: $protobuf.Writer): $protobuf.Writer;
+                public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): jspb.test.TestGroup.MessageInGroup;
+                public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): jspb.test.TestGroup.MessageInGroup;
+                public static verify(message: { [k: string]: any }): (string|null);
+                public static fromObject(object: { [k: string]: any }): jspb.test.TestGroup.MessageInGroup;
+                public static toObject(message: jspb.test.TestGroup.MessageInGroup, options?: $protobuf.IConversionOptions): { [k: string]: any };
+                public toJSON(): { [k: string]: any };
+                public static getTypeUrl(typeUrlPrefix?: string): string;
+
+                public $unknownFields?: ReadonlyArray<Uint8Array>;
+            }
+
+            namespace MessageInGroup {
+
+                interface INestedMessage {
+                    id?: (string|null);
+
+                    $unknownFields?: ReadonlyArray<Uint8Array>;
+                }
+
+                class NestedMessage implements INestedMessage {
+                    constructor(properties?: jspb.test.TestGroup.MessageInGroup.INestedMessage);
+                    public id: string;
+                    public static create(properties?: jspb.test.TestGroup.MessageInGroup.INestedMessage): jspb.test.TestGroup.MessageInGroup.NestedMessage;
+                    public static encode(message: jspb.test.TestGroup.MessageInGroup.INestedMessage, writer?: $protobuf.Writer): $protobuf.Writer;
+                    public static encodeDelimited(message: jspb.test.TestGroup.MessageInGroup.INestedMessage, writer?: $protobuf.Writer): $protobuf.Writer;
+                    public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): jspb.test.TestGroup.MessageInGroup.NestedMessage;
+                    public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): jspb.test.TestGroup.MessageInGroup.NestedMessage;
+                    public static verify(message: { [k: string]: any }): (string|null);
+                    public static fromObject(object: { [k: string]: any }): jspb.test.TestGroup.MessageInGroup.NestedMessage;
+                    public static toObject(message: jspb.test.TestGroup.MessageInGroup.NestedMessage, options?: $protobuf.IConversionOptions): { [k: string]: any };
+                    public toJSON(): { [k: string]: any };
+                    public static getTypeUrl(typeUrlPrefix?: string): string;
+
+                    public $unknownFields?: ReadonlyArray<Uint8Array>;
+                }
+            }
+
+            interface IEnumInGroup {
+                id: jspb.test.TestGroup.EnumInGroup.NestedEnum;
+
+                $unknownFields?: ReadonlyArray<Uint8Array>;
+            }
+
+            class EnumInGroup implements IEnumInGroup {
+                constructor(properties?: jspb.test.TestGroup.IEnumInGroup);
+                public id: jspb.test.TestGroup.EnumInGroup.NestedEnum;
+                public static create(properties?: jspb.test.TestGroup.IEnumInGroup): jspb.test.TestGroup.EnumInGroup;
+                public static encode(message: jspb.test.TestGroup.IEnumInGroup, writer?: $protobuf.Writer): $protobuf.Writer;
+                public static encodeDelimited(message: jspb.test.TestGroup.IEnumInGroup, writer?: $protobuf.Writer): $protobuf.Writer;
+                public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): jspb.test.TestGroup.EnumInGroup;
+                public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): jspb.test.TestGroup.EnumInGroup;
+                public static verify(message: { [k: string]: any }): (string|null);
+                public static fromObject(object: { [k: string]: any }): jspb.test.TestGroup.EnumInGroup;
+                public static toObject(message: jspb.test.TestGroup.EnumInGroup, options?: $protobuf.IConversionOptions): { [k: string]: any };
+                public toJSON(): { [k: string]: any };
+                public static getTypeUrl(typeUrlPrefix?: string): string;
+
+                public $unknownFields?: ReadonlyArray<Uint8Array>;
+            }
+
+            namespace EnumInGroup {
+
+                enum NestedEnum {
+                    first = 0,
+                    second = 1
+                }
             }
         }
 
         interface ITestGroup1 {
             group?: (jspb.test.TestGroup.IRepeatedGroup|null);
+
+            $unknownFields?: ReadonlyArray<Uint8Array>;
         }
 
         class TestGroup1 implements ITestGroup1 {
@@ -542,11 +715,15 @@ export namespace jspb {
             public static toObject(message: jspb.test.TestGroup1, options?: $protobuf.IConversionOptions): { [k: string]: any };
             public toJSON(): { [k: string]: any };
             public static getTypeUrl(typeUrlPrefix?: string): string;
+
+            public $unknownFields?: ReadonlyArray<Uint8Array>;
         }
 
         interface ITestReservedNames {
             extension?: (number|null);
             ".jspb.test.TestReservedNamesExtension.foo"?: (number|null);
+
+            $unknownFields?: ReadonlyArray<Uint8Array>;
         }
 
         class TestReservedNames implements ITestReservedNames {
@@ -562,9 +739,13 @@ export namespace jspb {
             public static toObject(message: jspb.test.TestReservedNames, options?: $protobuf.IConversionOptions): { [k: string]: any };
             public toJSON(): { [k: string]: any };
             public static getTypeUrl(typeUrlPrefix?: string): string;
+
+            public $unknownFields?: ReadonlyArray<Uint8Array>;
         }
 
         interface ITestReservedNamesExtension {
+
+            $unknownFields?: ReadonlyArray<Uint8Array>;
         }
 
         class TestReservedNamesExtension implements ITestReservedNamesExtension {
@@ -579,6 +760,8 @@ export namespace jspb {
             public static toObject(message: jspb.test.TestReservedNamesExtension, options?: $protobuf.IConversionOptions): { [k: string]: any };
             public toJSON(): { [k: string]: any };
             public static getTypeUrl(typeUrlPrefix?: string): string;
+
+            public $unknownFields?: ReadonlyArray<Uint8Array>;
         }
 
         interface ITestMessageWithOneof {
@@ -592,6 +775,8 @@ export namespace jspb {
             atwo?: (number|null);
             bone?: (number|null);
             btwo?: (number|null);
+
+            $unknownFields?: ReadonlyArray<Uint8Array>;
         }
 
         class TestMessageWithOneof implements ITestMessageWithOneof {
@@ -620,11 +805,15 @@ export namespace jspb {
             public static toObject(message: jspb.test.TestMessageWithOneof, options?: $protobuf.IConversionOptions): { [k: string]: any };
             public toJSON(): { [k: string]: any };
             public static getTypeUrl(typeUrlPrefix?: string): string;
+
+            public $unknownFields?: ReadonlyArray<Uint8Array>;
         }
 
         interface ITestEndsWithBytes {
             value?: (number|null);
             data?: (Uint8Array|null);
+
+            $unknownFields?: ReadonlyArray<Uint8Array>;
         }
 
         class TestEndsWithBytes implements ITestEndsWithBytes {
@@ -641,6 +830,8 @@ export namespace jspb {
             public static toObject(message: jspb.test.TestEndsWithBytes, options?: $protobuf.IConversionOptions): { [k: string]: any };
             public toJSON(): { [k: string]: any };
             public static getTypeUrl(typeUrlPrefix?: string): string;
+
+            public $unknownFields?: ReadonlyArray<Uint8Array>;
         }
 
         interface ITestMapFieldsNoBinary {
@@ -656,6 +847,8 @@ export namespace jspb {
             mapBoolString?: ({ [k: string]: string }|null);
             testMapFields?: (jspb.test.ITestMapFieldsNoBinary|null);
             mapStringTestmapfields?: ({ [k: string]: jspb.test.ITestMapFieldsNoBinary }|null);
+
+            $unknownFields?: ReadonlyArray<Uint8Array>;
         }
 
         class TestMapFieldsNoBinary implements ITestMapFieldsNoBinary {
@@ -682,6 +875,8 @@ export namespace jspb {
             public static toObject(message: jspb.test.TestMapFieldsNoBinary, options?: $protobuf.IConversionOptions): { [k: string]: any };
             public toJSON(): { [k: string]: any };
             public static getTypeUrl(typeUrlPrefix?: string): string;
+
+            public $unknownFields?: ReadonlyArray<Uint8Array>;
         }
 
         enum MapValueEnumNoBinary {
@@ -692,6 +887,8 @@ export namespace jspb {
 
         interface IMapValueMessageNoBinary {
             foo?: (number|null);
+
+            $unknownFields?: ReadonlyArray<Uint8Array>;
         }
 
         class MapValueMessageNoBinary implements IMapValueMessageNoBinary {
@@ -707,9 +904,13 @@ export namespace jspb {
             public static toObject(message: jspb.test.MapValueMessageNoBinary, options?: $protobuf.IConversionOptions): { [k: string]: any };
             public toJSON(): { [k: string]: any };
             public static getTypeUrl(typeUrlPrefix?: string): string;
+
+            public $unknownFields?: ReadonlyArray<Uint8Array>;
         }
 
         interface IDeeply {
+
+            $unknownFields?: ReadonlyArray<Uint8Array>;
         }
 
         class Deeply implements IDeeply {
@@ -724,11 +925,15 @@ export namespace jspb {
             public static toObject(message: jspb.test.Deeply, options?: $protobuf.IConversionOptions): { [k: string]: any };
             public toJSON(): { [k: string]: any };
             public static getTypeUrl(typeUrlPrefix?: string): string;
+
+            public $unknownFields?: ReadonlyArray<Uint8Array>;
         }
 
         namespace Deeply {
 
             interface INested {
+
+                $unknownFields?: ReadonlyArray<Uint8Array>;
             }
 
             class Nested implements INested {
@@ -743,12 +948,16 @@ export namespace jspb {
                 public static toObject(message: jspb.test.Deeply.Nested, options?: $protobuf.IConversionOptions): { [k: string]: any };
                 public toJSON(): { [k: string]: any };
                 public static getTypeUrl(typeUrlPrefix?: string): string;
+
+                public $unknownFields?: ReadonlyArray<Uint8Array>;
             }
 
             namespace Nested {
 
                 interface IMessage {
                     count?: (number|null);
+
+                    $unknownFields?: ReadonlyArray<Uint8Array>;
                 }
 
                 class Message implements IMessage {
@@ -764,6 +973,8 @@ export namespace jspb {
                     public static toObject(message: jspb.test.Deeply.Nested.Message, options?: $protobuf.IConversionOptions): { [k: string]: any };
                     public toJSON(): { [k: string]: any };
                     public static getTypeUrl(typeUrlPrefix?: string): string;
+
+                    public $unknownFields?: ReadonlyArray<Uint8Array>;
                 }
             }
         }
@@ -776,6 +987,8 @@ export namespace google {
 
         interface IFileDescriptorSet {
             file?: (google.protobuf.IFileDescriptorProto[]|null);
+
+            $unknownFields?: ReadonlyArray<Uint8Array>;
         }
 
         class FileDescriptorSet implements IFileDescriptorSet {
@@ -791,6 +1004,8 @@ export namespace google {
             public static toObject(message: google.protobuf.FileDescriptorSet, options?: $protobuf.IConversionOptions): { [k: string]: any };
             public toJSON(): { [k: string]: any };
             public static getTypeUrl(typeUrlPrefix?: string): string;
+
+            public $unknownFields?: ReadonlyArray<Uint8Array>;
         }
 
         interface IFileDescriptorProto {
@@ -806,6 +1021,8 @@ export namespace google {
             options?: (google.protobuf.IFileOptions|null);
             sourceCodeInfo?: (google.protobuf.ISourceCodeInfo|null);
             syntax?: (string|null);
+
+            $unknownFields?: ReadonlyArray<Uint8Array>;
         }
 
         class FileDescriptorProto implements IFileDescriptorProto {
@@ -832,6 +1049,8 @@ export namespace google {
             public static toObject(message: google.protobuf.FileDescriptorProto, options?: $protobuf.IConversionOptions): { [k: string]: any };
             public toJSON(): { [k: string]: any };
             public static getTypeUrl(typeUrlPrefix?: string): string;
+
+            public $unknownFields?: ReadonlyArray<Uint8Array>;
         }
 
         interface IDescriptorProto {
@@ -845,6 +1064,8 @@ export namespace google {
             options?: (google.protobuf.IMessageOptions|null);
             reservedRange?: (google.protobuf.DescriptorProto.IReservedRange[]|null);
             reservedName?: (string[]|null);
+
+            $unknownFields?: ReadonlyArray<Uint8Array>;
         }
 
         class DescriptorProto implements IDescriptorProto {
@@ -869,6 +1090,8 @@ export namespace google {
             public static toObject(message: google.protobuf.DescriptorProto, options?: $protobuf.IConversionOptions): { [k: string]: any };
             public toJSON(): { [k: string]: any };
             public static getTypeUrl(typeUrlPrefix?: string): string;
+
+            public $unknownFields?: ReadonlyArray<Uint8Array>;
         }
 
         namespace DescriptorProto {
@@ -876,6 +1099,8 @@ export namespace google {
             interface IExtensionRange {
                 start?: (number|null);
                 end?: (number|null);
+
+                $unknownFields?: ReadonlyArray<Uint8Array>;
             }
 
             class ExtensionRange implements IExtensionRange {
@@ -892,11 +1117,15 @@ export namespace google {
                 public static toObject(message: google.protobuf.DescriptorProto.ExtensionRange, options?: $protobuf.IConversionOptions): { [k: string]: any };
                 public toJSON(): { [k: string]: any };
                 public static getTypeUrl(typeUrlPrefix?: string): string;
+
+                public $unknownFields?: ReadonlyArray<Uint8Array>;
             }
 
             interface IReservedRange {
                 start?: (number|null);
                 end?: (number|null);
+
+                $unknownFields?: ReadonlyArray<Uint8Array>;
             }
 
             class ReservedRange implements IReservedRange {
@@ -913,6 +1142,8 @@ export namespace google {
                 public static toObject(message: google.protobuf.DescriptorProto.ReservedRange, options?: $protobuf.IConversionOptions): { [k: string]: any };
                 public toJSON(): { [k: string]: any };
                 public static getTypeUrl(typeUrlPrefix?: string): string;
+
+                public $unknownFields?: ReadonlyArray<Uint8Array>;
             }
         }
 
@@ -927,6 +1158,8 @@ export namespace google {
             oneofIndex?: (number|null);
             jsonName?: (string|null);
             options?: (google.protobuf.IFieldOptions|null);
+
+            $unknownFields?: ReadonlyArray<Uint8Array>;
         }
 
         class FieldDescriptorProto implements IFieldDescriptorProto {
@@ -951,6 +1184,8 @@ export namespace google {
             public static toObject(message: google.protobuf.FieldDescriptorProto, options?: $protobuf.IConversionOptions): { [k: string]: any };
             public toJSON(): { [k: string]: any };
             public static getTypeUrl(typeUrlPrefix?: string): string;
+
+            public $unknownFields?: ReadonlyArray<Uint8Array>;
         }
 
         namespace FieldDescriptorProto {
@@ -986,6 +1221,8 @@ export namespace google {
         interface IOneofDescriptorProto {
             name?: (string|null);
             options?: (google.protobuf.IOneofOptions|null);
+
+            $unknownFields?: ReadonlyArray<Uint8Array>;
         }
 
         class OneofDescriptorProto implements IOneofDescriptorProto {
@@ -1002,12 +1239,16 @@ export namespace google {
             public static toObject(message: google.protobuf.OneofDescriptorProto, options?: $protobuf.IConversionOptions): { [k: string]: any };
             public toJSON(): { [k: string]: any };
             public static getTypeUrl(typeUrlPrefix?: string): string;
+
+            public $unknownFields?: ReadonlyArray<Uint8Array>;
         }
 
         interface IEnumDescriptorProto {
             name?: (string|null);
             value?: (google.protobuf.IEnumValueDescriptorProto[]|null);
             options?: (google.protobuf.IEnumOptions|null);
+
+            $unknownFields?: ReadonlyArray<Uint8Array>;
         }
 
         class EnumDescriptorProto implements IEnumDescriptorProto {
@@ -1025,12 +1266,16 @@ export namespace google {
             public static toObject(message: google.protobuf.EnumDescriptorProto, options?: $protobuf.IConversionOptions): { [k: string]: any };
             public toJSON(): { [k: string]: any };
             public static getTypeUrl(typeUrlPrefix?: string): string;
+
+            public $unknownFields?: ReadonlyArray<Uint8Array>;
         }
 
         interface IEnumValueDescriptorProto {
             name?: (string|null);
             number?: (number|null);
             options?: (google.protobuf.IEnumValueOptions|null);
+
+            $unknownFields?: ReadonlyArray<Uint8Array>;
         }
 
         class EnumValueDescriptorProto implements IEnumValueDescriptorProto {
@@ -1048,12 +1293,16 @@ export namespace google {
             public static toObject(message: google.protobuf.EnumValueDescriptorProto, options?: $protobuf.IConversionOptions): { [k: string]: any };
             public toJSON(): { [k: string]: any };
             public static getTypeUrl(typeUrlPrefix?: string): string;
+
+            public $unknownFields?: ReadonlyArray<Uint8Array>;
         }
 
         interface IServiceDescriptorProto {
             name?: (string|null);
             method?: (google.protobuf.IMethodDescriptorProto[]|null);
             options?: (google.protobuf.IServiceOptions|null);
+
+            $unknownFields?: ReadonlyArray<Uint8Array>;
         }
 
         class ServiceDescriptorProto implements IServiceDescriptorProto {
@@ -1071,6 +1320,8 @@ export namespace google {
             public static toObject(message: google.protobuf.ServiceDescriptorProto, options?: $protobuf.IConversionOptions): { [k: string]: any };
             public toJSON(): { [k: string]: any };
             public static getTypeUrl(typeUrlPrefix?: string): string;
+
+            public $unknownFields?: ReadonlyArray<Uint8Array>;
         }
 
         interface IMethodDescriptorProto {
@@ -1080,6 +1331,8 @@ export namespace google {
             options?: (google.protobuf.IMethodOptions|null);
             clientStreaming?: (boolean|null);
             serverStreaming?: (boolean|null);
+
+            $unknownFields?: ReadonlyArray<Uint8Array>;
         }
 
         class MethodDescriptorProto implements IMethodDescriptorProto {
@@ -1100,6 +1353,8 @@ export namespace google {
             public static toObject(message: google.protobuf.MethodDescriptorProto, options?: $protobuf.IConversionOptions): { [k: string]: any };
             public toJSON(): { [k: string]: any };
             public static getTypeUrl(typeUrlPrefix?: string): string;
+
+            public $unknownFields?: ReadonlyArray<Uint8Array>;
         }
 
         interface IFileOptions {
@@ -1118,6 +1373,8 @@ export namespace google {
             objcClassPrefix?: (string|null);
             csharpNamespace?: (string|null);
             uninterpretedOption?: (google.protobuf.IUninterpretedOption[]|null);
+
+            $unknownFields?: ReadonlyArray<Uint8Array>;
         }
 
         class FileOptions implements IFileOptions {
@@ -1147,6 +1404,8 @@ export namespace google {
             public static toObject(message: google.protobuf.FileOptions, options?: $protobuf.IConversionOptions): { [k: string]: any };
             public toJSON(): { [k: string]: any };
             public static getTypeUrl(typeUrlPrefix?: string): string;
+
+            public $unknownFields?: ReadonlyArray<Uint8Array>;
         }
 
         namespace FileOptions {
@@ -1164,6 +1423,8 @@ export namespace google {
             deprecated?: (boolean|null);
             mapEntry?: (boolean|null);
             uninterpretedOption?: (google.protobuf.IUninterpretedOption[]|null);
+
+            $unknownFields?: ReadonlyArray<Uint8Array>;
         }
 
         class MessageOptions implements IMessageOptions {
@@ -1183,6 +1444,8 @@ export namespace google {
             public static toObject(message: google.protobuf.MessageOptions, options?: $protobuf.IConversionOptions): { [k: string]: any };
             public toJSON(): { [k: string]: any };
             public static getTypeUrl(typeUrlPrefix?: string): string;
+
+            public $unknownFields?: ReadonlyArray<Uint8Array>;
         }
 
         interface IFieldOptions {
@@ -1193,6 +1456,8 @@ export namespace google {
             deprecated?: (boolean|null);
             weak?: (boolean|null);
             uninterpretedOption?: (google.protobuf.IUninterpretedOption[]|null);
+
+            $unknownFields?: ReadonlyArray<Uint8Array>;
         }
 
         class FieldOptions implements IFieldOptions {
@@ -1214,6 +1479,8 @@ export namespace google {
             public static toObject(message: google.protobuf.FieldOptions, options?: $protobuf.IConversionOptions): { [k: string]: any };
             public toJSON(): { [k: string]: any };
             public static getTypeUrl(typeUrlPrefix?: string): string;
+
+            public $unknownFields?: ReadonlyArray<Uint8Array>;
         }
 
         namespace FieldOptions {
@@ -1233,6 +1500,8 @@ export namespace google {
 
         interface IOneofOptions {
             uninterpretedOption?: (google.protobuf.IUninterpretedOption[]|null);
+
+            $unknownFields?: ReadonlyArray<Uint8Array>;
         }
 
         class OneofOptions implements IOneofOptions {
@@ -1248,6 +1517,8 @@ export namespace google {
             public static toObject(message: google.protobuf.OneofOptions, options?: $protobuf.IConversionOptions): { [k: string]: any };
             public toJSON(): { [k: string]: any };
             public static getTypeUrl(typeUrlPrefix?: string): string;
+
+            public $unknownFields?: ReadonlyArray<Uint8Array>;
         }
 
         interface IEnumOptions {
@@ -1255,6 +1526,8 @@ export namespace google {
             deprecated?: (boolean|null);
             uninterpretedOption?: (google.protobuf.IUninterpretedOption[]|null);
             ".jspb.test.IsExtension.simpleOption"?: (string|null);
+
+            $unknownFields?: ReadonlyArray<Uint8Array>;
         }
 
         class EnumOptions implements IEnumOptions {
@@ -1272,11 +1545,15 @@ export namespace google {
             public static toObject(message: google.protobuf.EnumOptions, options?: $protobuf.IConversionOptions): { [k: string]: any };
             public toJSON(): { [k: string]: any };
             public static getTypeUrl(typeUrlPrefix?: string): string;
+
+            public $unknownFields?: ReadonlyArray<Uint8Array>;
         }
 
         interface IEnumValueOptions {
             deprecated?: (boolean|null);
             uninterpretedOption?: (google.protobuf.IUninterpretedOption[]|null);
+
+            $unknownFields?: ReadonlyArray<Uint8Array>;
         }
 
         class EnumValueOptions implements IEnumValueOptions {
@@ -1293,11 +1570,15 @@ export namespace google {
             public static toObject(message: google.protobuf.EnumValueOptions, options?: $protobuf.IConversionOptions): { [k: string]: any };
             public toJSON(): { [k: string]: any };
             public static getTypeUrl(typeUrlPrefix?: string): string;
+
+            public $unknownFields?: ReadonlyArray<Uint8Array>;
         }
 
         interface IServiceOptions {
             deprecated?: (boolean|null);
             uninterpretedOption?: (google.protobuf.IUninterpretedOption[]|null);
+
+            $unknownFields?: ReadonlyArray<Uint8Array>;
         }
 
         class ServiceOptions implements IServiceOptions {
@@ -1314,12 +1595,16 @@ export namespace google {
             public static toObject(message: google.protobuf.ServiceOptions, options?: $protobuf.IConversionOptions): { [k: string]: any };
             public toJSON(): { [k: string]: any };
             public static getTypeUrl(typeUrlPrefix?: string): string;
+
+            public $unknownFields?: ReadonlyArray<Uint8Array>;
         }
 
         interface IMethodOptions {
             deprecated?: (boolean|null);
             idempotencyLevel?: (google.protobuf.MethodOptions.IdempotencyLevel|null);
             uninterpretedOption?: (google.protobuf.IUninterpretedOption[]|null);
+
+            $unknownFields?: ReadonlyArray<Uint8Array>;
         }
 
         class MethodOptions implements IMethodOptions {
@@ -1337,6 +1622,8 @@ export namespace google {
             public static toObject(message: google.protobuf.MethodOptions, options?: $protobuf.IConversionOptions): { [k: string]: any };
             public toJSON(): { [k: string]: any };
             public static getTypeUrl(typeUrlPrefix?: string): string;
+
+            public $unknownFields?: ReadonlyArray<Uint8Array>;
         }
 
         namespace MethodOptions {
@@ -1356,6 +1643,8 @@ export namespace google {
             doubleValue?: (number|null);
             stringValue?: (Uint8Array|null);
             aggregateValue?: (string|null);
+
+            $unknownFields?: ReadonlyArray<Uint8Array>;
         }
 
         class UninterpretedOption implements IUninterpretedOption {
@@ -1377,6 +1666,8 @@ export namespace google {
             public static toObject(message: google.protobuf.UninterpretedOption, options?: $protobuf.IConversionOptions): { [k: string]: any };
             public toJSON(): { [k: string]: any };
             public static getTypeUrl(typeUrlPrefix?: string): string;
+
+            public $unknownFields?: ReadonlyArray<Uint8Array>;
         }
 
         namespace UninterpretedOption {
@@ -1384,6 +1675,8 @@ export namespace google {
             interface INamePart {
                 namePart: string;
                 isExtension: boolean;
+
+                $unknownFields?: ReadonlyArray<Uint8Array>;
             }
 
             class NamePart implements INamePart {
@@ -1400,11 +1693,15 @@ export namespace google {
                 public static toObject(message: google.protobuf.UninterpretedOption.NamePart, options?: $protobuf.IConversionOptions): { [k: string]: any };
                 public toJSON(): { [k: string]: any };
                 public static getTypeUrl(typeUrlPrefix?: string): string;
+
+                public $unknownFields?: ReadonlyArray<Uint8Array>;
             }
         }
 
         interface ISourceCodeInfo {
             location?: (google.protobuf.SourceCodeInfo.ILocation[]|null);
+
+            $unknownFields?: ReadonlyArray<Uint8Array>;
         }
 
         class SourceCodeInfo implements ISourceCodeInfo {
@@ -1420,6 +1717,8 @@ export namespace google {
             public static toObject(message: google.protobuf.SourceCodeInfo, options?: $protobuf.IConversionOptions): { [k: string]: any };
             public toJSON(): { [k: string]: any };
             public static getTypeUrl(typeUrlPrefix?: string): string;
+
+            public $unknownFields?: ReadonlyArray<Uint8Array>;
         }
 
         namespace SourceCodeInfo {
@@ -1430,6 +1729,8 @@ export namespace google {
                 leadingComments?: (string|null);
                 trailingComments?: (string|null);
                 leadingDetachedComments?: (string[]|null);
+
+                $unknownFields?: ReadonlyArray<Uint8Array>;
             }
 
             class Location implements ILocation {
@@ -1449,11 +1750,15 @@ export namespace google {
                 public static toObject(message: google.protobuf.SourceCodeInfo.Location, options?: $protobuf.IConversionOptions): { [k: string]: any };
                 public toJSON(): { [k: string]: any };
                 public static getTypeUrl(typeUrlPrefix?: string): string;
+
+                public $unknownFields?: ReadonlyArray<Uint8Array>;
             }
         }
 
         interface IGeneratedCodeInfo {
             annotation?: (google.protobuf.GeneratedCodeInfo.IAnnotation[]|null);
+
+            $unknownFields?: ReadonlyArray<Uint8Array>;
         }
 
         class GeneratedCodeInfo implements IGeneratedCodeInfo {
@@ -1469,6 +1774,8 @@ export namespace google {
             public static toObject(message: google.protobuf.GeneratedCodeInfo, options?: $protobuf.IConversionOptions): { [k: string]: any };
             public toJSON(): { [k: string]: any };
             public static getTypeUrl(typeUrlPrefix?: string): string;
+
+            public $unknownFields?: ReadonlyArray<Uint8Array>;
         }
 
         namespace GeneratedCodeInfo {
@@ -1478,6 +1785,8 @@ export namespace google {
                 sourceFile?: (string|null);
                 begin?: (number|null);
                 end?: (number|null);
+
+                $unknownFields?: ReadonlyArray<Uint8Array>;
             }
 
             class Annotation implements IAnnotation {
@@ -1496,6 +1805,8 @@ export namespace google {
                 public static toObject(message: google.protobuf.GeneratedCodeInfo.Annotation, options?: $protobuf.IConversionOptions): { [k: string]: any };
                 public toJSON(): { [k: string]: any };
                 public static getTypeUrl(typeUrlPrefix?: string): string;
+
+                public $unknownFields?: ReadonlyArray<Uint8Array>;
             }
         }
     }

--- a/tests/data/test.js
+++ b/tests/data/test.js
@@ -74,6 +74,17 @@ $root.jspb = (function() {
             Empty.encode = function encode(message, writer) {
                 if (!writer)
                     writer = $Writer.create();
+                var fullyUnknown = [];
+                if (message.$unknownFields && $root.jspb.test.Empty.decode)
+                    for (var i = 0; i < message.$unknownFields.length; ++i)
+                        try {
+                            var known = $root.jspb.test.Empty.decode(message.$unknownFields[i]);
+                            fullyUnknown = fullyUnknown.concat(known.$unknownFields || []);
+                            message = Object.assign(known, message);
+                        } catch (_) {
+                        }
+                for (var i = 0; i < fullyUnknown.length; ++i)
+                    writer._unknownField(fullyUnknown[i]);
                 return writer;
             };
 
@@ -106,10 +117,14 @@ $root.jspb = (function() {
                     reader = $Reader.create(reader);
                 var end = length === undefined ? reader.len : reader.pos + length, message = new $root.jspb.test.Empty();
                 while (reader.pos < end) {
+                    var unknownStartPos = reader.pos;
                     var tag = reader.uint32();
                     switch (tag >>> 3) {
                     default:
                         reader.skipType(tag & 7);
+                        if (!message.$unknownFields)
+                            message.$unknownFields = [];
+                        message.$unknownFields.push(reader.buf.slice(unknownStartPos, reader.pos));
                         break;
                     }
                 }
@@ -272,8 +287,19 @@ $root.jspb = (function() {
             EnumContainer.encode = function encode(message, writer) {
                 if (!writer)
                     writer = $Writer.create();
+                var fullyUnknown = [];
+                if (message.$unknownFields && $root.jspb.test.EnumContainer.decode)
+                    for (var i = 0; i < message.$unknownFields.length; ++i)
+                        try {
+                            var known = $root.jspb.test.EnumContainer.decode(message.$unknownFields[i]);
+                            fullyUnknown = fullyUnknown.concat(known.$unknownFields || []);
+                            message = Object.assign(known, message);
+                        } catch (_) {
+                        }
                 if (message.outerEnum != null && Object.hasOwnProperty.call(message, "outerEnum"))
                     writer.uint32(/* id 1, wireType 0 =*/8).int32(message.outerEnum);
+                for (var i = 0; i < fullyUnknown.length; ++i)
+                    writer._unknownField(fullyUnknown[i]);
                 return writer;
             };
 
@@ -306,13 +332,18 @@ $root.jspb = (function() {
                     reader = $Reader.create(reader);
                 var end = length === undefined ? reader.len : reader.pos + length, message = new $root.jspb.test.EnumContainer();
                 while (reader.pos < end) {
+                    var unknownStartPos = reader.pos;
                     var tag = reader.uint32();
                     switch (tag >>> 3) {
-                    case 1:
-                        message.outerEnum = reader.int32();
-                        break;
+                    case 1: {
+                            message.outerEnum = reader.int32();
+                            break;
+                        }
                     default:
                         reader.skipType(tag & 7);
+                        if (!message.$unknownFields)
+                            message.$unknownFields = [];
+                        message.$unknownFields.push(reader.buf.slice(unknownStartPos, reader.pos));
                         break;
                     }
                 }
@@ -370,6 +401,12 @@ $root.jspb = (function() {
                     return object;
                 var message = new $root.jspb.test.EnumContainer();
                 switch (object.outerEnum) {
+                default:
+                    if (typeof object.outerEnum === "number") {
+                        message.outerEnum = object.outerEnum;
+                        break;
+                    }
+                    break;
                 case "FOO":
                 case 1:
                     message.outerEnum = 1;
@@ -398,7 +435,7 @@ $root.jspb = (function() {
                 if (options.defaults)
                     object.outerEnum = options.enums === String ? "FOO" : 1;
                 if (message.outerEnum != null && message.hasOwnProperty("outerEnum"))
-                    object.outerEnum = options.enums === String ? $root.jspb.test.OuterEnum[message.outerEnum] : message.outerEnum;
+                    object.outerEnum = options.enums === String ? $root.jspb.test.OuterEnum[message.outerEnum] === undefined ? message.outerEnum : $root.jspb.test.OuterEnum[message.outerEnum] : message.outerEnum;
                 return object;
             };
 
@@ -506,12 +543,23 @@ $root.jspb = (function() {
             Simple1.encode = function encode(message, writer) {
                 if (!writer)
                     writer = $Writer.create();
+                var fullyUnknown = [];
+                if (message.$unknownFields && $root.jspb.test.Simple1.decode)
+                    for (var i = 0; i < message.$unknownFields.length; ++i)
+                        try {
+                            var known = $root.jspb.test.Simple1.decode(message.$unknownFields[i]);
+                            fullyUnknown = fullyUnknown.concat(known.$unknownFields || []);
+                            message = Object.assign(known, message);
+                        } catch (_) {
+                        }
                 writer.uint32(/* id 1, wireType 2 =*/10).string(message.aString);
                 if (message.aRepeatedString != null && message.aRepeatedString.length)
                     for (var i = 0; i < message.aRepeatedString.length; ++i)
                         writer.uint32(/* id 2, wireType 2 =*/18).string(message.aRepeatedString[i]);
                 if (message.aBoolean != null && Object.hasOwnProperty.call(message, "aBoolean"))
                     writer.uint32(/* id 3, wireType 0 =*/24).bool(message.aBoolean);
+                for (var i = 0; i < fullyUnknown.length; ++i)
+                    writer._unknownField(fullyUnknown[i]);
                 return writer;
             };
 
@@ -544,21 +592,28 @@ $root.jspb = (function() {
                     reader = $Reader.create(reader);
                 var end = length === undefined ? reader.len : reader.pos + length, message = new $root.jspb.test.Simple1();
                 while (reader.pos < end) {
+                    var unknownStartPos = reader.pos;
                     var tag = reader.uint32();
                     switch (tag >>> 3) {
-                    case 1:
-                        message.aString = reader.string();
-                        break;
-                    case 2:
-                        if (!(message.aRepeatedString && message.aRepeatedString.length))
-                            message.aRepeatedString = [];
-                        message.aRepeatedString.push(reader.string());
-                        break;
-                    case 3:
-                        message.aBoolean = reader.bool();
-                        break;
+                    case 1: {
+                            message.aString = reader.string();
+                            break;
+                        }
+                    case 2: {
+                            if (!(message.aRepeatedString && message.aRepeatedString.length))
+                                message.aRepeatedString = [];
+                            message.aRepeatedString.push(reader.string());
+                            break;
+                        }
+                    case 3: {
+                            message.aBoolean = reader.bool();
+                            break;
+                        }
                     default:
                         reader.skipType(tag & 7);
+                        if (!message.$unknownFields)
+                            message.$unknownFields = [];
+                        message.$unknownFields.push(reader.buf.slice(unknownStartPos, reader.pos));
                         break;
                     }
                 }
@@ -761,10 +816,21 @@ $root.jspb = (function() {
             Simple2.encode = function encode(message, writer) {
                 if (!writer)
                     writer = $Writer.create();
+                var fullyUnknown = [];
+                if (message.$unknownFields && $root.jspb.test.Simple2.decode)
+                    for (var i = 0; i < message.$unknownFields.length; ++i)
+                        try {
+                            var known = $root.jspb.test.Simple2.decode(message.$unknownFields[i]);
+                            fullyUnknown = fullyUnknown.concat(known.$unknownFields || []);
+                            message = Object.assign(known, message);
+                        } catch (_) {
+                        }
                 writer.uint32(/* id 1, wireType 2 =*/10).string(message.aString);
                 if (message.aRepeatedString != null && message.aRepeatedString.length)
                     for (var i = 0; i < message.aRepeatedString.length; ++i)
                         writer.uint32(/* id 2, wireType 2 =*/18).string(message.aRepeatedString[i]);
+                for (var i = 0; i < fullyUnknown.length; ++i)
+                    writer._unknownField(fullyUnknown[i]);
                 return writer;
             };
 
@@ -797,18 +863,24 @@ $root.jspb = (function() {
                     reader = $Reader.create(reader);
                 var end = length === undefined ? reader.len : reader.pos + length, message = new $root.jspb.test.Simple2();
                 while (reader.pos < end) {
+                    var unknownStartPos = reader.pos;
                     var tag = reader.uint32();
                     switch (tag >>> 3) {
-                    case 1:
-                        message.aString = reader.string();
-                        break;
-                    case 2:
-                        if (!(message.aRepeatedString && message.aRepeatedString.length))
-                            message.aRepeatedString = [];
-                        message.aRepeatedString.push(reader.string());
-                        break;
+                    case 1: {
+                            message.aString = reader.string();
+                            break;
+                        }
+                    case 2: {
+                            if (!(message.aRepeatedString && message.aRepeatedString.length))
+                                message.aRepeatedString = [];
+                            message.aRepeatedString.push(reader.string());
+                            break;
+                        }
                     default:
                         reader.skipType(tag & 7);
+                        if (!message.$unknownFields)
+                            message.$unknownFields = [];
+                        message.$unknownFields.push(reader.buf.slice(unknownStartPos, reader.pos));
                         break;
                     }
                 }
@@ -1019,10 +1091,21 @@ $root.jspb = (function() {
             SpecialCases.encode = function encode(message, writer) {
                 if (!writer)
                     writer = $Writer.create();
+                var fullyUnknown = [];
+                if (message.$unknownFields && $root.jspb.test.SpecialCases.decode)
+                    for (var i = 0; i < message.$unknownFields.length; ++i)
+                        try {
+                            var known = $root.jspb.test.SpecialCases.decode(message.$unknownFields[i]);
+                            fullyUnknown = fullyUnknown.concat(known.$unknownFields || []);
+                            message = Object.assign(known, message);
+                        } catch (_) {
+                        }
                 writer.uint32(/* id 1, wireType 2 =*/10).string(message.normal);
                 writer.uint32(/* id 2, wireType 2 =*/18).string(message["default"]);
                 writer.uint32(/* id 3, wireType 2 =*/26).string(message["function"]);
                 writer.uint32(/* id 4, wireType 2 =*/34).string(message["var"]);
+                for (var i = 0; i < fullyUnknown.length; ++i)
+                    writer._unknownField(fullyUnknown[i]);
                 return writer;
             };
 
@@ -1055,22 +1138,30 @@ $root.jspb = (function() {
                     reader = $Reader.create(reader);
                 var end = length === undefined ? reader.len : reader.pos + length, message = new $root.jspb.test.SpecialCases();
                 while (reader.pos < end) {
+                    var unknownStartPos = reader.pos;
                     var tag = reader.uint32();
                     switch (tag >>> 3) {
-                    case 1:
-                        message.normal = reader.string();
-                        break;
-                    case 2:
-                        message["default"] = reader.string();
-                        break;
-                    case 3:
-                        message["function"] = reader.string();
-                        break;
-                    case 4:
-                        message["var"] = reader.string();
-                        break;
+                    case 1: {
+                            message.normal = reader.string();
+                            break;
+                        }
+                    case 2: {
+                            message["default"] = reader.string();
+                            break;
+                        }
+                    case 3: {
+                            message["function"] = reader.string();
+                            break;
+                        }
+                    case 4: {
+                            message["var"] = reader.string();
+                            break;
+                        }
                     default:
                         reader.skipType(tag & 7);
+                        if (!message.$unknownFields)
+                            message.$unknownFields = [];
+                        message.$unknownFields.push(reader.buf.slice(unknownStartPos, reader.pos));
                         break;
                     }
                 }
@@ -1299,6 +1390,15 @@ $root.jspb = (function() {
             OptionalFields.encode = function encode(message, writer) {
                 if (!writer)
                     writer = $Writer.create();
+                var fullyUnknown = [];
+                if (message.$unknownFields && $root.jspb.test.OptionalFields.decode)
+                    for (var i = 0; i < message.$unknownFields.length; ++i)
+                        try {
+                            var known = $root.jspb.test.OptionalFields.decode(message.$unknownFields[i]);
+                            fullyUnknown = fullyUnknown.concat(known.$unknownFields || []);
+                            message = Object.assign(known, message);
+                        } catch (_) {
+                        }
                 if (message.aString != null && Object.hasOwnProperty.call(message, "aString"))
                     writer.uint32(/* id 1, wireType 2 =*/10).string(message.aString);
                 writer.uint32(/* id 2, wireType 0 =*/16).bool(message.aBool);
@@ -1310,6 +1410,8 @@ $root.jspb = (function() {
                 if (message.aRepeatedString != null && message.aRepeatedString.length)
                     for (var i = 0; i < message.aRepeatedString.length; ++i)
                         writer.uint32(/* id 5, wireType 2 =*/42).string(message.aRepeatedString[i]);
+                for (var i = 0; i < fullyUnknown.length; ++i)
+                    writer._unknownField(fullyUnknown[i]);
                 return writer;
             };
 
@@ -1342,29 +1444,38 @@ $root.jspb = (function() {
                     reader = $Reader.create(reader);
                 var end = length === undefined ? reader.len : reader.pos + length, message = new $root.jspb.test.OptionalFields();
                 while (reader.pos < end) {
+                    var unknownStartPos = reader.pos;
                     var tag = reader.uint32();
                     switch (tag >>> 3) {
-                    case 1:
-                        message.aString = reader.string();
-                        break;
-                    case 2:
-                        message.aBool = reader.bool();
-                        break;
-                    case 3:
-                        message.aNestedMessage = $root.jspb.test.OptionalFields.Nested.decode(reader, reader.uint32());
-                        break;
-                    case 4:
-                        if (!(message.aRepeatedMessage && message.aRepeatedMessage.length))
-                            message.aRepeatedMessage = [];
-                        message.aRepeatedMessage.push($root.jspb.test.OptionalFields.Nested.decode(reader, reader.uint32()));
-                        break;
-                    case 5:
-                        if (!(message.aRepeatedString && message.aRepeatedString.length))
-                            message.aRepeatedString = [];
-                        message.aRepeatedString.push(reader.string());
-                        break;
+                    case 1: {
+                            message.aString = reader.string();
+                            break;
+                        }
+                    case 2: {
+                            message.aBool = reader.bool();
+                            break;
+                        }
+                    case 3: {
+                            message.aNestedMessage = $root.jspb.test.OptionalFields.Nested.decode(reader, reader.uint32());
+                            break;
+                        }
+                    case 4: {
+                            if (!(message.aRepeatedMessage && message.aRepeatedMessage.length))
+                                message.aRepeatedMessage = [];
+                            message.aRepeatedMessage.push($root.jspb.test.OptionalFields.Nested.decode(reader, reader.uint32()));
+                            break;
+                        }
+                    case 5: {
+                            if (!(message.aRepeatedString && message.aRepeatedString.length))
+                                message.aRepeatedString = [];
+                            message.aRepeatedString.push(reader.string());
+                            break;
+                        }
                     default:
                         reader.skipType(tag & 7);
+                        if (!message.$unknownFields)
+                            message.$unknownFields = [];
+                        message.$unknownFields.push(reader.buf.slice(unknownStartPos, reader.pos));
                         break;
                     }
                 }
@@ -1593,8 +1704,19 @@ $root.jspb = (function() {
                 Nested.encode = function encode(message, writer) {
                     if (!writer)
                         writer = $Writer.create();
+                    var fullyUnknown = [];
+                    if (message.$unknownFields && $root.jspb.test.OptionalFields.Nested.decode)
+                        for (var i = 0; i < message.$unknownFields.length; ++i)
+                            try {
+                                var known = $root.jspb.test.OptionalFields.Nested.decode(message.$unknownFields[i]);
+                                fullyUnknown = fullyUnknown.concat(known.$unknownFields || []);
+                                message = Object.assign(known, message);
+                            } catch (_) {
+                            }
                     if (message.anInt != null && Object.hasOwnProperty.call(message, "anInt"))
                         writer.uint32(/* id 1, wireType 0 =*/8).int32(message.anInt);
+                    for (var i = 0; i < fullyUnknown.length; ++i)
+                        writer._unknownField(fullyUnknown[i]);
                     return writer;
                 };
 
@@ -1627,13 +1749,18 @@ $root.jspb = (function() {
                         reader = $Reader.create(reader);
                     var end = length === undefined ? reader.len : reader.pos + length, message = new $root.jspb.test.OptionalFields.Nested();
                     while (reader.pos < end) {
+                        var unknownStartPos = reader.pos;
                         var tag = reader.uint32();
                         switch (tag >>> 3) {
-                        case 1:
-                            message.anInt = reader.int32();
-                            break;
+                        case 1: {
+                                message.anInt = reader.int32();
+                                break;
+                            }
                         default:
                             reader.skipType(tag & 7);
+                            if (!message.$unknownFields)
+                                message.$unknownFields = [];
+                            message.$unknownFields.push(reader.buf.slice(unknownStartPos, reader.pos));
                             break;
                         }
                     }
@@ -1872,6 +1999,15 @@ $root.jspb = (function() {
             HasExtensions.encode = function encode(message, writer) {
                 if (!writer)
                     writer = $Writer.create();
+                var fullyUnknown = [];
+                if (message.$unknownFields && $root.jspb.test.HasExtensions.decode)
+                    for (var i = 0; i < message.$unknownFields.length; ++i)
+                        try {
+                            var known = $root.jspb.test.HasExtensions.decode(message.$unknownFields[i]);
+                            fullyUnknown = fullyUnknown.concat(known.$unknownFields || []);
+                            message = Object.assign(known, message);
+                        } catch (_) {
+                        }
                 if (message.str1 != null && Object.hasOwnProperty.call(message, "str1"))
                     writer.uint32(/* id 1, wireType 2 =*/10).string(message.str1);
                 if (message.str2 != null && Object.hasOwnProperty.call(message, "str2"))
@@ -1892,6 +2028,8 @@ $root.jspb = (function() {
                         $root.jspb.test.Simple1.encode(message[".jspb.test.IndirectExtension.repeatedSimple"][i], writer.uint32(/* id 104, wireType 2 =*/834).fork()).ldelim();
                 if (message[".jspb.test.simple1"] != null && Object.hasOwnProperty.call(message, ".jspb.test.simple1"))
                     $root.jspb.test.Simple1.encode(message[".jspb.test.simple1"], writer.uint32(/* id 105, wireType 2 =*/842).fork()).ldelim();
+                for (var i = 0; i < fullyUnknown.length; ++i)
+                    writer._unknownField(fullyUnknown[i]);
                 return writer;
             };
 
@@ -1924,41 +2062,54 @@ $root.jspb = (function() {
                     reader = $Reader.create(reader);
                 var end = length === undefined ? reader.len : reader.pos + length, message = new $root.jspb.test.HasExtensions();
                 while (reader.pos < end) {
+                    var unknownStartPos = reader.pos;
                     var tag = reader.uint32();
                     switch (tag >>> 3) {
-                    case 1:
-                        message.str1 = reader.string();
-                        break;
-                    case 2:
-                        message.str2 = reader.string();
-                        break;
-                    case 3:
-                        message.str3 = reader.string();
-                        break;
-                    case 100:
-                        message[".jspb.test.IsExtension.extField"] = $root.jspb.test.IsExtension.decode(reader, reader.uint32());
-                        break;
-                    case 101:
-                        message[".jspb.test.IndirectExtension.simple"] = $root.jspb.test.Simple1.decode(reader, reader.uint32());
-                        break;
-                    case 102:
-                        message[".jspb.test.IndirectExtension.str"] = reader.string();
-                        break;
-                    case 103:
-                        if (!(message[".jspb.test.IndirectExtension.repeatedStr"] && message[".jspb.test.IndirectExtension.repeatedStr"].length))
-                            message[".jspb.test.IndirectExtension.repeatedStr"] = [];
-                        message[".jspb.test.IndirectExtension.repeatedStr"].push(reader.string());
-                        break;
-                    case 104:
-                        if (!(message[".jspb.test.IndirectExtension.repeatedSimple"] && message[".jspb.test.IndirectExtension.repeatedSimple"].length))
-                            message[".jspb.test.IndirectExtension.repeatedSimple"] = [];
-                        message[".jspb.test.IndirectExtension.repeatedSimple"].push($root.jspb.test.Simple1.decode(reader, reader.uint32()));
-                        break;
-                    case 105:
-                        message[".jspb.test.simple1"] = $root.jspb.test.Simple1.decode(reader, reader.uint32());
-                        break;
+                    case 1: {
+                            message.str1 = reader.string();
+                            break;
+                        }
+                    case 2: {
+                            message.str2 = reader.string();
+                            break;
+                        }
+                    case 3: {
+                            message.str3 = reader.string();
+                            break;
+                        }
+                    case 100: {
+                            message[".jspb.test.IsExtension.extField"] = $root.jspb.test.IsExtension.decode(reader, reader.uint32());
+                            break;
+                        }
+                    case 101: {
+                            message[".jspb.test.IndirectExtension.simple"] = $root.jspb.test.Simple1.decode(reader, reader.uint32());
+                            break;
+                        }
+                    case 102: {
+                            message[".jspb.test.IndirectExtension.str"] = reader.string();
+                            break;
+                        }
+                    case 103: {
+                            if (!(message[".jspb.test.IndirectExtension.repeatedStr"] && message[".jspb.test.IndirectExtension.repeatedStr"].length))
+                                message[".jspb.test.IndirectExtension.repeatedStr"] = [];
+                            message[".jspb.test.IndirectExtension.repeatedStr"].push(reader.string());
+                            break;
+                        }
+                    case 104: {
+                            if (!(message[".jspb.test.IndirectExtension.repeatedSimple"] && message[".jspb.test.IndirectExtension.repeatedSimple"].length))
+                                message[".jspb.test.IndirectExtension.repeatedSimple"] = [];
+                            message[".jspb.test.IndirectExtension.repeatedSimple"].push($root.jspb.test.Simple1.decode(reader, reader.uint32()));
+                            break;
+                        }
+                    case 105: {
+                            message[".jspb.test.simple1"] = $root.jspb.test.Simple1.decode(reader, reader.uint32());
+                            break;
+                        }
                     default:
                         reader.skipType(tag & 7);
+                        if (!message.$unknownFields)
+                            message.$unknownFields = [];
+                        message.$unknownFields.push(reader.buf.slice(unknownStartPos, reader.pos));
                         break;
                     }
                 }
@@ -2269,6 +2420,15 @@ $root.jspb = (function() {
             Complex.encode = function encode(message, writer) {
                 if (!writer)
                     writer = $Writer.create();
+                var fullyUnknown = [];
+                if (message.$unknownFields && $root.jspb.test.Complex.decode)
+                    for (var i = 0; i < message.$unknownFields.length; ++i)
+                        try {
+                            var known = $root.jspb.test.Complex.decode(message.$unknownFields[i]);
+                            fullyUnknown = fullyUnknown.concat(known.$unknownFields || []);
+                            message = Object.assign(known, message);
+                        } catch (_) {
+                        }
                 writer.uint32(/* id 1, wireType 2 =*/10).string(message.aString);
                 if (message.aNestedMessage != null && Object.hasOwnProperty.call(message, "aNestedMessage"))
                     $root.jspb.test.Complex.Nested.encode(message.aNestedMessage, writer.uint32(/* id 4, wireType 2 =*/34).fork()).ldelim();
@@ -2279,6 +2439,8 @@ $root.jspb = (function() {
                     for (var i = 0; i < message.aRepeatedString.length; ++i)
                         writer.uint32(/* id 7, wireType 2 =*/58).string(message.aRepeatedString[i]);
                 writer.uint32(/* id 9, wireType 0 =*/72).bool(message.anOutOfOrderBool);
+                for (var i = 0; i < fullyUnknown.length; ++i)
+                    writer._unknownField(fullyUnknown[i]);
                 return writer;
             };
 
@@ -2311,29 +2473,38 @@ $root.jspb = (function() {
                     reader = $Reader.create(reader);
                 var end = length === undefined ? reader.len : reader.pos + length, message = new $root.jspb.test.Complex();
                 while (reader.pos < end) {
+                    var unknownStartPos = reader.pos;
                     var tag = reader.uint32();
                     switch (tag >>> 3) {
-                    case 1:
-                        message.aString = reader.string();
-                        break;
-                    case 9:
-                        message.anOutOfOrderBool = reader.bool();
-                        break;
-                    case 4:
-                        message.aNestedMessage = $root.jspb.test.Complex.Nested.decode(reader, reader.uint32());
-                        break;
-                    case 5:
-                        if (!(message.aRepeatedMessage && message.aRepeatedMessage.length))
-                            message.aRepeatedMessage = [];
-                        message.aRepeatedMessage.push($root.jspb.test.Complex.Nested.decode(reader, reader.uint32()));
-                        break;
-                    case 7:
-                        if (!(message.aRepeatedString && message.aRepeatedString.length))
-                            message.aRepeatedString = [];
-                        message.aRepeatedString.push(reader.string());
-                        break;
+                    case 1: {
+                            message.aString = reader.string();
+                            break;
+                        }
+                    case 9: {
+                            message.anOutOfOrderBool = reader.bool();
+                            break;
+                        }
+                    case 4: {
+                            message.aNestedMessage = $root.jspb.test.Complex.Nested.decode(reader, reader.uint32());
+                            break;
+                        }
+                    case 5: {
+                            if (!(message.aRepeatedMessage && message.aRepeatedMessage.length))
+                                message.aRepeatedMessage = [];
+                            message.aRepeatedMessage.push($root.jspb.test.Complex.Nested.decode(reader, reader.uint32()));
+                            break;
+                        }
+                    case 7: {
+                            if (!(message.aRepeatedString && message.aRepeatedString.length))
+                                message.aRepeatedString = [];
+                            message.aRepeatedString.push(reader.string());
+                            break;
+                        }
                     default:
                         reader.skipType(tag & 7);
+                        if (!message.$unknownFields)
+                            message.$unknownFields = [];
+                        message.$unknownFields.push(reader.buf.slice(unknownStartPos, reader.pos));
                         break;
                     }
                 }
@@ -2563,7 +2734,18 @@ $root.jspb = (function() {
                 Nested.encode = function encode(message, writer) {
                     if (!writer)
                         writer = $Writer.create();
+                    var fullyUnknown = [];
+                    if (message.$unknownFields && $root.jspb.test.Complex.Nested.decode)
+                        for (var i = 0; i < message.$unknownFields.length; ++i)
+                            try {
+                                var known = $root.jspb.test.Complex.Nested.decode(message.$unknownFields[i]);
+                                fullyUnknown = fullyUnknown.concat(known.$unknownFields || []);
+                                message = Object.assign(known, message);
+                            } catch (_) {
+                            }
                     writer.uint32(/* id 2, wireType 0 =*/16).int32(message.anInt);
+                    for (var i = 0; i < fullyUnknown.length; ++i)
+                        writer._unknownField(fullyUnknown[i]);
                     return writer;
                 };
 
@@ -2596,13 +2778,18 @@ $root.jspb = (function() {
                         reader = $Reader.create(reader);
                     var end = length === undefined ? reader.len : reader.pos + length, message = new $root.jspb.test.Complex.Nested();
                     while (reader.pos < end) {
+                        var unknownStartPos = reader.pos;
                         var tag = reader.uint32();
                         switch (tag >>> 3) {
-                        case 2:
-                            message.anInt = reader.int32();
-                            break;
+                        case 2: {
+                                message.anInt = reader.int32();
+                                break;
+                            }
                         default:
                             reader.skipType(tag & 7);
+                            if (!message.$unknownFields)
+                                message.$unknownFields = [];
+                            message.$unknownFields.push(reader.buf.slice(unknownStartPos, reader.pos));
                             break;
                         }
                     }
@@ -2759,6 +2946,17 @@ $root.jspb = (function() {
             OuterMessage.encode = function encode(message, writer) {
                 if (!writer)
                     writer = $Writer.create();
+                var fullyUnknown = [];
+                if (message.$unknownFields && $root.jspb.test.OuterMessage.decode)
+                    for (var i = 0; i < message.$unknownFields.length; ++i)
+                        try {
+                            var known = $root.jspb.test.OuterMessage.decode(message.$unknownFields[i]);
+                            fullyUnknown = fullyUnknown.concat(known.$unknownFields || []);
+                            message = Object.assign(known, message);
+                        } catch (_) {
+                        }
+                for (var i = 0; i < fullyUnknown.length; ++i)
+                    writer._unknownField(fullyUnknown[i]);
                 return writer;
             };
 
@@ -2791,10 +2989,14 @@ $root.jspb = (function() {
                     reader = $Reader.create(reader);
                 var end = length === undefined ? reader.len : reader.pos + length, message = new $root.jspb.test.OuterMessage();
                 while (reader.pos < end) {
+                    var unknownStartPos = reader.pos;
                     var tag = reader.uint32();
                     switch (tag >>> 3) {
                     default:
                         reader.skipType(tag & 7);
+                        if (!message.$unknownFields)
+                            message.$unknownFields = [];
+                        message.$unknownFields.push(reader.buf.slice(unknownStartPos, reader.pos));
                         break;
                     }
                 }
@@ -2940,8 +3142,19 @@ $root.jspb = (function() {
                 Complex.encode = function encode(message, writer) {
                     if (!writer)
                         writer = $Writer.create();
+                    var fullyUnknown = [];
+                    if (message.$unknownFields && $root.jspb.test.OuterMessage.Complex.decode)
+                        for (var i = 0; i < message.$unknownFields.length; ++i)
+                            try {
+                                var known = $root.jspb.test.OuterMessage.Complex.decode(message.$unknownFields[i]);
+                                fullyUnknown = fullyUnknown.concat(known.$unknownFields || []);
+                                message = Object.assign(known, message);
+                            } catch (_) {
+                            }
                     if (message.innerComplexField != null && Object.hasOwnProperty.call(message, "innerComplexField"))
                         writer.uint32(/* id 1, wireType 0 =*/8).int32(message.innerComplexField);
+                    for (var i = 0; i < fullyUnknown.length; ++i)
+                        writer._unknownField(fullyUnknown[i]);
                     return writer;
                 };
 
@@ -2974,13 +3187,18 @@ $root.jspb = (function() {
                         reader = $Reader.create(reader);
                     var end = length === undefined ? reader.len : reader.pos + length, message = new $root.jspb.test.OuterMessage.Complex();
                     while (reader.pos < end) {
+                        var unknownStartPos = reader.pos;
                         var tag = reader.uint32();
                         switch (tag >>> 3) {
-                        case 1:
-                            message.innerComplexField = reader.int32();
-                            break;
+                        case 1: {
+                                message.innerComplexField = reader.int32();
+                                break;
+                            }
                         default:
                             reader.skipType(tag & 7);
+                            if (!message.$unknownFields)
+                                message.$unknownFields = [];
+                            message.$unknownFields.push(reader.buf.slice(unknownStartPos, reader.pos));
                             break;
                         }
                     }
@@ -3145,8 +3363,19 @@ $root.jspb = (function() {
             IsExtension.encode = function encode(message, writer) {
                 if (!writer)
                     writer = $Writer.create();
+                var fullyUnknown = [];
+                if (message.$unknownFields && $root.jspb.test.IsExtension.decode)
+                    for (var i = 0; i < message.$unknownFields.length; ++i)
+                        try {
+                            var known = $root.jspb.test.IsExtension.decode(message.$unknownFields[i]);
+                            fullyUnknown = fullyUnknown.concat(known.$unknownFields || []);
+                            message = Object.assign(known, message);
+                        } catch (_) {
+                        }
                 if (message.ext1 != null && Object.hasOwnProperty.call(message, "ext1"))
                     writer.uint32(/* id 1, wireType 2 =*/10).string(message.ext1);
+                for (var i = 0; i < fullyUnknown.length; ++i)
+                    writer._unknownField(fullyUnknown[i]);
                 return writer;
             };
 
@@ -3179,13 +3408,18 @@ $root.jspb = (function() {
                     reader = $Reader.create(reader);
                 var end = length === undefined ? reader.len : reader.pos + length, message = new $root.jspb.test.IsExtension();
                 while (reader.pos < end) {
+                    var unknownStartPos = reader.pos;
                     var tag = reader.uint32();
                     switch (tag >>> 3) {
-                    case 1:
-                        message.ext1 = reader.string();
-                        break;
+                    case 1: {
+                            message.ext1 = reader.string();
+                            break;
+                        }
                     default:
                         reader.skipType(tag & 7);
+                        if (!message.$unknownFields)
+                            message.$unknownFields = [];
+                        message.$unknownFields.push(reader.buf.slice(unknownStartPos, reader.pos));
                         break;
                     }
                 }
@@ -3338,6 +3572,17 @@ $root.jspb = (function() {
             IndirectExtension.encode = function encode(message, writer) {
                 if (!writer)
                     writer = $Writer.create();
+                var fullyUnknown = [];
+                if (message.$unknownFields && $root.jspb.test.IndirectExtension.decode)
+                    for (var i = 0; i < message.$unknownFields.length; ++i)
+                        try {
+                            var known = $root.jspb.test.IndirectExtension.decode(message.$unknownFields[i]);
+                            fullyUnknown = fullyUnknown.concat(known.$unknownFields || []);
+                            message = Object.assign(known, message);
+                        } catch (_) {
+                        }
+                for (var i = 0; i < fullyUnknown.length; ++i)
+                    writer._unknownField(fullyUnknown[i]);
                 return writer;
             };
 
@@ -3370,10 +3615,14 @@ $root.jspb = (function() {
                     reader = $Reader.create(reader);
                 var end = length === undefined ? reader.len : reader.pos + length, message = new $root.jspb.test.IndirectExtension();
                 while (reader.pos < end) {
+                    var unknownStartPos = reader.pos;
                     var tag = reader.uint32();
                     switch (tag >>> 3) {
                     default:
                         reader.skipType(tag & 7);
+                        if (!message.$unknownFields)
+                            message.$unknownFields = [];
+                        message.$unknownFields.push(reader.buf.slice(unknownStartPos, reader.pos));
                         break;
                     }
                 }
@@ -3567,6 +3816,15 @@ $root.jspb = (function() {
             DefaultValues.encode = function encode(message, writer) {
                 if (!writer)
                     writer = $Writer.create();
+                var fullyUnknown = [];
+                if (message.$unknownFields && $root.jspb.test.DefaultValues.decode)
+                    for (var i = 0; i < message.$unknownFields.length; ++i)
+                        try {
+                            var known = $root.jspb.test.DefaultValues.decode(message.$unknownFields[i]);
+                            fullyUnknown = fullyUnknown.concat(known.$unknownFields || []);
+                            message = Object.assign(known, message);
+                        } catch (_) {
+                        }
                 if (message.stringField != null && Object.hasOwnProperty.call(message, "stringField"))
                     writer.uint32(/* id 1, wireType 2 =*/10).string(message.stringField);
                 if (message.boolField != null && Object.hasOwnProperty.call(message, "boolField"))
@@ -3579,6 +3837,8 @@ $root.jspb = (function() {
                     writer.uint32(/* id 6, wireType 2 =*/50).string(message.emptyField);
                 if (message.bytesField != null && Object.hasOwnProperty.call(message, "bytesField"))
                     writer.uint32(/* id 8, wireType 2 =*/66).bytes(message.bytesField);
+                for (var i = 0; i < fullyUnknown.length; ++i)
+                    writer._unknownField(fullyUnknown[i]);
                 return writer;
             };
 
@@ -3611,28 +3871,38 @@ $root.jspb = (function() {
                     reader = $Reader.create(reader);
                 var end = length === undefined ? reader.len : reader.pos + length, message = new $root.jspb.test.DefaultValues();
                 while (reader.pos < end) {
+                    var unknownStartPos = reader.pos;
                     var tag = reader.uint32();
                     switch (tag >>> 3) {
-                    case 1:
-                        message.stringField = reader.string();
-                        break;
-                    case 2:
-                        message.boolField = reader.bool();
-                        break;
-                    case 3:
-                        message.intField = reader.int64();
-                        break;
-                    case 4:
-                        message.enumField = reader.int32();
-                        break;
-                    case 6:
-                        message.emptyField = reader.string();
-                        break;
-                    case 8:
-                        message.bytesField = reader.bytes();
-                        break;
+                    case 1: {
+                            message.stringField = reader.string();
+                            break;
+                        }
+                    case 2: {
+                            message.boolField = reader.bool();
+                            break;
+                        }
+                    case 3: {
+                            message.intField = reader.int64();
+                            break;
+                        }
+                    case 4: {
+                            message.enumField = reader.int32();
+                            break;
+                        }
+                    case 6: {
+                            message.emptyField = reader.string();
+                            break;
+                        }
+                    case 8: {
+                            message.bytesField = reader.bytes();
+                            break;
+                        }
                     default:
                         reader.skipType(tag & 7);
+                        if (!message.$unknownFields)
+                            message.$unknownFields = [];
+                        message.$unknownFields.push(reader.buf.slice(unknownStartPos, reader.pos));
                         break;
                     }
                 }
@@ -3718,6 +3988,12 @@ $root.jspb = (function() {
                     else if (typeof object.intField === "object")
                         message.intField = new $util.LongBits(object.intField.low >>> 0, object.intField.high >>> 0).toNumber();
                 switch (object.enumField) {
+                default:
+                    if (typeof object.enumField === "number") {
+                        message.enumField = object.enumField;
+                        break;
+                    }
+                    break;
                 case "E1":
                 case 13:
                     message.enumField = 13;
@@ -3782,7 +4058,7 @@ $root.jspb = (function() {
                     else
                         object.intField = options.longs === String ? $util.Long.prototype.toString.call(message.intField) : options.longs === Number ? new $util.LongBits(message.intField.low >>> 0, message.intField.high >>> 0).toNumber() : message.intField;
                 if (message.enumField != null && message.hasOwnProperty("enumField"))
-                    object.enumField = options.enums === String ? $root.jspb.test.DefaultValues.Enum[message.enumField] : message.enumField;
+                    object.enumField = options.enums === String ? $root.jspb.test.DefaultValues.Enum[message.enumField] === undefined ? message.enumField : $root.jspb.test.DefaultValues.Enum[message.enumField] : message.enumField;
                 if (message.emptyField != null && message.hasOwnProperty("emptyField"))
                     object.emptyField = message.emptyField;
                 if (message.bytesField != null && message.hasOwnProperty("bytesField"))
@@ -3954,6 +4230,15 @@ $root.jspb = (function() {
             FloatingPointFields.encode = function encode(message, writer) {
                 if (!writer)
                     writer = $Writer.create();
+                var fullyUnknown = [];
+                if (message.$unknownFields && $root.jspb.test.FloatingPointFields.decode)
+                    for (var i = 0; i < message.$unknownFields.length; ++i)
+                        try {
+                            var known = $root.jspb.test.FloatingPointFields.decode(message.$unknownFields[i]);
+                            fullyUnknown = fullyUnknown.concat(known.$unknownFields || []);
+                            message = Object.assign(known, message);
+                        } catch (_) {
+                        }
                 if (message.optionalFloatField != null && Object.hasOwnProperty.call(message, "optionalFloatField"))
                     writer.uint32(/* id 1, wireType 5 =*/13).float(message.optionalFloatField);
                 writer.uint32(/* id 2, wireType 5 =*/21).float(message.requiredFloatField);
@@ -3970,6 +4255,8 @@ $root.jspb = (function() {
                         writer.uint32(/* id 7, wireType 1 =*/57).double(message.repeatedDoubleField[i]);
                 if (message.defaultDoubleField != null && Object.hasOwnProperty.call(message, "defaultDoubleField"))
                     writer.uint32(/* id 8, wireType 1 =*/65).double(message.defaultDoubleField);
+                for (var i = 0; i < fullyUnknown.length; ++i)
+                    writer._unknownField(fullyUnknown[i]);
                 return writer;
             };
 
@@ -4002,48 +4289,60 @@ $root.jspb = (function() {
                     reader = $Reader.create(reader);
                 var end = length === undefined ? reader.len : reader.pos + length, message = new $root.jspb.test.FloatingPointFields();
                 while (reader.pos < end) {
+                    var unknownStartPos = reader.pos;
                     var tag = reader.uint32();
                     switch (tag >>> 3) {
-                    case 1:
-                        message.optionalFloatField = reader.float();
-                        break;
-                    case 2:
-                        message.requiredFloatField = reader.float();
-                        break;
-                    case 3:
-                        if (!(message.repeatedFloatField && message.repeatedFloatField.length))
-                            message.repeatedFloatField = [];
-                        if ((tag & 7) === 2) {
-                            var end2 = reader.uint32() + reader.pos;
-                            while (reader.pos < end2)
+                    case 1: {
+                            message.optionalFloatField = reader.float();
+                            break;
+                        }
+                    case 2: {
+                            message.requiredFloatField = reader.float();
+                            break;
+                        }
+                    case 3: {
+                            if (!(message.repeatedFloatField && message.repeatedFloatField.length))
+                                message.repeatedFloatField = [];
+                            if ((tag & 7) === 2) {
+                                var end2 = reader.uint32() + reader.pos;
+                                while (reader.pos < end2)
+                                    message.repeatedFloatField.push(reader.float());
+                            } else
                                 message.repeatedFloatField.push(reader.float());
-                        } else
-                            message.repeatedFloatField.push(reader.float());
-                        break;
-                    case 4:
-                        message.defaultFloatField = reader.float();
-                        break;
-                    case 5:
-                        message.optionalDoubleField = reader.double();
-                        break;
-                    case 6:
-                        message.requiredDoubleField = reader.double();
-                        break;
-                    case 7:
-                        if (!(message.repeatedDoubleField && message.repeatedDoubleField.length))
-                            message.repeatedDoubleField = [];
-                        if ((tag & 7) === 2) {
-                            var end2 = reader.uint32() + reader.pos;
-                            while (reader.pos < end2)
+                            break;
+                        }
+                    case 4: {
+                            message.defaultFloatField = reader.float();
+                            break;
+                        }
+                    case 5: {
+                            message.optionalDoubleField = reader.double();
+                            break;
+                        }
+                    case 6: {
+                            message.requiredDoubleField = reader.double();
+                            break;
+                        }
+                    case 7: {
+                            if (!(message.repeatedDoubleField && message.repeatedDoubleField.length))
+                                message.repeatedDoubleField = [];
+                            if ((tag & 7) === 2) {
+                                var end2 = reader.uint32() + reader.pos;
+                                while (reader.pos < end2)
+                                    message.repeatedDoubleField.push(reader.double());
+                            } else
                                 message.repeatedDoubleField.push(reader.double());
-                        } else
-                            message.repeatedDoubleField.push(reader.double());
-                        break;
-                    case 8:
-                        message.defaultDoubleField = reader.double();
-                        break;
+                            break;
+                        }
+                    case 8: {
+                            message.defaultDoubleField = reader.double();
+                            break;
+                        }
                     default:
                         reader.skipType(tag & 7);
+                        if (!message.$unknownFields)
+                            message.$unknownFields = [];
+                        message.$unknownFields.push(reader.buf.slice(unknownStartPos, reader.pos));
                         break;
                     }
                 }
@@ -4336,6 +4635,15 @@ $root.jspb = (function() {
             TestClone.encode = function encode(message, writer) {
                 if (!writer)
                     writer = $Writer.create();
+                var fullyUnknown = [];
+                if (message.$unknownFields && $root.jspb.test.TestClone.decode)
+                    for (var i = 0; i < message.$unknownFields.length; ++i)
+                        try {
+                            var known = $root.jspb.test.TestClone.decode(message.$unknownFields[i]);
+                            fullyUnknown = fullyUnknown.concat(known.$unknownFields || []);
+                            message = Object.assign(known, message);
+                        } catch (_) {
+                        }
                 if (message.str != null && Object.hasOwnProperty.call(message, "str"))
                     writer.uint32(/* id 1, wireType 2 =*/10).string(message.str);
                 if (message.simple1 != null && Object.hasOwnProperty.call(message, "simple1"))
@@ -4349,6 +4657,8 @@ $root.jspb = (function() {
                     writer.uint32(/* id 7, wireType 2 =*/58).string(message.unused);
                 if (message[".jspb.test.CloneExtension.extField"] != null && Object.hasOwnProperty.call(message, ".jspb.test.CloneExtension.extField"))
                     $root.jspb.test.CloneExtension.encode(message[".jspb.test.CloneExtension.extField"], writer.uint32(/* id 100, wireType 2 =*/802).fork()).ldelim();
+                for (var i = 0; i < fullyUnknown.length; ++i)
+                    writer._unknownField(fullyUnknown[i]);
                 return writer;
             };
 
@@ -4381,30 +4691,40 @@ $root.jspb = (function() {
                     reader = $Reader.create(reader);
                 var end = length === undefined ? reader.len : reader.pos + length, message = new $root.jspb.test.TestClone();
                 while (reader.pos < end) {
+                    var unknownStartPos = reader.pos;
                     var tag = reader.uint32();
                     switch (tag >>> 3) {
-                    case 1:
-                        message.str = reader.string();
-                        break;
-                    case 3:
-                        message.simple1 = $root.jspb.test.Simple1.decode(reader, reader.uint32());
-                        break;
-                    case 5:
-                        if (!(message.simple2 && message.simple2.length))
-                            message.simple2 = [];
-                        message.simple2.push($root.jspb.test.Simple1.decode(reader, reader.uint32()));
-                        break;
-                    case 6:
-                        message.bytesField = reader.bytes();
-                        break;
-                    case 7:
-                        message.unused = reader.string();
-                        break;
-                    case 100:
-                        message[".jspb.test.CloneExtension.extField"] = $root.jspb.test.CloneExtension.decode(reader, reader.uint32());
-                        break;
+                    case 1: {
+                            message.str = reader.string();
+                            break;
+                        }
+                    case 3: {
+                            message.simple1 = $root.jspb.test.Simple1.decode(reader, reader.uint32());
+                            break;
+                        }
+                    case 5: {
+                            if (!(message.simple2 && message.simple2.length))
+                                message.simple2 = [];
+                            message.simple2.push($root.jspb.test.Simple1.decode(reader, reader.uint32()));
+                            break;
+                        }
+                    case 6: {
+                            message.bytesField = reader.bytes();
+                            break;
+                        }
+                    case 7: {
+                            message.unused = reader.string();
+                            break;
+                        }
+                    case 100: {
+                            message[".jspb.test.CloneExtension.extField"] = $root.jspb.test.CloneExtension.decode(reader, reader.uint32());
+                            break;
+                        }
                     default:
                         reader.skipType(tag & 7);
+                        if (!message.$unknownFields)
+                            message.$unknownFields = [];
+                        message.$unknownFields.push(reader.buf.slice(unknownStartPos, reader.pos));
                         break;
                     }
                 }
@@ -4644,8 +4964,19 @@ $root.jspb = (function() {
             CloneExtension.encode = function encode(message, writer) {
                 if (!writer)
                     writer = $Writer.create();
+                var fullyUnknown = [];
+                if (message.$unknownFields && $root.jspb.test.CloneExtension.decode)
+                    for (var i = 0; i < message.$unknownFields.length; ++i)
+                        try {
+                            var known = $root.jspb.test.CloneExtension.decode(message.$unknownFields[i]);
+                            fullyUnknown = fullyUnknown.concat(known.$unknownFields || []);
+                            message = Object.assign(known, message);
+                        } catch (_) {
+                        }
                 if (message.ext != null && Object.hasOwnProperty.call(message, "ext"))
                     writer.uint32(/* id 2, wireType 2 =*/18).string(message.ext);
+                for (var i = 0; i < fullyUnknown.length; ++i)
+                    writer._unknownField(fullyUnknown[i]);
                 return writer;
             };
 
@@ -4678,13 +5009,18 @@ $root.jspb = (function() {
                     reader = $Reader.create(reader);
                 var end = length === undefined ? reader.len : reader.pos + length, message = new $root.jspb.test.CloneExtension();
                 while (reader.pos < end) {
+                    var unknownStartPos = reader.pos;
                     var tag = reader.uint32();
                     switch (tag >>> 3) {
-                    case 2:
-                        message.ext = reader.string();
-                        break;
+                    case 2: {
+                            message.ext = reader.string();
+                            break;
+                        }
                     default:
                         reader.skipType(tag & 7);
+                        if (!message.$unknownFields)
+                            message.$unknownFields = [];
+                        message.$unknownFields.push(reader.buf.slice(unknownStartPos, reader.pos));
                         break;
                     }
                 }
@@ -4799,6 +5135,8 @@ $root.jspb = (function() {
              * @property {Array.<jspb.test.TestGroup.IRepeatedGroup>|null} [repeatedGroup] TestGroup repeatedGroup
              * @property {jspb.test.TestGroup.IRequiredGroup} requiredGroup TestGroup requiredGroup
              * @property {jspb.test.TestGroup.IOptionalGroup|null} [optionalGroup] TestGroup optionalGroup
+             * @property {jspb.test.TestGroup.IMessageInGroup|null} [messageInGroup] TestGroup messageInGroup
+             * @property {jspb.test.TestGroup.IEnumInGroup|null} [enumInGroup] TestGroup enumInGroup
              * @property {string|null} [id] TestGroup id
              * @property {jspb.test.ISimple2} requiredSimple TestGroup requiredSimple
              * @property {jspb.test.ISimple2|null} [optionalSimple] TestGroup optionalSimple
@@ -4843,6 +5181,22 @@ $root.jspb = (function() {
              * @instance
              */
             TestGroup.prototype.optionalGroup = null;
+
+            /**
+             * TestGroup messageInGroup.
+             * @member {jspb.test.TestGroup.IMessageInGroup|null|undefined} messageInGroup
+             * @memberof jspb.test.TestGroup
+             * @instance
+             */
+            TestGroup.prototype.messageInGroup = null;
+
+            /**
+             * TestGroup enumInGroup.
+             * @member {jspb.test.TestGroup.IEnumInGroup|null|undefined} enumInGroup
+             * @memberof jspb.test.TestGroup
+             * @instance
+             */
+            TestGroup.prototype.enumInGroup = null;
 
             /**
              * TestGroup id.
@@ -4892,17 +5246,32 @@ $root.jspb = (function() {
             TestGroup.encode = function encode(message, writer) {
                 if (!writer)
                     writer = $Writer.create();
+                var fullyUnknown = [];
+                if (message.$unknownFields && $root.jspb.test.TestGroup.decode)
+                    for (var i = 0; i < message.$unknownFields.length; ++i)
+                        try {
+                            var known = $root.jspb.test.TestGroup.decode(message.$unknownFields[i]);
+                            fullyUnknown = fullyUnknown.concat(known.$unknownFields || []);
+                            message = Object.assign(known, message);
+                        } catch (_) {
+                        }
                 if (message.repeatedGroup != null && message.repeatedGroup.length)
                     for (var i = 0; i < message.repeatedGroup.length; ++i)
                         $root.jspb.test.TestGroup.RepeatedGroup.encode(message.repeatedGroup[i], writer.uint32(/* id 1, wireType 3 =*/11)).uint32(/* id 1, wireType 4 =*/12);
                 $root.jspb.test.TestGroup.RequiredGroup.encode(message.requiredGroup, writer.uint32(/* id 2, wireType 3 =*/19)).uint32(/* id 2, wireType 4 =*/20);
                 if (message.optionalGroup != null && Object.hasOwnProperty.call(message, "optionalGroup"))
                     $root.jspb.test.TestGroup.OptionalGroup.encode(message.optionalGroup, writer.uint32(/* id 3, wireType 3 =*/27)).uint32(/* id 3, wireType 4 =*/28);
+                if (message.messageInGroup != null && Object.hasOwnProperty.call(message, "messageInGroup"))
+                    $root.jspb.test.TestGroup.MessageInGroup.encode(message.messageInGroup, writer.uint32(/* id 4, wireType 3 =*/35)).uint32(/* id 4, wireType 4 =*/36);
+                if (message.enumInGroup != null && Object.hasOwnProperty.call(message, "enumInGroup"))
+                    $root.jspb.test.TestGroup.EnumInGroup.encode(message.enumInGroup, writer.uint32(/* id 5, wireType 3 =*/43)).uint32(/* id 5, wireType 4 =*/44);
                 if (message.id != null && Object.hasOwnProperty.call(message, "id"))
-                    writer.uint32(/* id 4, wireType 2 =*/34).string(message.id);
-                $root.jspb.test.Simple2.encode(message.requiredSimple, writer.uint32(/* id 5, wireType 2 =*/42).fork()).ldelim();
+                    writer.uint32(/* id 6, wireType 2 =*/50).string(message.id);
+                $root.jspb.test.Simple2.encode(message.requiredSimple, writer.uint32(/* id 7, wireType 2 =*/58).fork()).ldelim();
                 if (message.optionalSimple != null && Object.hasOwnProperty.call(message, "optionalSimple"))
-                    $root.jspb.test.Simple2.encode(message.optionalSimple, writer.uint32(/* id 6, wireType 2 =*/50).fork()).ldelim();
+                    $root.jspb.test.Simple2.encode(message.optionalSimple, writer.uint32(/* id 8, wireType 2 =*/66).fork()).ldelim();
+                for (var i = 0; i < fullyUnknown.length; ++i)
+                    writer._unknownField(fullyUnknown[i]);
                 return writer;
             };
 
@@ -4935,30 +5304,48 @@ $root.jspb = (function() {
                     reader = $Reader.create(reader);
                 var end = length === undefined ? reader.len : reader.pos + length, message = new $root.jspb.test.TestGroup();
                 while (reader.pos < end) {
+                    var unknownStartPos = reader.pos;
                     var tag = reader.uint32();
                     switch (tag >>> 3) {
-                    case 1:
-                        if (!(message.repeatedGroup && message.repeatedGroup.length))
-                            message.repeatedGroup = [];
-                        message.repeatedGroup.push($root.jspb.test.TestGroup.RepeatedGroup.decode(reader));
-                        break;
-                    case 2:
-                        message.requiredGroup = $root.jspb.test.TestGroup.RequiredGroup.decode(reader);
-                        break;
-                    case 3:
-                        message.optionalGroup = $root.jspb.test.TestGroup.OptionalGroup.decode(reader);
-                        break;
-                    case 4:
-                        message.id = reader.string();
-                        break;
-                    case 5:
-                        message.requiredSimple = $root.jspb.test.Simple2.decode(reader, reader.uint32());
-                        break;
-                    case 6:
-                        message.optionalSimple = $root.jspb.test.Simple2.decode(reader, reader.uint32());
-                        break;
+                    case 1: {
+                            if (!(message.repeatedGroup && message.repeatedGroup.length))
+                                message.repeatedGroup = [];
+                            message.repeatedGroup.push($root.jspb.test.TestGroup.RepeatedGroup.decode(reader));
+                            break;
+                        }
+                    case 2: {
+                            message.requiredGroup = $root.jspb.test.TestGroup.RequiredGroup.decode(reader);
+                            break;
+                        }
+                    case 3: {
+                            message.optionalGroup = $root.jspb.test.TestGroup.OptionalGroup.decode(reader);
+                            break;
+                        }
+                    case 4: {
+                            message.messageInGroup = $root.jspb.test.TestGroup.MessageInGroup.decode(reader);
+                            break;
+                        }
+                    case 5: {
+                            message.enumInGroup = $root.jspb.test.TestGroup.EnumInGroup.decode(reader);
+                            break;
+                        }
+                    case 6: {
+                            message.id = reader.string();
+                            break;
+                        }
+                    case 7: {
+                            message.requiredSimple = $root.jspb.test.Simple2.decode(reader, reader.uint32());
+                            break;
+                        }
+                    case 8: {
+                            message.optionalSimple = $root.jspb.test.Simple2.decode(reader, reader.uint32());
+                            break;
+                        }
                     default:
                         reader.skipType(tag & 7);
+                        if (!message.$unknownFields)
+                            message.$unknownFields = [];
+                        message.$unknownFields.push(reader.buf.slice(unknownStartPos, reader.pos));
                         break;
                     }
                 }
@@ -5015,6 +5402,16 @@ $root.jspb = (function() {
                     if (error)
                         return "optionalGroup." + error;
                 }
+                if (message.messageInGroup != null && message.hasOwnProperty("messageInGroup")) {
+                    var error = $root.jspb.test.TestGroup.MessageInGroup.verify(message.messageInGroup);
+                    if (error)
+                        return "messageInGroup." + error;
+                }
+                if (message.enumInGroup != null && message.hasOwnProperty("enumInGroup")) {
+                    var error = $root.jspb.test.TestGroup.EnumInGroup.verify(message.enumInGroup);
+                    if (error)
+                        return "enumInGroup." + error;
+                }
                 if (message.id != null && message.hasOwnProperty("id"))
                     if (!$util.isString(message.id))
                         return "id: string expected";
@@ -5063,6 +5460,16 @@ $root.jspb = (function() {
                         throw TypeError(".jspb.test.TestGroup.optionalGroup: object expected");
                     message.optionalGroup = $root.jspb.test.TestGroup.OptionalGroup.fromObject(object.optionalGroup);
                 }
+                if (object.messageInGroup != null) {
+                    if (typeof object.messageInGroup !== "object")
+                        throw TypeError(".jspb.test.TestGroup.messageInGroup: object expected");
+                    message.messageInGroup = $root.jspb.test.TestGroup.MessageInGroup.fromObject(object.messageInGroup);
+                }
+                if (object.enumInGroup != null) {
+                    if (typeof object.enumInGroup !== "object")
+                        throw TypeError(".jspb.test.TestGroup.enumInGroup: object expected");
+                    message.enumInGroup = $root.jspb.test.TestGroup.EnumInGroup.fromObject(object.enumInGroup);
+                }
                 if (object.id != null)
                     message.id = String(object.id);
                 if (object.requiredSimple != null) {
@@ -5096,6 +5503,8 @@ $root.jspb = (function() {
                 if (options.defaults) {
                     object.requiredGroup = null;
                     object.optionalGroup = null;
+                    object.messageInGroup = null;
+                    object.enumInGroup = null;
                     object.id = "";
                     object.requiredSimple = null;
                     object.optionalSimple = null;
@@ -5109,6 +5518,10 @@ $root.jspb = (function() {
                     object.requiredGroup = $root.jspb.test.TestGroup.RequiredGroup.toObject(message.requiredGroup, options);
                 if (message.optionalGroup != null && message.hasOwnProperty("optionalGroup"))
                     object.optionalGroup = $root.jspb.test.TestGroup.OptionalGroup.toObject(message.optionalGroup, options);
+                if (message.messageInGroup != null && message.hasOwnProperty("messageInGroup"))
+                    object.messageInGroup = $root.jspb.test.TestGroup.MessageInGroup.toObject(message.messageInGroup, options);
+                if (message.enumInGroup != null && message.hasOwnProperty("enumInGroup"))
+                    object.enumInGroup = $root.jspb.test.TestGroup.EnumInGroup.toObject(message.enumInGroup, options);
                 if (message.id != null && message.hasOwnProperty("id"))
                     object.id = message.id;
                 if (message.requiredSimple != null && message.hasOwnProperty("requiredSimple"))
@@ -5210,10 +5623,21 @@ $root.jspb = (function() {
                 RepeatedGroup.encode = function encode(message, writer) {
                     if (!writer)
                         writer = $Writer.create();
+                    var fullyUnknown = [];
+                    if (message.$unknownFields && $root.jspb.test.TestGroup.RepeatedGroup.decode)
+                        for (var i = 0; i < message.$unknownFields.length; ++i)
+                            try {
+                                var known = $root.jspb.test.TestGroup.RepeatedGroup.decode(message.$unknownFields[i]);
+                                fullyUnknown = fullyUnknown.concat(known.$unknownFields || []);
+                                message = Object.assign(known, message);
+                            } catch (_) {
+                            }
                     writer.uint32(/* id 1, wireType 2 =*/10).string(message.id);
                     if (message.someBool != null && message.someBool.length)
                         for (var i = 0; i < message.someBool.length; ++i)
                             writer.uint32(/* id 2, wireType 0 =*/16).bool(message.someBool[i]);
+                    for (var i = 0; i < fullyUnknown.length; ++i)
+                        writer._unknownField(fullyUnknown[i]);
                     return writer;
                 };
 
@@ -5246,25 +5670,31 @@ $root.jspb = (function() {
                         reader = $Reader.create(reader);
                     var end = length === undefined ? reader.len : reader.pos + length, message = new $root.jspb.test.TestGroup.RepeatedGroup();
                     while (reader.pos < end) {
+                        var unknownStartPos = reader.pos;
                         var tag = reader.uint32();
                         if ((tag & 7) === 4)
                             break;
                         switch (tag >>> 3) {
-                        case 1:
-                            message.id = reader.string();
-                            break;
-                        case 2:
-                            if (!(message.someBool && message.someBool.length))
-                                message.someBool = [];
-                            if ((tag & 7) === 2) {
-                                var end2 = reader.uint32() + reader.pos;
-                                while (reader.pos < end2)
+                        case 1: {
+                                message.id = reader.string();
+                                break;
+                            }
+                        case 2: {
+                                if (!(message.someBool && message.someBool.length))
+                                    message.someBool = [];
+                                if ((tag & 7) === 2) {
+                                    var end2 = reader.uint32() + reader.pos;
+                                    while (reader.pos < end2)
+                                        message.someBool.push(reader.bool());
+                                } else
                                     message.someBool.push(reader.bool());
-                            } else
-                                message.someBool.push(reader.bool());
-                            break;
+                                break;
+                            }
                         default:
                             reader.skipType(tag & 7);
+                            if (!message.$unknownFields)
+                                message.$unknownFields = [];
+                            message.$unknownFields.push(reader.buf.slice(unknownStartPos, reader.pos));
                             break;
                         }
                     }
@@ -5448,7 +5878,18 @@ $root.jspb = (function() {
                 RequiredGroup.encode = function encode(message, writer) {
                     if (!writer)
                         writer = $Writer.create();
+                    var fullyUnknown = [];
+                    if (message.$unknownFields && $root.jspb.test.TestGroup.RequiredGroup.decode)
+                        for (var i = 0; i < message.$unknownFields.length; ++i)
+                            try {
+                                var known = $root.jspb.test.TestGroup.RequiredGroup.decode(message.$unknownFields[i]);
+                                fullyUnknown = fullyUnknown.concat(known.$unknownFields || []);
+                                message = Object.assign(known, message);
+                            } catch (_) {
+                            }
                     writer.uint32(/* id 1, wireType 2 =*/10).string(message.id);
+                    for (var i = 0; i < fullyUnknown.length; ++i)
+                        writer._unknownField(fullyUnknown[i]);
                     return writer;
                 };
 
@@ -5481,15 +5922,20 @@ $root.jspb = (function() {
                         reader = $Reader.create(reader);
                     var end = length === undefined ? reader.len : reader.pos + length, message = new $root.jspb.test.TestGroup.RequiredGroup();
                     while (reader.pos < end) {
+                        var unknownStartPos = reader.pos;
                         var tag = reader.uint32();
                         if ((tag & 7) === 4)
                             break;
                         switch (tag >>> 3) {
-                        case 1:
-                            message.id = reader.string();
-                            break;
+                        case 1: {
+                                message.id = reader.string();
+                                break;
+                            }
                         default:
                             reader.skipType(tag & 7);
+                            if (!message.$unknownFields)
+                                message.$unknownFields = [];
+                            message.$unknownFields.push(reader.buf.slice(unknownStartPos, reader.pos));
                             break;
                         }
                     }
@@ -5652,7 +6098,18 @@ $root.jspb = (function() {
                 OptionalGroup.encode = function encode(message, writer) {
                     if (!writer)
                         writer = $Writer.create();
+                    var fullyUnknown = [];
+                    if (message.$unknownFields && $root.jspb.test.TestGroup.OptionalGroup.decode)
+                        for (var i = 0; i < message.$unknownFields.length; ++i)
+                            try {
+                                var known = $root.jspb.test.TestGroup.OptionalGroup.decode(message.$unknownFields[i]);
+                                fullyUnknown = fullyUnknown.concat(known.$unknownFields || []);
+                                message = Object.assign(known, message);
+                            } catch (_) {
+                            }
                     writer.uint32(/* id 1, wireType 2 =*/10).string(message.id);
+                    for (var i = 0; i < fullyUnknown.length; ++i)
+                        writer._unknownField(fullyUnknown[i]);
                     return writer;
                 };
 
@@ -5685,15 +6142,20 @@ $root.jspb = (function() {
                         reader = $Reader.create(reader);
                     var end = length === undefined ? reader.len : reader.pos + length, message = new $root.jspb.test.TestGroup.OptionalGroup();
                     while (reader.pos < end) {
+                        var unknownStartPos = reader.pos;
                         var tag = reader.uint32();
                         if ((tag & 7) === 4)
                             break;
                         switch (tag >>> 3) {
-                        case 1:
-                            message.id = reader.string();
-                            break;
+                        case 1: {
+                                message.id = reader.string();
+                                break;
+                            }
                         default:
                             reader.skipType(tag & 7);
+                            if (!message.$unknownFields)
+                                message.$unknownFields = [];
+                            message.$unknownFields.push(reader.buf.slice(unknownStartPos, reader.pos));
                             break;
                         }
                     }
@@ -5800,6 +6262,703 @@ $root.jspb = (function() {
                 return OptionalGroup;
             })();
 
+            TestGroup.MessageInGroup = (function() {
+
+                /**
+                 * Properties of a MessageInGroup.
+                 * @memberof jspb.test.TestGroup
+                 * @interface IMessageInGroup
+                 * @property {jspb.test.TestGroup.MessageInGroup.INestedMessage} id MessageInGroup id
+                 */
+
+                /**
+                 * Constructs a new MessageInGroup.
+                 * @memberof jspb.test.TestGroup
+                 * @classdesc Represents a MessageInGroup.
+                 * @implements IMessageInGroup
+                 * @constructor
+                 * @param {jspb.test.TestGroup.IMessageInGroup=} [properties] Properties to set
+                 */
+                function MessageInGroup(properties) {
+                    if (properties)
+                        for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                            if (properties[keys[i]] != null)
+                                this[keys[i]] = properties[keys[i]];
+                }
+
+                /**
+                 * MessageInGroup id.
+                 * @member {jspb.test.TestGroup.MessageInGroup.INestedMessage} id
+                 * @memberof jspb.test.TestGroup.MessageInGroup
+                 * @instance
+                 */
+                MessageInGroup.prototype.id = null;
+
+                /**
+                 * Creates a new MessageInGroup instance using the specified properties.
+                 * @function create
+                 * @memberof jspb.test.TestGroup.MessageInGroup
+                 * @static
+                 * @param {jspb.test.TestGroup.IMessageInGroup=} [properties] Properties to set
+                 * @returns {jspb.test.TestGroup.MessageInGroup} MessageInGroup instance
+                 */
+                MessageInGroup.create = function create(properties) {
+                    return new MessageInGroup(properties);
+                };
+
+                /**
+                 * Encodes the specified MessageInGroup message. Does not implicitly {@link jspb.test.TestGroup.MessageInGroup.verify|verify} messages.
+                 * @function encode
+                 * @memberof jspb.test.TestGroup.MessageInGroup
+                 * @static
+                 * @param {jspb.test.TestGroup.IMessageInGroup} message MessageInGroup message or plain object to encode
+                 * @param {$protobuf.Writer} [writer] Writer to encode to
+                 * @returns {$protobuf.Writer} Writer
+                 */
+                MessageInGroup.encode = function encode(message, writer) {
+                    if (!writer)
+                        writer = $Writer.create();
+                    var fullyUnknown = [];
+                    if (message.$unknownFields && $root.jspb.test.TestGroup.MessageInGroup.decode)
+                        for (var i = 0; i < message.$unknownFields.length; ++i)
+                            try {
+                                var known = $root.jspb.test.TestGroup.MessageInGroup.decode(message.$unknownFields[i]);
+                                fullyUnknown = fullyUnknown.concat(known.$unknownFields || []);
+                                message = Object.assign(known, message);
+                            } catch (_) {
+                            }
+                    $root.jspb.test.TestGroup.MessageInGroup.NestedMessage.encode(message.id, writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
+                    for (var i = 0; i < fullyUnknown.length; ++i)
+                        writer._unknownField(fullyUnknown[i]);
+                    return writer;
+                };
+
+                /**
+                 * Encodes the specified MessageInGroup message, length delimited. Does not implicitly {@link jspb.test.TestGroup.MessageInGroup.verify|verify} messages.
+                 * @function encodeDelimited
+                 * @memberof jspb.test.TestGroup.MessageInGroup
+                 * @static
+                 * @param {jspb.test.TestGroup.IMessageInGroup} message MessageInGroup message or plain object to encode
+                 * @param {$protobuf.Writer} [writer] Writer to encode to
+                 * @returns {$protobuf.Writer} Writer
+                 */
+                MessageInGroup.encodeDelimited = function encodeDelimited(message, writer) {
+                    return this.encode(message, writer).ldelim();
+                };
+
+                /**
+                 * Decodes a MessageInGroup message from the specified reader or buffer.
+                 * @function decode
+                 * @memberof jspb.test.TestGroup.MessageInGroup
+                 * @static
+                 * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+                 * @param {number} [length] Message length if known beforehand
+                 * @returns {jspb.test.TestGroup.MessageInGroup} MessageInGroup
+                 * @throws {Error} If the payload is not a reader or valid buffer
+                 * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                 */
+                MessageInGroup.decode = function decode(reader, length) {
+                    if (!(reader instanceof $Reader))
+                        reader = $Reader.create(reader);
+                    var end = length === undefined ? reader.len : reader.pos + length, message = new $root.jspb.test.TestGroup.MessageInGroup();
+                    while (reader.pos < end) {
+                        var unknownStartPos = reader.pos;
+                        var tag = reader.uint32();
+                        if ((tag & 7) === 4)
+                            break;
+                        switch (tag >>> 3) {
+                        case 1: {
+                                message.id = $root.jspb.test.TestGroup.MessageInGroup.NestedMessage.decode(reader, reader.uint32());
+                                break;
+                            }
+                        default:
+                            reader.skipType(tag & 7);
+                            if (!message.$unknownFields)
+                                message.$unknownFields = [];
+                            message.$unknownFields.push(reader.buf.slice(unknownStartPos, reader.pos));
+                            break;
+                        }
+                    }
+                    if (!message.hasOwnProperty("id"))
+                        throw $util.ProtocolError("missing required 'id'", { instance: message });
+                    return message;
+                };
+
+                /**
+                 * Decodes a MessageInGroup message from the specified reader or buffer, length delimited.
+                 * @function decodeDelimited
+                 * @memberof jspb.test.TestGroup.MessageInGroup
+                 * @static
+                 * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+                 * @returns {jspb.test.TestGroup.MessageInGroup} MessageInGroup
+                 * @throws {Error} If the payload is not a reader or valid buffer
+                 * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                 */
+                MessageInGroup.decodeDelimited = function decodeDelimited(reader) {
+                    if (!(reader instanceof $Reader))
+                        reader = new $Reader(reader);
+                    return this.decode(reader, reader.uint32());
+                };
+
+                /**
+                 * Verifies a MessageInGroup message.
+                 * @function verify
+                 * @memberof jspb.test.TestGroup.MessageInGroup
+                 * @static
+                 * @param {Object.<string,*>} message Plain object to verify
+                 * @returns {string|null} `null` if valid, otherwise the reason why it is not
+                 */
+                MessageInGroup.verify = function verify(message) {
+                    if (typeof message !== "object" || message === null)
+                        return "object expected";
+                    {
+                        var error = $root.jspb.test.TestGroup.MessageInGroup.NestedMessage.verify(message.id);
+                        if (error)
+                            return "id." + error;
+                    }
+                    return null;
+                };
+
+                /**
+                 * Creates a MessageInGroup message from a plain object. Also converts values to their respective internal types.
+                 * @function fromObject
+                 * @memberof jspb.test.TestGroup.MessageInGroup
+                 * @static
+                 * @param {Object.<string,*>} object Plain object
+                 * @returns {jspb.test.TestGroup.MessageInGroup} MessageInGroup
+                 */
+                MessageInGroup.fromObject = function fromObject(object) {
+                    if (object instanceof $root.jspb.test.TestGroup.MessageInGroup)
+                        return object;
+                    var message = new $root.jspb.test.TestGroup.MessageInGroup();
+                    if (object.id != null) {
+                        if (typeof object.id !== "object")
+                            throw TypeError(".jspb.test.TestGroup.MessageInGroup.id: object expected");
+                        message.id = $root.jspb.test.TestGroup.MessageInGroup.NestedMessage.fromObject(object.id);
+                    }
+                    return message;
+                };
+
+                /**
+                 * Creates a plain object from a MessageInGroup message. Also converts values to other types if specified.
+                 * @function toObject
+                 * @memberof jspb.test.TestGroup.MessageInGroup
+                 * @static
+                 * @param {jspb.test.TestGroup.MessageInGroup} message MessageInGroup
+                 * @param {$protobuf.IConversionOptions} [options] Conversion options
+                 * @returns {Object.<string,*>} Plain object
+                 */
+                MessageInGroup.toObject = function toObject(message, options) {
+                    if (!options)
+                        options = {};
+                    var object = {};
+                    if (options.defaults)
+                        object.id = null;
+                    if (message.id != null && message.hasOwnProperty("id"))
+                        object.id = $root.jspb.test.TestGroup.MessageInGroup.NestedMessage.toObject(message.id, options);
+                    return object;
+                };
+
+                /**
+                 * Converts this MessageInGroup to JSON.
+                 * @function toJSON
+                 * @memberof jspb.test.TestGroup.MessageInGroup
+                 * @instance
+                 * @returns {Object.<string,*>} JSON object
+                 */
+                MessageInGroup.prototype.toJSON = function toJSON() {
+                    return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+                };
+
+                /**
+                 * Gets the default type url for MessageInGroup
+                 * @function getTypeUrl
+                 * @memberof jspb.test.TestGroup.MessageInGroup
+                 * @static
+                 * @param {string} [typeUrlPrefix] your custom typeUrlPrefix(default "type.googleapis.com")
+                 * @returns {string} The default type url
+                 */
+                MessageInGroup.getTypeUrl = function getTypeUrl(typeUrlPrefix) {
+                    if (typeUrlPrefix === undefined) {
+                        typeUrlPrefix = "type.googleapis.com";
+                    }
+                    return typeUrlPrefix + "/jspb.test.TestGroup.MessageInGroup";
+                };
+
+                MessageInGroup.NestedMessage = (function() {
+
+                    /**
+                     * Properties of a NestedMessage.
+                     * @memberof jspb.test.TestGroup.MessageInGroup
+                     * @interface INestedMessage
+                     * @property {string|null} [id] NestedMessage id
+                     */
+
+                    /**
+                     * Constructs a new NestedMessage.
+                     * @memberof jspb.test.TestGroup.MessageInGroup
+                     * @classdesc Represents a NestedMessage.
+                     * @implements INestedMessage
+                     * @constructor
+                     * @param {jspb.test.TestGroup.MessageInGroup.INestedMessage=} [properties] Properties to set
+                     */
+                    function NestedMessage(properties) {
+                        if (properties)
+                            for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                                if (properties[keys[i]] != null)
+                                    this[keys[i]] = properties[keys[i]];
+                    }
+
+                    /**
+                     * NestedMessage id.
+                     * @member {string} id
+                     * @memberof jspb.test.TestGroup.MessageInGroup.NestedMessage
+                     * @instance
+                     */
+                    NestedMessage.prototype.id = "";
+
+                    /**
+                     * Creates a new NestedMessage instance using the specified properties.
+                     * @function create
+                     * @memberof jspb.test.TestGroup.MessageInGroup.NestedMessage
+                     * @static
+                     * @param {jspb.test.TestGroup.MessageInGroup.INestedMessage=} [properties] Properties to set
+                     * @returns {jspb.test.TestGroup.MessageInGroup.NestedMessage} NestedMessage instance
+                     */
+                    NestedMessage.create = function create(properties) {
+                        return new NestedMessage(properties);
+                    };
+
+                    /**
+                     * Encodes the specified NestedMessage message. Does not implicitly {@link jspb.test.TestGroup.MessageInGroup.NestedMessage.verify|verify} messages.
+                     * @function encode
+                     * @memberof jspb.test.TestGroup.MessageInGroup.NestedMessage
+                     * @static
+                     * @param {jspb.test.TestGroup.MessageInGroup.INestedMessage} message NestedMessage message or plain object to encode
+                     * @param {$protobuf.Writer} [writer] Writer to encode to
+                     * @returns {$protobuf.Writer} Writer
+                     */
+                    NestedMessage.encode = function encode(message, writer) {
+                        if (!writer)
+                            writer = $Writer.create();
+                        var fullyUnknown = [];
+                        if (message.$unknownFields && $root.jspb.test.TestGroup.MessageInGroup.NestedMessage.decode)
+                            for (var i = 0; i < message.$unknownFields.length; ++i)
+                                try {
+                                    var known = $root.jspb.test.TestGroup.MessageInGroup.NestedMessage.decode(message.$unknownFields[i]);
+                                    fullyUnknown = fullyUnknown.concat(known.$unknownFields || []);
+                                    message = Object.assign(known, message);
+                                } catch (_) {
+                                }
+                        if (message.id != null && Object.hasOwnProperty.call(message, "id"))
+                            writer.uint32(/* id 1, wireType 2 =*/10).string(message.id);
+                        for (var i = 0; i < fullyUnknown.length; ++i)
+                            writer._unknownField(fullyUnknown[i]);
+                        return writer;
+                    };
+
+                    /**
+                     * Encodes the specified NestedMessage message, length delimited. Does not implicitly {@link jspb.test.TestGroup.MessageInGroup.NestedMessage.verify|verify} messages.
+                     * @function encodeDelimited
+                     * @memberof jspb.test.TestGroup.MessageInGroup.NestedMessage
+                     * @static
+                     * @param {jspb.test.TestGroup.MessageInGroup.INestedMessage} message NestedMessage message or plain object to encode
+                     * @param {$protobuf.Writer} [writer] Writer to encode to
+                     * @returns {$protobuf.Writer} Writer
+                     */
+                    NestedMessage.encodeDelimited = function encodeDelimited(message, writer) {
+                        return this.encode(message, writer).ldelim();
+                    };
+
+                    /**
+                     * Decodes a NestedMessage message from the specified reader or buffer.
+                     * @function decode
+                     * @memberof jspb.test.TestGroup.MessageInGroup.NestedMessage
+                     * @static
+                     * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+                     * @param {number} [length] Message length if known beforehand
+                     * @returns {jspb.test.TestGroup.MessageInGroup.NestedMessage} NestedMessage
+                     * @throws {Error} If the payload is not a reader or valid buffer
+                     * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                     */
+                    NestedMessage.decode = function decode(reader, length) {
+                        if (!(reader instanceof $Reader))
+                            reader = $Reader.create(reader);
+                        var end = length === undefined ? reader.len : reader.pos + length, message = new $root.jspb.test.TestGroup.MessageInGroup.NestedMessage();
+                        while (reader.pos < end) {
+                            var unknownStartPos = reader.pos;
+                            var tag = reader.uint32();
+                            switch (tag >>> 3) {
+                            case 1: {
+                                    message.id = reader.string();
+                                    break;
+                                }
+                            default:
+                                reader.skipType(tag & 7);
+                                if (!message.$unknownFields)
+                                    message.$unknownFields = [];
+                                message.$unknownFields.push(reader.buf.slice(unknownStartPos, reader.pos));
+                                break;
+                            }
+                        }
+                        return message;
+                    };
+
+                    /**
+                     * Decodes a NestedMessage message from the specified reader or buffer, length delimited.
+                     * @function decodeDelimited
+                     * @memberof jspb.test.TestGroup.MessageInGroup.NestedMessage
+                     * @static
+                     * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+                     * @returns {jspb.test.TestGroup.MessageInGroup.NestedMessage} NestedMessage
+                     * @throws {Error} If the payload is not a reader or valid buffer
+                     * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                     */
+                    NestedMessage.decodeDelimited = function decodeDelimited(reader) {
+                        if (!(reader instanceof $Reader))
+                            reader = new $Reader(reader);
+                        return this.decode(reader, reader.uint32());
+                    };
+
+                    /**
+                     * Verifies a NestedMessage message.
+                     * @function verify
+                     * @memberof jspb.test.TestGroup.MessageInGroup.NestedMessage
+                     * @static
+                     * @param {Object.<string,*>} message Plain object to verify
+                     * @returns {string|null} `null` if valid, otherwise the reason why it is not
+                     */
+                    NestedMessage.verify = function verify(message) {
+                        if (typeof message !== "object" || message === null)
+                            return "object expected";
+                        if (message.id != null && message.hasOwnProperty("id"))
+                            if (!$util.isString(message.id))
+                                return "id: string expected";
+                        return null;
+                    };
+
+                    /**
+                     * Creates a NestedMessage message from a plain object. Also converts values to their respective internal types.
+                     * @function fromObject
+                     * @memberof jspb.test.TestGroup.MessageInGroup.NestedMessage
+                     * @static
+                     * @param {Object.<string,*>} object Plain object
+                     * @returns {jspb.test.TestGroup.MessageInGroup.NestedMessage} NestedMessage
+                     */
+                    NestedMessage.fromObject = function fromObject(object) {
+                        if (object instanceof $root.jspb.test.TestGroup.MessageInGroup.NestedMessage)
+                            return object;
+                        var message = new $root.jspb.test.TestGroup.MessageInGroup.NestedMessage();
+                        if (object.id != null)
+                            message.id = String(object.id);
+                        return message;
+                    };
+
+                    /**
+                     * Creates a plain object from a NestedMessage message. Also converts values to other types if specified.
+                     * @function toObject
+                     * @memberof jspb.test.TestGroup.MessageInGroup.NestedMessage
+                     * @static
+                     * @param {jspb.test.TestGroup.MessageInGroup.NestedMessage} message NestedMessage
+                     * @param {$protobuf.IConversionOptions} [options] Conversion options
+                     * @returns {Object.<string,*>} Plain object
+                     */
+                    NestedMessage.toObject = function toObject(message, options) {
+                        if (!options)
+                            options = {};
+                        var object = {};
+                        if (options.defaults)
+                            object.id = "";
+                        if (message.id != null && message.hasOwnProperty("id"))
+                            object.id = message.id;
+                        return object;
+                    };
+
+                    /**
+                     * Converts this NestedMessage to JSON.
+                     * @function toJSON
+                     * @memberof jspb.test.TestGroup.MessageInGroup.NestedMessage
+                     * @instance
+                     * @returns {Object.<string,*>} JSON object
+                     */
+                    NestedMessage.prototype.toJSON = function toJSON() {
+                        return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+                    };
+
+                    /**
+                     * Gets the default type url for NestedMessage
+                     * @function getTypeUrl
+                     * @memberof jspb.test.TestGroup.MessageInGroup.NestedMessage
+                     * @static
+                     * @param {string} [typeUrlPrefix] your custom typeUrlPrefix(default "type.googleapis.com")
+                     * @returns {string} The default type url
+                     */
+                    NestedMessage.getTypeUrl = function getTypeUrl(typeUrlPrefix) {
+                        if (typeUrlPrefix === undefined) {
+                            typeUrlPrefix = "type.googleapis.com";
+                        }
+                        return typeUrlPrefix + "/jspb.test.TestGroup.MessageInGroup.NestedMessage";
+                    };
+
+                    return NestedMessage;
+                })();
+
+                return MessageInGroup;
+            })();
+
+            TestGroup.EnumInGroup = (function() {
+
+                /**
+                 * Properties of an EnumInGroup.
+                 * @memberof jspb.test.TestGroup
+                 * @interface IEnumInGroup
+                 * @property {jspb.test.TestGroup.EnumInGroup.NestedEnum} id EnumInGroup id
+                 */
+
+                /**
+                 * Constructs a new EnumInGroup.
+                 * @memberof jspb.test.TestGroup
+                 * @classdesc Represents an EnumInGroup.
+                 * @implements IEnumInGroup
+                 * @constructor
+                 * @param {jspb.test.TestGroup.IEnumInGroup=} [properties] Properties to set
+                 */
+                function EnumInGroup(properties) {
+                    if (properties)
+                        for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                            if (properties[keys[i]] != null)
+                                this[keys[i]] = properties[keys[i]];
+                }
+
+                /**
+                 * EnumInGroup id.
+                 * @member {jspb.test.TestGroup.EnumInGroup.NestedEnum} id
+                 * @memberof jspb.test.TestGroup.EnumInGroup
+                 * @instance
+                 */
+                EnumInGroup.prototype.id = 0;
+
+                /**
+                 * Creates a new EnumInGroup instance using the specified properties.
+                 * @function create
+                 * @memberof jspb.test.TestGroup.EnumInGroup
+                 * @static
+                 * @param {jspb.test.TestGroup.IEnumInGroup=} [properties] Properties to set
+                 * @returns {jspb.test.TestGroup.EnumInGroup} EnumInGroup instance
+                 */
+                EnumInGroup.create = function create(properties) {
+                    return new EnumInGroup(properties);
+                };
+
+                /**
+                 * Encodes the specified EnumInGroup message. Does not implicitly {@link jspb.test.TestGroup.EnumInGroup.verify|verify} messages.
+                 * @function encode
+                 * @memberof jspb.test.TestGroup.EnumInGroup
+                 * @static
+                 * @param {jspb.test.TestGroup.IEnumInGroup} message EnumInGroup message or plain object to encode
+                 * @param {$protobuf.Writer} [writer] Writer to encode to
+                 * @returns {$protobuf.Writer} Writer
+                 */
+                EnumInGroup.encode = function encode(message, writer) {
+                    if (!writer)
+                        writer = $Writer.create();
+                    var fullyUnknown = [];
+                    if (message.$unknownFields && $root.jspb.test.TestGroup.EnumInGroup.decode)
+                        for (var i = 0; i < message.$unknownFields.length; ++i)
+                            try {
+                                var known = $root.jspb.test.TestGroup.EnumInGroup.decode(message.$unknownFields[i]);
+                                fullyUnknown = fullyUnknown.concat(known.$unknownFields || []);
+                                message = Object.assign(known, message);
+                            } catch (_) {
+                            }
+                    writer.uint32(/* id 1, wireType 0 =*/8).int32(message.id);
+                    for (var i = 0; i < fullyUnknown.length; ++i)
+                        writer._unknownField(fullyUnknown[i]);
+                    return writer;
+                };
+
+                /**
+                 * Encodes the specified EnumInGroup message, length delimited. Does not implicitly {@link jspb.test.TestGroup.EnumInGroup.verify|verify} messages.
+                 * @function encodeDelimited
+                 * @memberof jspb.test.TestGroup.EnumInGroup
+                 * @static
+                 * @param {jspb.test.TestGroup.IEnumInGroup} message EnumInGroup message or plain object to encode
+                 * @param {$protobuf.Writer} [writer] Writer to encode to
+                 * @returns {$protobuf.Writer} Writer
+                 */
+                EnumInGroup.encodeDelimited = function encodeDelimited(message, writer) {
+                    return this.encode(message, writer).ldelim();
+                };
+
+                /**
+                 * Decodes an EnumInGroup message from the specified reader or buffer.
+                 * @function decode
+                 * @memberof jspb.test.TestGroup.EnumInGroup
+                 * @static
+                 * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+                 * @param {number} [length] Message length if known beforehand
+                 * @returns {jspb.test.TestGroup.EnumInGroup} EnumInGroup
+                 * @throws {Error} If the payload is not a reader or valid buffer
+                 * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                 */
+                EnumInGroup.decode = function decode(reader, length) {
+                    if (!(reader instanceof $Reader))
+                        reader = $Reader.create(reader);
+                    var end = length === undefined ? reader.len : reader.pos + length, message = new $root.jspb.test.TestGroup.EnumInGroup();
+                    while (reader.pos < end) {
+                        var unknownStartPos = reader.pos;
+                        var tag = reader.uint32();
+                        if ((tag & 7) === 4)
+                            break;
+                        switch (tag >>> 3) {
+                        case 1: {
+                                message.id = reader.int32();
+                                break;
+                            }
+                        default:
+                            reader.skipType(tag & 7);
+                            if (!message.$unknownFields)
+                                message.$unknownFields = [];
+                            message.$unknownFields.push(reader.buf.slice(unknownStartPos, reader.pos));
+                            break;
+                        }
+                    }
+                    if (!message.hasOwnProperty("id"))
+                        throw $util.ProtocolError("missing required 'id'", { instance: message });
+                    return message;
+                };
+
+                /**
+                 * Decodes an EnumInGroup message from the specified reader or buffer, length delimited.
+                 * @function decodeDelimited
+                 * @memberof jspb.test.TestGroup.EnumInGroup
+                 * @static
+                 * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+                 * @returns {jspb.test.TestGroup.EnumInGroup} EnumInGroup
+                 * @throws {Error} If the payload is not a reader or valid buffer
+                 * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                 */
+                EnumInGroup.decodeDelimited = function decodeDelimited(reader) {
+                    if (!(reader instanceof $Reader))
+                        reader = new $Reader(reader);
+                    return this.decode(reader, reader.uint32());
+                };
+
+                /**
+                 * Verifies an EnumInGroup message.
+                 * @function verify
+                 * @memberof jspb.test.TestGroup.EnumInGroup
+                 * @static
+                 * @param {Object.<string,*>} message Plain object to verify
+                 * @returns {string|null} `null` if valid, otherwise the reason why it is not
+                 */
+                EnumInGroup.verify = function verify(message) {
+                    if (typeof message !== "object" || message === null)
+                        return "object expected";
+                    switch (message.id) {
+                    default:
+                        return "id: enum value expected";
+                    case 0:
+                    case 1:
+                        break;
+                    }
+                    return null;
+                };
+
+                /**
+                 * Creates an EnumInGroup message from a plain object. Also converts values to their respective internal types.
+                 * @function fromObject
+                 * @memberof jspb.test.TestGroup.EnumInGroup
+                 * @static
+                 * @param {Object.<string,*>} object Plain object
+                 * @returns {jspb.test.TestGroup.EnumInGroup} EnumInGroup
+                 */
+                EnumInGroup.fromObject = function fromObject(object) {
+                    if (object instanceof $root.jspb.test.TestGroup.EnumInGroup)
+                        return object;
+                    var message = new $root.jspb.test.TestGroup.EnumInGroup();
+                    switch (object.id) {
+                    default:
+                        if (typeof object.id === "number") {
+                            message.id = object.id;
+                            break;
+                        }
+                        break;
+                    case "first":
+                    case 0:
+                        message.id = 0;
+                        break;
+                    case "second":
+                    case 1:
+                        message.id = 1;
+                        break;
+                    }
+                    return message;
+                };
+
+                /**
+                 * Creates a plain object from an EnumInGroup message. Also converts values to other types if specified.
+                 * @function toObject
+                 * @memberof jspb.test.TestGroup.EnumInGroup
+                 * @static
+                 * @param {jspb.test.TestGroup.EnumInGroup} message EnumInGroup
+                 * @param {$protobuf.IConversionOptions} [options] Conversion options
+                 * @returns {Object.<string,*>} Plain object
+                 */
+                EnumInGroup.toObject = function toObject(message, options) {
+                    if (!options)
+                        options = {};
+                    var object = {};
+                    if (options.defaults)
+                        object.id = options.enums === String ? "first" : 0;
+                    if (message.id != null && message.hasOwnProperty("id"))
+                        object.id = options.enums === String ? $root.jspb.test.TestGroup.EnumInGroup.NestedEnum[message.id] === undefined ? message.id : $root.jspb.test.TestGroup.EnumInGroup.NestedEnum[message.id] : message.id;
+                    return object;
+                };
+
+                /**
+                 * Converts this EnumInGroup to JSON.
+                 * @function toJSON
+                 * @memberof jspb.test.TestGroup.EnumInGroup
+                 * @instance
+                 * @returns {Object.<string,*>} JSON object
+                 */
+                EnumInGroup.prototype.toJSON = function toJSON() {
+                    return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+                };
+
+                /**
+                 * Gets the default type url for EnumInGroup
+                 * @function getTypeUrl
+                 * @memberof jspb.test.TestGroup.EnumInGroup
+                 * @static
+                 * @param {string} [typeUrlPrefix] your custom typeUrlPrefix(default "type.googleapis.com")
+                 * @returns {string} The default type url
+                 */
+                EnumInGroup.getTypeUrl = function getTypeUrl(typeUrlPrefix) {
+                    if (typeUrlPrefix === undefined) {
+                        typeUrlPrefix = "type.googleapis.com";
+                    }
+                    return typeUrlPrefix + "/jspb.test.TestGroup.EnumInGroup";
+                };
+
+                /**
+                 * NestedEnum enum.
+                 * @name jspb.test.TestGroup.EnumInGroup.NestedEnum
+                 * @enum {number}
+                 * @property {number} first=0 first value
+                 * @property {number} second=1 second value
+                 */
+                EnumInGroup.NestedEnum = (function() {
+                    var valuesById = {}, values = Object.create(valuesById);
+                    values[valuesById[0] = "first"] = 0;
+                    values[valuesById[1] = "second"] = 1;
+                    return values;
+                })();
+
+                return EnumInGroup;
+            })();
+
             return TestGroup;
         })();
 
@@ -5859,8 +7018,19 @@ $root.jspb = (function() {
             TestGroup1.encode = function encode(message, writer) {
                 if (!writer)
                     writer = $Writer.create();
+                var fullyUnknown = [];
+                if (message.$unknownFields && $root.jspb.test.TestGroup1.decode)
+                    for (var i = 0; i < message.$unknownFields.length; ++i)
+                        try {
+                            var known = $root.jspb.test.TestGroup1.decode(message.$unknownFields[i]);
+                            fullyUnknown = fullyUnknown.concat(known.$unknownFields || []);
+                            message = Object.assign(known, message);
+                        } catch (_) {
+                        }
                 if (message.group != null && Object.hasOwnProperty.call(message, "group"))
                     $root.jspb.test.TestGroup.RepeatedGroup.encode(message.group, writer.uint32(/* id 1, wireType 3 =*/11)).uint32(/* id 1, wireType 4 =*/12);
+                for (var i = 0; i < fullyUnknown.length; ++i)
+                    writer._unknownField(fullyUnknown[i]);
                 return writer;
             };
 
@@ -5893,13 +7063,18 @@ $root.jspb = (function() {
                     reader = $Reader.create(reader);
                 var end = length === undefined ? reader.len : reader.pos + length, message = new $root.jspb.test.TestGroup1();
                 while (reader.pos < end) {
+                    var unknownStartPos = reader.pos;
                     var tag = reader.uint32();
                     switch (tag >>> 3) {
-                    case 1:
-                        message.group = $root.jspb.test.TestGroup.RepeatedGroup.decode(reader);
-                        break;
+                    case 1: {
+                            message.group = $root.jspb.test.TestGroup.RepeatedGroup.decode(reader);
+                            break;
+                        }
                     default:
                         reader.skipType(tag & 7);
+                        if (!message.$unknownFields)
+                            message.$unknownFields = [];
+                        message.$unknownFields.push(reader.buf.slice(unknownStartPos, reader.pos));
                         break;
                     }
                 }
@@ -6075,10 +7250,21 @@ $root.jspb = (function() {
             TestReservedNames.encode = function encode(message, writer) {
                 if (!writer)
                     writer = $Writer.create();
+                var fullyUnknown = [];
+                if (message.$unknownFields && $root.jspb.test.TestReservedNames.decode)
+                    for (var i = 0; i < message.$unknownFields.length; ++i)
+                        try {
+                            var known = $root.jspb.test.TestReservedNames.decode(message.$unknownFields[i]);
+                            fullyUnknown = fullyUnknown.concat(known.$unknownFields || []);
+                            message = Object.assign(known, message);
+                        } catch (_) {
+                        }
                 if (message.extension != null && Object.hasOwnProperty.call(message, "extension"))
                     writer.uint32(/* id 1, wireType 0 =*/8).int32(message.extension);
                 if (message[".jspb.test.TestReservedNamesExtension.foo"] != null && Object.hasOwnProperty.call(message, ".jspb.test.TestReservedNamesExtension.foo"))
                     writer.uint32(/* id 10, wireType 0 =*/80).int32(message[".jspb.test.TestReservedNamesExtension.foo"]);
+                for (var i = 0; i < fullyUnknown.length; ++i)
+                    writer._unknownField(fullyUnknown[i]);
                 return writer;
             };
 
@@ -6111,16 +7297,22 @@ $root.jspb = (function() {
                     reader = $Reader.create(reader);
                 var end = length === undefined ? reader.len : reader.pos + length, message = new $root.jspb.test.TestReservedNames();
                 while (reader.pos < end) {
+                    var unknownStartPos = reader.pos;
                     var tag = reader.uint32();
                     switch (tag >>> 3) {
-                    case 1:
-                        message.extension = reader.int32();
-                        break;
-                    case 10:
-                        message[".jspb.test.TestReservedNamesExtension.foo"] = reader.int32();
-                        break;
+                    case 1: {
+                            message.extension = reader.int32();
+                            break;
+                        }
+                    case 10: {
+                            message[".jspb.test.TestReservedNamesExtension.foo"] = reader.int32();
+                            break;
+                        }
                     default:
                         reader.skipType(tag & 7);
+                        if (!message.$unknownFields)
+                            message.$unknownFields = [];
+                        message.$unknownFields.push(reader.buf.slice(unknownStartPos, reader.pos));
                         break;
                     }
                 }
@@ -6282,6 +7474,17 @@ $root.jspb = (function() {
             TestReservedNamesExtension.encode = function encode(message, writer) {
                 if (!writer)
                     writer = $Writer.create();
+                var fullyUnknown = [];
+                if (message.$unknownFields && $root.jspb.test.TestReservedNamesExtension.decode)
+                    for (var i = 0; i < message.$unknownFields.length; ++i)
+                        try {
+                            var known = $root.jspb.test.TestReservedNamesExtension.decode(message.$unknownFields[i]);
+                            fullyUnknown = fullyUnknown.concat(known.$unknownFields || []);
+                            message = Object.assign(known, message);
+                        } catch (_) {
+                        }
+                for (var i = 0; i < fullyUnknown.length; ++i)
+                    writer._unknownField(fullyUnknown[i]);
                 return writer;
             };
 
@@ -6314,10 +7517,14 @@ $root.jspb = (function() {
                     reader = $Reader.create(reader);
                 var end = length === undefined ? reader.len : reader.pos + length, message = new $root.jspb.test.TestReservedNamesExtension();
                 while (reader.pos < end) {
+                    var unknownStartPos = reader.pos;
                     var tag = reader.uint32();
                     switch (tag >>> 3) {
                     default:
                         reader.skipType(tag & 7);
+                        if (!message.$unknownFields)
+                            message.$unknownFields = [];
+                        message.$unknownFields.push(reader.buf.slice(unknownStartPos, reader.pos));
                         break;
                     }
                 }
@@ -6595,6 +7802,15 @@ $root.jspb = (function() {
             TestMessageWithOneof.encode = function encode(message, writer) {
                 if (!writer)
                     writer = $Writer.create();
+                var fullyUnknown = [];
+                if (message.$unknownFields && $root.jspb.test.TestMessageWithOneof.decode)
+                    for (var i = 0; i < message.$unknownFields.length; ++i)
+                        try {
+                            var known = $root.jspb.test.TestMessageWithOneof.decode(message.$unknownFields[i]);
+                            fullyUnknown = fullyUnknown.concat(known.$unknownFields || []);
+                            message = Object.assign(known, message);
+                        } catch (_) {
+                        }
                 if (message.pone != null && Object.hasOwnProperty.call(message, "pone"))
                     writer.uint32(/* id 3, wireType 2 =*/26).string(message.pone);
                 if (message.pthree != null && Object.hasOwnProperty.call(message, "pthree"))
@@ -6616,6 +7832,8 @@ $root.jspb = (function() {
                     writer.uint32(/* id 12, wireType 0 =*/96).int32(message.bone);
                 if (message.btwo != null && Object.hasOwnProperty.call(message, "btwo"))
                     writer.uint32(/* id 13, wireType 0 =*/104).int32(message.btwo);
+                for (var i = 0; i < fullyUnknown.length; ++i)
+                    writer._unknownField(fullyUnknown[i]);
                 return writer;
             };
 
@@ -6648,42 +7866,56 @@ $root.jspb = (function() {
                     reader = $Reader.create(reader);
                 var end = length === undefined ? reader.len : reader.pos + length, message = new $root.jspb.test.TestMessageWithOneof();
                 while (reader.pos < end) {
+                    var unknownStartPos = reader.pos;
                     var tag = reader.uint32();
                     switch (tag >>> 3) {
-                    case 3:
-                        message.pone = reader.string();
-                        break;
-                    case 5:
-                        message.pthree = reader.string();
-                        break;
-                    case 6:
-                        message.rone = $root.jspb.test.TestMessageWithOneof.decode(reader, reader.uint32());
-                        break;
-                    case 7:
-                        message.rtwo = reader.string();
-                        break;
-                    case 8:
-                        message.normalField = reader.bool();
-                        break;
-                    case 9:
-                        if (!(message.repeatedField && message.repeatedField.length))
-                            message.repeatedField = [];
-                        message.repeatedField.push(reader.string());
-                        break;
-                    case 10:
-                        message.aone = reader.int32();
-                        break;
-                    case 11:
-                        message.atwo = reader.int32();
-                        break;
-                    case 12:
-                        message.bone = reader.int32();
-                        break;
-                    case 13:
-                        message.btwo = reader.int32();
-                        break;
+                    case 3: {
+                            message.pone = reader.string();
+                            break;
+                        }
+                    case 5: {
+                            message.pthree = reader.string();
+                            break;
+                        }
+                    case 6: {
+                            message.rone = $root.jspb.test.TestMessageWithOneof.decode(reader, reader.uint32());
+                            break;
+                        }
+                    case 7: {
+                            message.rtwo = reader.string();
+                            break;
+                        }
+                    case 8: {
+                            message.normalField = reader.bool();
+                            break;
+                        }
+                    case 9: {
+                            if (!(message.repeatedField && message.repeatedField.length))
+                                message.repeatedField = [];
+                            message.repeatedField.push(reader.string());
+                            break;
+                        }
+                    case 10: {
+                            message.aone = reader.int32();
+                            break;
+                        }
+                    case 11: {
+                            message.atwo = reader.int32();
+                            break;
+                        }
+                    case 12: {
+                            message.bone = reader.int32();
+                            break;
+                        }
+                    case 13: {
+                            message.btwo = reader.int32();
+                            break;
+                        }
                     default:
                         reader.skipType(tag & 7);
+                        if (!message.$unknownFields)
+                            message.$unknownFields = [];
+                        message.$unknownFields.push(reader.buf.slice(unknownStartPos, reader.pos));
                         break;
                     }
                 }
@@ -6986,10 +8218,21 @@ $root.jspb = (function() {
             TestEndsWithBytes.encode = function encode(message, writer) {
                 if (!writer)
                     writer = $Writer.create();
+                var fullyUnknown = [];
+                if (message.$unknownFields && $root.jspb.test.TestEndsWithBytes.decode)
+                    for (var i = 0; i < message.$unknownFields.length; ++i)
+                        try {
+                            var known = $root.jspb.test.TestEndsWithBytes.decode(message.$unknownFields[i]);
+                            fullyUnknown = fullyUnknown.concat(known.$unknownFields || []);
+                            message = Object.assign(known, message);
+                        } catch (_) {
+                        }
                 if (message.value != null && Object.hasOwnProperty.call(message, "value"))
                     writer.uint32(/* id 1, wireType 0 =*/8).int32(message.value);
                 if (message.data != null && Object.hasOwnProperty.call(message, "data"))
                     writer.uint32(/* id 2, wireType 2 =*/18).bytes(message.data);
+                for (var i = 0; i < fullyUnknown.length; ++i)
+                    writer._unknownField(fullyUnknown[i]);
                 return writer;
             };
 
@@ -7022,16 +8265,22 @@ $root.jspb = (function() {
                     reader = $Reader.create(reader);
                 var end = length === undefined ? reader.len : reader.pos + length, message = new $root.jspb.test.TestEndsWithBytes();
                 while (reader.pos < end) {
+                    var unknownStartPos = reader.pos;
                     var tag = reader.uint32();
                     switch (tag >>> 3) {
-                    case 1:
-                        message.value = reader.int32();
-                        break;
-                    case 2:
-                        message.data = reader.bytes();
-                        break;
+                    case 1: {
+                            message.value = reader.int32();
+                            break;
+                        }
+                    case 2: {
+                            message.data = reader.bytes();
+                            break;
+                        }
                     default:
                         reader.skipType(tag & 7);
+                        if (!message.$unknownFields)
+                            message.$unknownFields = [];
+                        message.$unknownFields.push(reader.buf.slice(unknownStartPos, reader.pos));
                         break;
                     }
                 }
@@ -7321,6 +8570,15 @@ $root.jspb = (function() {
             TestMapFieldsNoBinary.encode = function encode(message, writer) {
                 if (!writer)
                     writer = $Writer.create();
+                var fullyUnknown = [];
+                if (message.$unknownFields && $root.jspb.test.TestMapFieldsNoBinary.decode)
+                    for (var i = 0; i < message.$unknownFields.length; ++i)
+                        try {
+                            var known = $root.jspb.test.TestMapFieldsNoBinary.decode(message.$unknownFields[i]);
+                            fullyUnknown = fullyUnknown.concat(known.$unknownFields || []);
+                            message = Object.assign(known, message);
+                        } catch (_) {
+                        }
                 if (message.mapStringString != null && Object.hasOwnProperty.call(message, "mapStringString"))
                     for (var keys = Object.keys(message.mapStringString), i = 0; i < keys.length; ++i)
                         writer.uint32(/* id 1, wireType 2 =*/10).fork().uint32(/* id 1, wireType 2 =*/10).string(keys[i]).uint32(/* id 2, wireType 2 =*/18).string(message.mapStringString[keys[i]]).ldelim();
@@ -7360,6 +8618,8 @@ $root.jspb = (function() {
                         writer.uint32(/* id 12, wireType 2 =*/98).fork().uint32(/* id 1, wireType 2 =*/10).string(keys[i]);
                         $root.jspb.test.TestMapFieldsNoBinary.encode(message.mapStringTestmapfields[keys[i]], writer.uint32(/* id 2, wireType 2 =*/18).fork()).ldelim().ldelim();
                     }
+                for (var i = 0; i < fullyUnknown.length; ++i)
+                    writer._unknownField(fullyUnknown[i]);
                 return writer;
             };
 
@@ -7392,255 +8652,271 @@ $root.jspb = (function() {
                     reader = $Reader.create(reader);
                 var end = length === undefined ? reader.len : reader.pos + length, message = new $root.jspb.test.TestMapFieldsNoBinary(), key, value;
                 while (reader.pos < end) {
+                    var unknownStartPos = reader.pos;
                     var tag = reader.uint32();
                     switch (tag >>> 3) {
-                    case 1:
-                        if (message.mapStringString === $util.emptyObject)
-                            message.mapStringString = {};
-                        var end2 = reader.uint32() + reader.pos;
-                        key = "";
-                        value = "";
-                        while (reader.pos < end2) {
-                            var tag2 = reader.uint32();
-                            switch (tag2 >>> 3) {
-                            case 1:
-                                key = reader.string();
-                                break;
-                            case 2:
-                                value = reader.string();
-                                break;
-                            default:
-                                reader.skipType(tag2 & 7);
-                                break;
+                    case 1: {
+                            if (message.mapStringString === $util.emptyObject)
+                                message.mapStringString = {};
+                            var end2 = reader.uint32() + reader.pos;
+                            key = "";
+                            value = "";
+                            while (reader.pos < end2) {
+                                var tag2 = reader.uint32();
+                                switch (tag2 >>> 3) {
+                                case 1:
+                                    key = reader.string();
+                                    break;
+                                case 2:
+                                    value = reader.string();
+                                    break;
+                                default:
+                                    reader.skipType(tag2 & 7);
+                                    break;
+                                }
                             }
+                            message.mapStringString[key] = value;
+                            break;
                         }
-                        message.mapStringString[key] = value;
-                        break;
-                    case 2:
-                        if (message.mapStringInt32 === $util.emptyObject)
-                            message.mapStringInt32 = {};
-                        var end2 = reader.uint32() + reader.pos;
-                        key = "";
-                        value = 0;
-                        while (reader.pos < end2) {
-                            var tag2 = reader.uint32();
-                            switch (tag2 >>> 3) {
-                            case 1:
-                                key = reader.string();
-                                break;
-                            case 2:
-                                value = reader.int32();
-                                break;
-                            default:
-                                reader.skipType(tag2 & 7);
-                                break;
+                    case 2: {
+                            if (message.mapStringInt32 === $util.emptyObject)
+                                message.mapStringInt32 = {};
+                            var end2 = reader.uint32() + reader.pos;
+                            key = "";
+                            value = 0;
+                            while (reader.pos < end2) {
+                                var tag2 = reader.uint32();
+                                switch (tag2 >>> 3) {
+                                case 1:
+                                    key = reader.string();
+                                    break;
+                                case 2:
+                                    value = reader.int32();
+                                    break;
+                                default:
+                                    reader.skipType(tag2 & 7);
+                                    break;
+                                }
                             }
+                            message.mapStringInt32[key] = value;
+                            break;
                         }
-                        message.mapStringInt32[key] = value;
-                        break;
-                    case 3:
-                        if (message.mapStringInt64 === $util.emptyObject)
-                            message.mapStringInt64 = {};
-                        var end2 = reader.uint32() + reader.pos;
-                        key = "";
-                        value = 0;
-                        while (reader.pos < end2) {
-                            var tag2 = reader.uint32();
-                            switch (tag2 >>> 3) {
-                            case 1:
-                                key = reader.string();
-                                break;
-                            case 2:
-                                value = reader.int64();
-                                break;
-                            default:
-                                reader.skipType(tag2 & 7);
-                                break;
+                    case 3: {
+                            if (message.mapStringInt64 === $util.emptyObject)
+                                message.mapStringInt64 = {};
+                            var end2 = reader.uint32() + reader.pos;
+                            key = "";
+                            value = 0;
+                            while (reader.pos < end2) {
+                                var tag2 = reader.uint32();
+                                switch (tag2 >>> 3) {
+                                case 1:
+                                    key = reader.string();
+                                    break;
+                                case 2:
+                                    value = reader.int64();
+                                    break;
+                                default:
+                                    reader.skipType(tag2 & 7);
+                                    break;
+                                }
                             }
+                            message.mapStringInt64[key] = value;
+                            break;
                         }
-                        message.mapStringInt64[key] = value;
-                        break;
-                    case 4:
-                        if (message.mapStringBool === $util.emptyObject)
-                            message.mapStringBool = {};
-                        var end2 = reader.uint32() + reader.pos;
-                        key = "";
-                        value = false;
-                        while (reader.pos < end2) {
-                            var tag2 = reader.uint32();
-                            switch (tag2 >>> 3) {
-                            case 1:
-                                key = reader.string();
-                                break;
-                            case 2:
-                                value = reader.bool();
-                                break;
-                            default:
-                                reader.skipType(tag2 & 7);
-                                break;
+                    case 4: {
+                            if (message.mapStringBool === $util.emptyObject)
+                                message.mapStringBool = {};
+                            var end2 = reader.uint32() + reader.pos;
+                            key = "";
+                            value = false;
+                            while (reader.pos < end2) {
+                                var tag2 = reader.uint32();
+                                switch (tag2 >>> 3) {
+                                case 1:
+                                    key = reader.string();
+                                    break;
+                                case 2:
+                                    value = reader.bool();
+                                    break;
+                                default:
+                                    reader.skipType(tag2 & 7);
+                                    break;
+                                }
                             }
+                            message.mapStringBool[key] = value;
+                            break;
                         }
-                        message.mapStringBool[key] = value;
-                        break;
-                    case 5:
-                        if (message.mapStringDouble === $util.emptyObject)
-                            message.mapStringDouble = {};
-                        var end2 = reader.uint32() + reader.pos;
-                        key = "";
-                        value = 0;
-                        while (reader.pos < end2) {
-                            var tag2 = reader.uint32();
-                            switch (tag2 >>> 3) {
-                            case 1:
-                                key = reader.string();
-                                break;
-                            case 2:
-                                value = reader.double();
-                                break;
-                            default:
-                                reader.skipType(tag2 & 7);
-                                break;
+                    case 5: {
+                            if (message.mapStringDouble === $util.emptyObject)
+                                message.mapStringDouble = {};
+                            var end2 = reader.uint32() + reader.pos;
+                            key = "";
+                            value = 0;
+                            while (reader.pos < end2) {
+                                var tag2 = reader.uint32();
+                                switch (tag2 >>> 3) {
+                                case 1:
+                                    key = reader.string();
+                                    break;
+                                case 2:
+                                    value = reader.double();
+                                    break;
+                                default:
+                                    reader.skipType(tag2 & 7);
+                                    break;
+                                }
                             }
+                            message.mapStringDouble[key] = value;
+                            break;
                         }
-                        message.mapStringDouble[key] = value;
-                        break;
-                    case 6:
-                        if (message.mapStringEnum === $util.emptyObject)
-                            message.mapStringEnum = {};
-                        var end2 = reader.uint32() + reader.pos;
-                        key = "";
-                        value = 0;
-                        while (reader.pos < end2) {
-                            var tag2 = reader.uint32();
-                            switch (tag2 >>> 3) {
-                            case 1:
-                                key = reader.string();
-                                break;
-                            case 2:
-                                value = reader.int32();
-                                break;
-                            default:
-                                reader.skipType(tag2 & 7);
-                                break;
+                    case 6: {
+                            if (message.mapStringEnum === $util.emptyObject)
+                                message.mapStringEnum = {};
+                            var end2 = reader.uint32() + reader.pos;
+                            key = "";
+                            value = 0;
+                            while (reader.pos < end2) {
+                                var tag2 = reader.uint32();
+                                switch (tag2 >>> 3) {
+                                case 1:
+                                    key = reader.string();
+                                    break;
+                                case 2:
+                                    value = reader.int32();
+                                    break;
+                                default:
+                                    reader.skipType(tag2 & 7);
+                                    break;
+                                }
                             }
+                            message.mapStringEnum[key] = value;
+                            break;
                         }
-                        message.mapStringEnum[key] = value;
-                        break;
-                    case 7:
-                        if (message.mapStringMsg === $util.emptyObject)
-                            message.mapStringMsg = {};
-                        var end2 = reader.uint32() + reader.pos;
-                        key = "";
-                        value = null;
-                        while (reader.pos < end2) {
-                            var tag2 = reader.uint32();
-                            switch (tag2 >>> 3) {
-                            case 1:
-                                key = reader.string();
-                                break;
-                            case 2:
-                                value = $root.jspb.test.MapValueMessageNoBinary.decode(reader, reader.uint32());
-                                break;
-                            default:
-                                reader.skipType(tag2 & 7);
-                                break;
+                    case 7: {
+                            if (message.mapStringMsg === $util.emptyObject)
+                                message.mapStringMsg = {};
+                            var end2 = reader.uint32() + reader.pos;
+                            key = "";
+                            value = null;
+                            while (reader.pos < end2) {
+                                var tag2 = reader.uint32();
+                                switch (tag2 >>> 3) {
+                                case 1:
+                                    key = reader.string();
+                                    break;
+                                case 2:
+                                    value = $root.jspb.test.MapValueMessageNoBinary.decode(reader, reader.uint32());
+                                    break;
+                                default:
+                                    reader.skipType(tag2 & 7);
+                                    break;
+                                }
                             }
+                            message.mapStringMsg[key] = value;
+                            break;
                         }
-                        message.mapStringMsg[key] = value;
-                        break;
-                    case 8:
-                        if (message.mapInt32String === $util.emptyObject)
-                            message.mapInt32String = {};
-                        var end2 = reader.uint32() + reader.pos;
-                        key = 0;
-                        value = "";
-                        while (reader.pos < end2) {
-                            var tag2 = reader.uint32();
-                            switch (tag2 >>> 3) {
-                            case 1:
-                                key = reader.int32();
-                                break;
-                            case 2:
-                                value = reader.string();
-                                break;
-                            default:
-                                reader.skipType(tag2 & 7);
-                                break;
+                    case 8: {
+                            if (message.mapInt32String === $util.emptyObject)
+                                message.mapInt32String = {};
+                            var end2 = reader.uint32() + reader.pos;
+                            key = 0;
+                            value = "";
+                            while (reader.pos < end2) {
+                                var tag2 = reader.uint32();
+                                switch (tag2 >>> 3) {
+                                case 1:
+                                    key = reader.int32();
+                                    break;
+                                case 2:
+                                    value = reader.string();
+                                    break;
+                                default:
+                                    reader.skipType(tag2 & 7);
+                                    break;
+                                }
                             }
+                            message.mapInt32String[key] = value;
+                            break;
                         }
-                        message.mapInt32String[key] = value;
-                        break;
-                    case 9:
-                        if (message.mapInt64String === $util.emptyObject)
-                            message.mapInt64String = {};
-                        var end2 = reader.uint32() + reader.pos;
-                        key = 0;
-                        value = "";
-                        while (reader.pos < end2) {
-                            var tag2 = reader.uint32();
-                            switch (tag2 >>> 3) {
-                            case 1:
-                                key = reader.int64();
-                                break;
-                            case 2:
-                                value = reader.string();
-                                break;
-                            default:
-                                reader.skipType(tag2 & 7);
-                                break;
+                    case 9: {
+                            if (message.mapInt64String === $util.emptyObject)
+                                message.mapInt64String = {};
+                            var end2 = reader.uint32() + reader.pos;
+                            key = 0;
+                            value = "";
+                            while (reader.pos < end2) {
+                                var tag2 = reader.uint32();
+                                switch (tag2 >>> 3) {
+                                case 1:
+                                    key = reader.int64();
+                                    break;
+                                case 2:
+                                    value = reader.string();
+                                    break;
+                                default:
+                                    reader.skipType(tag2 & 7);
+                                    break;
+                                }
                             }
+                            message.mapInt64String[typeof key === "object" ? $util.longToHash(key) : key] = value;
+                            break;
                         }
-                        message.mapInt64String[typeof key === "object" ? $util.longToHash(key) : key] = value;
-                        break;
-                    case 10:
-                        if (message.mapBoolString === $util.emptyObject)
-                            message.mapBoolString = {};
-                        var end2 = reader.uint32() + reader.pos;
-                        key = false;
-                        value = "";
-                        while (reader.pos < end2) {
-                            var tag2 = reader.uint32();
-                            switch (tag2 >>> 3) {
-                            case 1:
-                                key = reader.bool();
-                                break;
-                            case 2:
-                                value = reader.string();
-                                break;
-                            default:
-                                reader.skipType(tag2 & 7);
-                                break;
+                    case 10: {
+                            if (message.mapBoolString === $util.emptyObject)
+                                message.mapBoolString = {};
+                            var end2 = reader.uint32() + reader.pos;
+                            key = false;
+                            value = "";
+                            while (reader.pos < end2) {
+                                var tag2 = reader.uint32();
+                                switch (tag2 >>> 3) {
+                                case 1:
+                                    key = reader.bool();
+                                    break;
+                                case 2:
+                                    value = reader.string();
+                                    break;
+                                default:
+                                    reader.skipType(tag2 & 7);
+                                    break;
+                                }
                             }
+                            message.mapBoolString[key] = value;
+                            break;
                         }
-                        message.mapBoolString[key] = value;
-                        break;
-                    case 11:
-                        message.testMapFields = $root.jspb.test.TestMapFieldsNoBinary.decode(reader, reader.uint32());
-                        break;
-                    case 12:
-                        if (message.mapStringTestmapfields === $util.emptyObject)
-                            message.mapStringTestmapfields = {};
-                        var end2 = reader.uint32() + reader.pos;
-                        key = "";
-                        value = null;
-                        while (reader.pos < end2) {
-                            var tag2 = reader.uint32();
-                            switch (tag2 >>> 3) {
-                            case 1:
-                                key = reader.string();
-                                break;
-                            case 2:
-                                value = $root.jspb.test.TestMapFieldsNoBinary.decode(reader, reader.uint32());
-                                break;
-                            default:
-                                reader.skipType(tag2 & 7);
-                                break;
+                    case 11: {
+                            message.testMapFields = $root.jspb.test.TestMapFieldsNoBinary.decode(reader, reader.uint32());
+                            break;
+                        }
+                    case 12: {
+                            if (message.mapStringTestmapfields === $util.emptyObject)
+                                message.mapStringTestmapfields = {};
+                            var end2 = reader.uint32() + reader.pos;
+                            key = "";
+                            value = null;
+                            while (reader.pos < end2) {
+                                var tag2 = reader.uint32();
+                                switch (tag2 >>> 3) {
+                                case 1:
+                                    key = reader.string();
+                                    break;
+                                case 2:
+                                    value = $root.jspb.test.TestMapFieldsNoBinary.decode(reader, reader.uint32());
+                                    break;
+                                default:
+                                    reader.skipType(tag2 & 7);
+                                    break;
+                                }
                             }
+                            message.mapStringTestmapfields[key] = value;
+                            break;
                         }
-                        message.mapStringTestmapfields[key] = value;
-                        break;
                     default:
                         reader.skipType(tag & 7);
+                        if (!message.$unknownFields)
+                            message.$unknownFields = [];
+                        message.$unknownFields.push(reader.buf.slice(unknownStartPos, reader.pos));
                         break;
                     }
                 }
@@ -7849,6 +9125,12 @@ $root.jspb = (function() {
                     message.mapStringEnum = {};
                     for (var keys = Object.keys(object.mapStringEnum), i = 0; i < keys.length; ++i)
                         switch (object.mapStringEnum[keys[i]]) {
+                        default:
+                            if (typeof object.mapStringEnum[keys[i]] === "number") {
+                                message.mapStringEnum[keys[i]] = object.mapStringEnum[keys[i]];
+                                break;
+                            }
+                            break;
                         case "MAP_VALUE_FOO_NOBINARY":
                         case 0:
                             message.mapStringEnum[keys[i]] = 0;
@@ -7972,7 +9254,7 @@ $root.jspb = (function() {
                 if (message.mapStringEnum && (keys2 = Object.keys(message.mapStringEnum)).length) {
                     object.mapStringEnum = {};
                     for (var j = 0; j < keys2.length; ++j)
-                        object.mapStringEnum[keys2[j]] = options.enums === String ? $root.jspb.test.MapValueEnumNoBinary[message.mapStringEnum[keys2[j]]] : message.mapStringEnum[keys2[j]];
+                        object.mapStringEnum[keys2[j]] = options.enums === String ? $root.jspb.test.MapValueEnumNoBinary[message.mapStringEnum[keys2[j]]] === undefined ? message.mapStringEnum[keys2[j]] : $root.jspb.test.MapValueEnumNoBinary[message.mapStringEnum[keys2[j]]] : message.mapStringEnum[keys2[j]];
                 }
                 if (message.mapStringMsg && (keys2 = Object.keys(message.mapStringMsg)).length) {
                     object.mapStringMsg = {};
@@ -8105,8 +9387,19 @@ $root.jspb = (function() {
             MapValueMessageNoBinary.encode = function encode(message, writer) {
                 if (!writer)
                     writer = $Writer.create();
+                var fullyUnknown = [];
+                if (message.$unknownFields && $root.jspb.test.MapValueMessageNoBinary.decode)
+                    for (var i = 0; i < message.$unknownFields.length; ++i)
+                        try {
+                            var known = $root.jspb.test.MapValueMessageNoBinary.decode(message.$unknownFields[i]);
+                            fullyUnknown = fullyUnknown.concat(known.$unknownFields || []);
+                            message = Object.assign(known, message);
+                        } catch (_) {
+                        }
                 if (message.foo != null && Object.hasOwnProperty.call(message, "foo"))
                     writer.uint32(/* id 1, wireType 0 =*/8).int32(message.foo);
+                for (var i = 0; i < fullyUnknown.length; ++i)
+                    writer._unknownField(fullyUnknown[i]);
                 return writer;
             };
 
@@ -8139,13 +9432,18 @@ $root.jspb = (function() {
                     reader = $Reader.create(reader);
                 var end = length === undefined ? reader.len : reader.pos + length, message = new $root.jspb.test.MapValueMessageNoBinary();
                 while (reader.pos < end) {
+                    var unknownStartPos = reader.pos;
                     var tag = reader.uint32();
                     switch (tag >>> 3) {
-                    case 1:
-                        message.foo = reader.int32();
-                        break;
+                    case 1: {
+                            message.foo = reader.int32();
+                            break;
+                        }
                     default:
                         reader.skipType(tag & 7);
+                        if (!message.$unknownFields)
+                            message.$unknownFields = [];
+                        message.$unknownFields.push(reader.buf.slice(unknownStartPos, reader.pos));
                         break;
                     }
                 }
@@ -8298,6 +9596,17 @@ $root.jspb = (function() {
             Deeply.encode = function encode(message, writer) {
                 if (!writer)
                     writer = $Writer.create();
+                var fullyUnknown = [];
+                if (message.$unknownFields && $root.jspb.test.Deeply.decode)
+                    for (var i = 0; i < message.$unknownFields.length; ++i)
+                        try {
+                            var known = $root.jspb.test.Deeply.decode(message.$unknownFields[i]);
+                            fullyUnknown = fullyUnknown.concat(known.$unknownFields || []);
+                            message = Object.assign(known, message);
+                        } catch (_) {
+                        }
+                for (var i = 0; i < fullyUnknown.length; ++i)
+                    writer._unknownField(fullyUnknown[i]);
                 return writer;
             };
 
@@ -8330,10 +9639,14 @@ $root.jspb = (function() {
                     reader = $Reader.create(reader);
                 var end = length === undefined ? reader.len : reader.pos + length, message = new $root.jspb.test.Deeply();
                 while (reader.pos < end) {
+                    var unknownStartPos = reader.pos;
                     var tag = reader.uint32();
                     switch (tag >>> 3) {
                     default:
                         reader.skipType(tag & 7);
+                        if (!message.$unknownFields)
+                            message.$unknownFields = [];
+                        message.$unknownFields.push(reader.buf.slice(unknownStartPos, reader.pos));
                         break;
                     }
                 }
@@ -8470,6 +9783,17 @@ $root.jspb = (function() {
                 Nested.encode = function encode(message, writer) {
                     if (!writer)
                         writer = $Writer.create();
+                    var fullyUnknown = [];
+                    if (message.$unknownFields && $root.jspb.test.Deeply.Nested.decode)
+                        for (var i = 0; i < message.$unknownFields.length; ++i)
+                            try {
+                                var known = $root.jspb.test.Deeply.Nested.decode(message.$unknownFields[i]);
+                                fullyUnknown = fullyUnknown.concat(known.$unknownFields || []);
+                                message = Object.assign(known, message);
+                            } catch (_) {
+                            }
+                    for (var i = 0; i < fullyUnknown.length; ++i)
+                        writer._unknownField(fullyUnknown[i]);
                     return writer;
                 };
 
@@ -8502,10 +9826,14 @@ $root.jspb = (function() {
                         reader = $Reader.create(reader);
                     var end = length === undefined ? reader.len : reader.pos + length, message = new $root.jspb.test.Deeply.Nested();
                     while (reader.pos < end) {
+                        var unknownStartPos = reader.pos;
                         var tag = reader.uint32();
                         switch (tag >>> 3) {
                         default:
                             reader.skipType(tag & 7);
+                            if (!message.$unknownFields)
+                                message.$unknownFields = [];
+                            message.$unknownFields.push(reader.buf.slice(unknownStartPos, reader.pos));
                             break;
                         }
                     }
@@ -8651,8 +9979,19 @@ $root.jspb = (function() {
                     Message.encode = function encode(message, writer) {
                         if (!writer)
                             writer = $Writer.create();
+                        var fullyUnknown = [];
+                        if (message.$unknownFields && $root.jspb.test.Deeply.Nested.Message.decode)
+                            for (var i = 0; i < message.$unknownFields.length; ++i)
+                                try {
+                                    var known = $root.jspb.test.Deeply.Nested.Message.decode(message.$unknownFields[i]);
+                                    fullyUnknown = fullyUnknown.concat(known.$unknownFields || []);
+                                    message = Object.assign(known, message);
+                                } catch (_) {
+                                }
                         if (message.count != null && Object.hasOwnProperty.call(message, "count"))
                             writer.uint32(/* id 1, wireType 0 =*/8).int32(message.count);
+                        for (var i = 0; i < fullyUnknown.length; ++i)
+                            writer._unknownField(fullyUnknown[i]);
                         return writer;
                     };
 
@@ -8685,13 +10024,18 @@ $root.jspb = (function() {
                             reader = $Reader.create(reader);
                         var end = length === undefined ? reader.len : reader.pos + length, message = new $root.jspb.test.Deeply.Nested.Message();
                         while (reader.pos < end) {
+                            var unknownStartPos = reader.pos;
                             var tag = reader.uint32();
                             switch (tag >>> 3) {
-                            case 1:
-                                message.count = reader.int32();
-                                break;
+                            case 1: {
+                                    message.count = reader.int32();
+                                    break;
+                                }
                             default:
                                 reader.skipType(tag & 7);
+                                if (!message.$unknownFields)
+                                    message.$unknownFields = [];
+                                message.$unknownFields.push(reader.buf.slice(unknownStartPos, reader.pos));
                                 break;
                             }
                         }
@@ -8884,9 +10228,20 @@ $root.google = (function() {
             FileDescriptorSet.encode = function encode(message, writer) {
                 if (!writer)
                     writer = $Writer.create();
+                var fullyUnknown = [];
+                if (message.$unknownFields && $root.google.protobuf.FileDescriptorSet.decode)
+                    for (var i = 0; i < message.$unknownFields.length; ++i)
+                        try {
+                            var known = $root.google.protobuf.FileDescriptorSet.decode(message.$unknownFields[i]);
+                            fullyUnknown = fullyUnknown.concat(known.$unknownFields || []);
+                            message = Object.assign(known, message);
+                        } catch (_) {
+                        }
                 if (message.file != null && message.file.length)
                     for (var i = 0; i < message.file.length; ++i)
                         $root.google.protobuf.FileDescriptorProto.encode(message.file[i], writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
+                for (var i = 0; i < fullyUnknown.length; ++i)
+                    writer._unknownField(fullyUnknown[i]);
                 return writer;
             };
 
@@ -8919,15 +10274,20 @@ $root.google = (function() {
                     reader = $Reader.create(reader);
                 var end = length === undefined ? reader.len : reader.pos + length, message = new $root.google.protobuf.FileDescriptorSet();
                 while (reader.pos < end) {
+                    var unknownStartPos = reader.pos;
                     var tag = reader.uint32();
                     switch (tag >>> 3) {
-                    case 1:
-                        if (!(message.file && message.file.length))
-                            message.file = [];
-                        message.file.push($root.google.protobuf.FileDescriptorProto.decode(reader, reader.uint32()));
-                        break;
+                    case 1: {
+                            if (!(message.file && message.file.length))
+                                message.file = [];
+                            message.file.push($root.google.protobuf.FileDescriptorProto.decode(reader, reader.uint32()));
+                            break;
+                        }
                     default:
                         reader.skipType(tag & 7);
+                        if (!message.$unknownFields)
+                            message.$unknownFields = [];
+                        message.$unknownFields.push(reader.buf.slice(unknownStartPos, reader.pos));
                         break;
                     }
                 }
@@ -9212,6 +10572,15 @@ $root.google = (function() {
             FileDescriptorProto.encode = function encode(message, writer) {
                 if (!writer)
                     writer = $Writer.create();
+                var fullyUnknown = [];
+                if (message.$unknownFields && $root.google.protobuf.FileDescriptorProto.decode)
+                    for (var i = 0; i < message.$unknownFields.length; ++i)
+                        try {
+                            var known = $root.google.protobuf.FileDescriptorProto.decode(message.$unknownFields[i]);
+                            fullyUnknown = fullyUnknown.concat(known.$unknownFields || []);
+                            message = Object.assign(known, message);
+                        } catch (_) {
+                        }
                 if (message.name != null && Object.hasOwnProperty.call(message, "name"))
                     writer.uint32(/* id 1, wireType 2 =*/10).string(message.name);
                 if (message["package"] != null && Object.hasOwnProperty.call(message, "package"))
@@ -9243,6 +10612,8 @@ $root.google = (function() {
                         writer.uint32(/* id 11, wireType 0 =*/88).int32(message.weakDependency[i]);
                 if (message.syntax != null && Object.hasOwnProperty.call(message, "syntax"))
                     writer.uint32(/* id 12, wireType 2 =*/98).string(message.syntax);
+                for (var i = 0; i < fullyUnknown.length; ++i)
+                    writer._unknownField(fullyUnknown[i]);
                 return writer;
             };
 
@@ -9275,70 +10646,86 @@ $root.google = (function() {
                     reader = $Reader.create(reader);
                 var end = length === undefined ? reader.len : reader.pos + length, message = new $root.google.protobuf.FileDescriptorProto();
                 while (reader.pos < end) {
+                    var unknownStartPos = reader.pos;
                     var tag = reader.uint32();
                     switch (tag >>> 3) {
-                    case 1:
-                        message.name = reader.string();
-                        break;
-                    case 2:
-                        message["package"] = reader.string();
-                        break;
-                    case 3:
-                        if (!(message.dependency && message.dependency.length))
-                            message.dependency = [];
-                        message.dependency.push(reader.string());
-                        break;
-                    case 10:
-                        if (!(message.publicDependency && message.publicDependency.length))
-                            message.publicDependency = [];
-                        if ((tag & 7) === 2) {
-                            var end2 = reader.uint32() + reader.pos;
-                            while (reader.pos < end2)
+                    case 1: {
+                            message.name = reader.string();
+                            break;
+                        }
+                    case 2: {
+                            message["package"] = reader.string();
+                            break;
+                        }
+                    case 3: {
+                            if (!(message.dependency && message.dependency.length))
+                                message.dependency = [];
+                            message.dependency.push(reader.string());
+                            break;
+                        }
+                    case 10: {
+                            if (!(message.publicDependency && message.publicDependency.length))
+                                message.publicDependency = [];
+                            if ((tag & 7) === 2) {
+                                var end2 = reader.uint32() + reader.pos;
+                                while (reader.pos < end2)
+                                    message.publicDependency.push(reader.int32());
+                            } else
                                 message.publicDependency.push(reader.int32());
-                        } else
-                            message.publicDependency.push(reader.int32());
-                        break;
-                    case 11:
-                        if (!(message.weakDependency && message.weakDependency.length))
-                            message.weakDependency = [];
-                        if ((tag & 7) === 2) {
-                            var end2 = reader.uint32() + reader.pos;
-                            while (reader.pos < end2)
+                            break;
+                        }
+                    case 11: {
+                            if (!(message.weakDependency && message.weakDependency.length))
+                                message.weakDependency = [];
+                            if ((tag & 7) === 2) {
+                                var end2 = reader.uint32() + reader.pos;
+                                while (reader.pos < end2)
+                                    message.weakDependency.push(reader.int32());
+                            } else
                                 message.weakDependency.push(reader.int32());
-                        } else
-                            message.weakDependency.push(reader.int32());
-                        break;
-                    case 4:
-                        if (!(message.messageType && message.messageType.length))
-                            message.messageType = [];
-                        message.messageType.push($root.google.protobuf.DescriptorProto.decode(reader, reader.uint32()));
-                        break;
-                    case 5:
-                        if (!(message.enumType && message.enumType.length))
-                            message.enumType = [];
-                        message.enumType.push($root.google.protobuf.EnumDescriptorProto.decode(reader, reader.uint32()));
-                        break;
-                    case 6:
-                        if (!(message.service && message.service.length))
-                            message.service = [];
-                        message.service.push($root.google.protobuf.ServiceDescriptorProto.decode(reader, reader.uint32()));
-                        break;
-                    case 7:
-                        if (!(message.extension && message.extension.length))
-                            message.extension = [];
-                        message.extension.push($root.google.protobuf.FieldDescriptorProto.decode(reader, reader.uint32()));
-                        break;
-                    case 8:
-                        message.options = $root.google.protobuf.FileOptions.decode(reader, reader.uint32());
-                        break;
-                    case 9:
-                        message.sourceCodeInfo = $root.google.protobuf.SourceCodeInfo.decode(reader, reader.uint32());
-                        break;
-                    case 12:
-                        message.syntax = reader.string();
-                        break;
+                            break;
+                        }
+                    case 4: {
+                            if (!(message.messageType && message.messageType.length))
+                                message.messageType = [];
+                            message.messageType.push($root.google.protobuf.DescriptorProto.decode(reader, reader.uint32()));
+                            break;
+                        }
+                    case 5: {
+                            if (!(message.enumType && message.enumType.length))
+                                message.enumType = [];
+                            message.enumType.push($root.google.protobuf.EnumDescriptorProto.decode(reader, reader.uint32()));
+                            break;
+                        }
+                    case 6: {
+                            if (!(message.service && message.service.length))
+                                message.service = [];
+                            message.service.push($root.google.protobuf.ServiceDescriptorProto.decode(reader, reader.uint32()));
+                            break;
+                        }
+                    case 7: {
+                            if (!(message.extension && message.extension.length))
+                                message.extension = [];
+                            message.extension.push($root.google.protobuf.FieldDescriptorProto.decode(reader, reader.uint32()));
+                            break;
+                        }
+                    case 8: {
+                            message.options = $root.google.protobuf.FileOptions.decode(reader, reader.uint32());
+                            break;
+                        }
+                    case 9: {
+                            message.sourceCodeInfo = $root.google.protobuf.SourceCodeInfo.decode(reader, reader.uint32());
+                            break;
+                        }
+                    case 12: {
+                            message.syntax = reader.string();
+                            break;
+                        }
                     default:
                         reader.skipType(tag & 7);
+                        if (!message.$unknownFields)
+                            message.$unknownFields = [];
+                        message.$unknownFields.push(reader.buf.slice(unknownStartPos, reader.pos));
                         break;
                     }
                 }
@@ -9794,6 +11181,15 @@ $root.google = (function() {
             DescriptorProto.encode = function encode(message, writer) {
                 if (!writer)
                     writer = $Writer.create();
+                var fullyUnknown = [];
+                if (message.$unknownFields && $root.google.protobuf.DescriptorProto.decode)
+                    for (var i = 0; i < message.$unknownFields.length; ++i)
+                        try {
+                            var known = $root.google.protobuf.DescriptorProto.decode(message.$unknownFields[i]);
+                            fullyUnknown = fullyUnknown.concat(known.$unknownFields || []);
+                            message = Object.assign(known, message);
+                        } catch (_) {
+                        }
                 if (message.name != null && Object.hasOwnProperty.call(message, "name"))
                     writer.uint32(/* id 1, wireType 2 =*/10).string(message.name);
                 if (message.field != null && message.field.length)
@@ -9822,6 +11218,8 @@ $root.google = (function() {
                 if (message.reservedName != null && message.reservedName.length)
                     for (var i = 0; i < message.reservedName.length; ++i)
                         writer.uint32(/* id 10, wireType 2 =*/82).string(message.reservedName[i]);
+                for (var i = 0; i < fullyUnknown.length; ++i)
+                    writer._unknownField(fullyUnknown[i]);
                 return writer;
             };
 
@@ -9854,56 +11252,70 @@ $root.google = (function() {
                     reader = $Reader.create(reader);
                 var end = length === undefined ? reader.len : reader.pos + length, message = new $root.google.protobuf.DescriptorProto();
                 while (reader.pos < end) {
+                    var unknownStartPos = reader.pos;
                     var tag = reader.uint32();
                     switch (tag >>> 3) {
-                    case 1:
-                        message.name = reader.string();
-                        break;
-                    case 2:
-                        if (!(message.field && message.field.length))
-                            message.field = [];
-                        message.field.push($root.google.protobuf.FieldDescriptorProto.decode(reader, reader.uint32()));
-                        break;
-                    case 6:
-                        if (!(message.extension && message.extension.length))
-                            message.extension = [];
-                        message.extension.push($root.google.protobuf.FieldDescriptorProto.decode(reader, reader.uint32()));
-                        break;
-                    case 3:
-                        if (!(message.nestedType && message.nestedType.length))
-                            message.nestedType = [];
-                        message.nestedType.push($root.google.protobuf.DescriptorProto.decode(reader, reader.uint32()));
-                        break;
-                    case 4:
-                        if (!(message.enumType && message.enumType.length))
-                            message.enumType = [];
-                        message.enumType.push($root.google.protobuf.EnumDescriptorProto.decode(reader, reader.uint32()));
-                        break;
-                    case 5:
-                        if (!(message.extensionRange && message.extensionRange.length))
-                            message.extensionRange = [];
-                        message.extensionRange.push($root.google.protobuf.DescriptorProto.ExtensionRange.decode(reader, reader.uint32()));
-                        break;
-                    case 8:
-                        if (!(message.oneofDecl && message.oneofDecl.length))
-                            message.oneofDecl = [];
-                        message.oneofDecl.push($root.google.protobuf.OneofDescriptorProto.decode(reader, reader.uint32()));
-                        break;
-                    case 7:
-                        message.options = $root.google.protobuf.MessageOptions.decode(reader, reader.uint32());
-                        break;
-                    case 9:
-                        if (!(message.reservedRange && message.reservedRange.length))
-                            message.reservedRange = [];
-                        message.reservedRange.push($root.google.protobuf.DescriptorProto.ReservedRange.decode(reader, reader.uint32()));
-                        break;
-                    case 10:
-                        if (!(message.reservedName && message.reservedName.length))
-                            message.reservedName = [];
-                        message.reservedName.push(reader.string());
-                        break;
+                    case 1: {
+                            message.name = reader.string();
+                            break;
+                        }
+                    case 2: {
+                            if (!(message.field && message.field.length))
+                                message.field = [];
+                            message.field.push($root.google.protobuf.FieldDescriptorProto.decode(reader, reader.uint32()));
+                            break;
+                        }
+                    case 6: {
+                            if (!(message.extension && message.extension.length))
+                                message.extension = [];
+                            message.extension.push($root.google.protobuf.FieldDescriptorProto.decode(reader, reader.uint32()));
+                            break;
+                        }
+                    case 3: {
+                            if (!(message.nestedType && message.nestedType.length))
+                                message.nestedType = [];
+                            message.nestedType.push($root.google.protobuf.DescriptorProto.decode(reader, reader.uint32()));
+                            break;
+                        }
+                    case 4: {
+                            if (!(message.enumType && message.enumType.length))
+                                message.enumType = [];
+                            message.enumType.push($root.google.protobuf.EnumDescriptorProto.decode(reader, reader.uint32()));
+                            break;
+                        }
+                    case 5: {
+                            if (!(message.extensionRange && message.extensionRange.length))
+                                message.extensionRange = [];
+                            message.extensionRange.push($root.google.protobuf.DescriptorProto.ExtensionRange.decode(reader, reader.uint32()));
+                            break;
+                        }
+                    case 8: {
+                            if (!(message.oneofDecl && message.oneofDecl.length))
+                                message.oneofDecl = [];
+                            message.oneofDecl.push($root.google.protobuf.OneofDescriptorProto.decode(reader, reader.uint32()));
+                            break;
+                        }
+                    case 7: {
+                            message.options = $root.google.protobuf.MessageOptions.decode(reader, reader.uint32());
+                            break;
+                        }
+                    case 9: {
+                            if (!(message.reservedRange && message.reservedRange.length))
+                                message.reservedRange = [];
+                            message.reservedRange.push($root.google.protobuf.DescriptorProto.ReservedRange.decode(reader, reader.uint32()));
+                            break;
+                        }
+                    case 10: {
+                            if (!(message.reservedName && message.reservedName.length))
+                                message.reservedName = [];
+                            message.reservedName.push(reader.string());
+                            break;
+                        }
                     default:
                         reader.skipType(tag & 7);
+                        if (!message.$unknownFields)
+                            message.$unknownFields = [];
+                        message.$unknownFields.push(reader.buf.slice(unknownStartPos, reader.pos));
                         break;
                     }
                 }
@@ -10282,10 +11694,21 @@ $root.google = (function() {
                 ExtensionRange.encode = function encode(message, writer) {
                     if (!writer)
                         writer = $Writer.create();
+                    var fullyUnknown = [];
+                    if (message.$unknownFields && $root.google.protobuf.DescriptorProto.ExtensionRange.decode)
+                        for (var i = 0; i < message.$unknownFields.length; ++i)
+                            try {
+                                var known = $root.google.protobuf.DescriptorProto.ExtensionRange.decode(message.$unknownFields[i]);
+                                fullyUnknown = fullyUnknown.concat(known.$unknownFields || []);
+                                message = Object.assign(known, message);
+                            } catch (_) {
+                            }
                     if (message.start != null && Object.hasOwnProperty.call(message, "start"))
                         writer.uint32(/* id 1, wireType 0 =*/8).int32(message.start);
                     if (message.end != null && Object.hasOwnProperty.call(message, "end"))
                         writer.uint32(/* id 2, wireType 0 =*/16).int32(message.end);
+                    for (var i = 0; i < fullyUnknown.length; ++i)
+                        writer._unknownField(fullyUnknown[i]);
                     return writer;
                 };
 
@@ -10318,16 +11741,22 @@ $root.google = (function() {
                         reader = $Reader.create(reader);
                     var end = length === undefined ? reader.len : reader.pos + length, message = new $root.google.protobuf.DescriptorProto.ExtensionRange();
                     while (reader.pos < end) {
+                        var unknownStartPos = reader.pos;
                         var tag = reader.uint32();
                         switch (tag >>> 3) {
-                        case 1:
-                            message.start = reader.int32();
-                            break;
-                        case 2:
-                            message.end = reader.int32();
-                            break;
+                        case 1: {
+                                message.start = reader.int32();
+                                break;
+                            }
+                        case 2: {
+                                message.end = reader.int32();
+                                break;
+                            }
                         default:
                             reader.skipType(tag & 7);
+                            if (!message.$unknownFields)
+                                message.$unknownFields = [];
+                            message.$unknownFields.push(reader.buf.slice(unknownStartPos, reader.pos));
                             break;
                         }
                     }
@@ -10507,10 +11936,21 @@ $root.google = (function() {
                 ReservedRange.encode = function encode(message, writer) {
                     if (!writer)
                         writer = $Writer.create();
+                    var fullyUnknown = [];
+                    if (message.$unknownFields && $root.google.protobuf.DescriptorProto.ReservedRange.decode)
+                        for (var i = 0; i < message.$unknownFields.length; ++i)
+                            try {
+                                var known = $root.google.protobuf.DescriptorProto.ReservedRange.decode(message.$unknownFields[i]);
+                                fullyUnknown = fullyUnknown.concat(known.$unknownFields || []);
+                                message = Object.assign(known, message);
+                            } catch (_) {
+                            }
                     if (message.start != null && Object.hasOwnProperty.call(message, "start"))
                         writer.uint32(/* id 1, wireType 0 =*/8).int32(message.start);
                     if (message.end != null && Object.hasOwnProperty.call(message, "end"))
                         writer.uint32(/* id 2, wireType 0 =*/16).int32(message.end);
+                    for (var i = 0; i < fullyUnknown.length; ++i)
+                        writer._unknownField(fullyUnknown[i]);
                     return writer;
                 };
 
@@ -10543,16 +11983,22 @@ $root.google = (function() {
                         reader = $Reader.create(reader);
                     var end = length === undefined ? reader.len : reader.pos + length, message = new $root.google.protobuf.DescriptorProto.ReservedRange();
                     while (reader.pos < end) {
+                        var unknownStartPos = reader.pos;
                         var tag = reader.uint32();
                         switch (tag >>> 3) {
-                        case 1:
-                            message.start = reader.int32();
-                            break;
-                        case 2:
-                            message.end = reader.int32();
-                            break;
+                        case 1: {
+                                message.start = reader.int32();
+                                break;
+                            }
+                        case 2: {
+                                message.end = reader.int32();
+                                break;
+                            }
                         default:
                             reader.skipType(tag & 7);
+                            if (!message.$unknownFields)
+                                message.$unknownFields = [];
+                            message.$unknownFields.push(reader.buf.slice(unknownStartPos, reader.pos));
                             break;
                         }
                     }
@@ -10807,6 +12253,15 @@ $root.google = (function() {
             FieldDescriptorProto.encode = function encode(message, writer) {
                 if (!writer)
                     writer = $Writer.create();
+                var fullyUnknown = [];
+                if (message.$unknownFields && $root.google.protobuf.FieldDescriptorProto.decode)
+                    for (var i = 0; i < message.$unknownFields.length; ++i)
+                        try {
+                            var known = $root.google.protobuf.FieldDescriptorProto.decode(message.$unknownFields[i]);
+                            fullyUnknown = fullyUnknown.concat(known.$unknownFields || []);
+                            message = Object.assign(known, message);
+                        } catch (_) {
+                        }
                 if (message.name != null && Object.hasOwnProperty.call(message, "name"))
                     writer.uint32(/* id 1, wireType 2 =*/10).string(message.name);
                 if (message.extendee != null && Object.hasOwnProperty.call(message, "extendee"))
@@ -10827,6 +12282,8 @@ $root.google = (function() {
                     writer.uint32(/* id 9, wireType 0 =*/72).int32(message.oneofIndex);
                 if (message.jsonName != null && Object.hasOwnProperty.call(message, "jsonName"))
                     writer.uint32(/* id 10, wireType 2 =*/82).string(message.jsonName);
+                for (var i = 0; i < fullyUnknown.length; ++i)
+                    writer._unknownField(fullyUnknown[i]);
                 return writer;
             };
 
@@ -10859,40 +12316,54 @@ $root.google = (function() {
                     reader = $Reader.create(reader);
                 var end = length === undefined ? reader.len : reader.pos + length, message = new $root.google.protobuf.FieldDescriptorProto();
                 while (reader.pos < end) {
+                    var unknownStartPos = reader.pos;
                     var tag = reader.uint32();
                     switch (tag >>> 3) {
-                    case 1:
-                        message.name = reader.string();
-                        break;
-                    case 3:
-                        message.number = reader.int32();
-                        break;
-                    case 4:
-                        message.label = reader.int32();
-                        break;
-                    case 5:
-                        message.type = reader.int32();
-                        break;
-                    case 6:
-                        message.typeName = reader.string();
-                        break;
-                    case 2:
-                        message.extendee = reader.string();
-                        break;
-                    case 7:
-                        message.defaultValue = reader.string();
-                        break;
-                    case 9:
-                        message.oneofIndex = reader.int32();
-                        break;
-                    case 10:
-                        message.jsonName = reader.string();
-                        break;
-                    case 8:
-                        message.options = $root.google.protobuf.FieldOptions.decode(reader, reader.uint32());
-                        break;
+                    case 1: {
+                            message.name = reader.string();
+                            break;
+                        }
+                    case 3: {
+                            message.number = reader.int32();
+                            break;
+                        }
+                    case 4: {
+                            message.label = reader.int32();
+                            break;
+                        }
+                    case 5: {
+                            message.type = reader.int32();
+                            break;
+                        }
+                    case 6: {
+                            message.typeName = reader.string();
+                            break;
+                        }
+                    case 2: {
+                            message.extendee = reader.string();
+                            break;
+                        }
+                    case 7: {
+                            message.defaultValue = reader.string();
+                            break;
+                        }
+                    case 9: {
+                            message.oneofIndex = reader.int32();
+                            break;
+                        }
+                    case 10: {
+                            message.jsonName = reader.string();
+                            break;
+                        }
+                    case 8: {
+                            message.options = $root.google.protobuf.FieldOptions.decode(reader, reader.uint32());
+                            break;
+                        }
                     default:
                         reader.skipType(tag & 7);
+                        if (!message.$unknownFields)
+                            message.$unknownFields = [];
+                        message.$unknownFields.push(reader.buf.slice(unknownStartPos, reader.pos));
                         break;
                     }
                 }
@@ -11005,6 +12476,12 @@ $root.google = (function() {
                 if (object.number != null)
                     message.number = object.number | 0;
                 switch (object.label) {
+                default:
+                    if (typeof object.label === "number") {
+                        message.label = object.label;
+                        break;
+                    }
+                    break;
                 case "LABEL_OPTIONAL":
                 case 1:
                     message.label = 1;
@@ -11019,6 +12496,12 @@ $root.google = (function() {
                     break;
                 }
                 switch (object.type) {
+                default:
+                    if (typeof object.type === "number") {
+                        message.type = object.type;
+                        break;
+                    }
+                    break;
                 case "TYPE_DOUBLE":
                 case 1:
                     message.type = 1;
@@ -11142,9 +12625,9 @@ $root.google = (function() {
                 if (message.number != null && message.hasOwnProperty("number"))
                     object.number = message.number;
                 if (message.label != null && message.hasOwnProperty("label"))
-                    object.label = options.enums === String ? $root.google.protobuf.FieldDescriptorProto.Label[message.label] : message.label;
+                    object.label = options.enums === String ? $root.google.protobuf.FieldDescriptorProto.Label[message.label] === undefined ? message.label : $root.google.protobuf.FieldDescriptorProto.Label[message.label] : message.label;
                 if (message.type != null && message.hasOwnProperty("type"))
-                    object.type = options.enums === String ? $root.google.protobuf.FieldDescriptorProto.Type[message.type] : message.type;
+                    object.type = options.enums === String ? $root.google.protobuf.FieldDescriptorProto.Type[message.type] === undefined ? message.type : $root.google.protobuf.FieldDescriptorProto.Type[message.type] : message.type;
                 if (message.typeName != null && message.hasOwnProperty("typeName"))
                     object.typeName = message.typeName;
                 if (message.defaultValue != null && message.hasOwnProperty("defaultValue"))
@@ -11314,10 +12797,21 @@ $root.google = (function() {
             OneofDescriptorProto.encode = function encode(message, writer) {
                 if (!writer)
                     writer = $Writer.create();
+                var fullyUnknown = [];
+                if (message.$unknownFields && $root.google.protobuf.OneofDescriptorProto.decode)
+                    for (var i = 0; i < message.$unknownFields.length; ++i)
+                        try {
+                            var known = $root.google.protobuf.OneofDescriptorProto.decode(message.$unknownFields[i]);
+                            fullyUnknown = fullyUnknown.concat(known.$unknownFields || []);
+                            message = Object.assign(known, message);
+                        } catch (_) {
+                        }
                 if (message.name != null && Object.hasOwnProperty.call(message, "name"))
                     writer.uint32(/* id 1, wireType 2 =*/10).string(message.name);
                 if (message.options != null && Object.hasOwnProperty.call(message, "options"))
                     $root.google.protobuf.OneofOptions.encode(message.options, writer.uint32(/* id 2, wireType 2 =*/18).fork()).ldelim();
+                for (var i = 0; i < fullyUnknown.length; ++i)
+                    writer._unknownField(fullyUnknown[i]);
                 return writer;
             };
 
@@ -11350,16 +12844,22 @@ $root.google = (function() {
                     reader = $Reader.create(reader);
                 var end = length === undefined ? reader.len : reader.pos + length, message = new $root.google.protobuf.OneofDescriptorProto();
                 while (reader.pos < end) {
+                    var unknownStartPos = reader.pos;
                     var tag = reader.uint32();
                     switch (tag >>> 3) {
-                    case 1:
-                        message.name = reader.string();
-                        break;
-                    case 2:
-                        message.options = $root.google.protobuf.OneofOptions.decode(reader, reader.uint32());
-                        break;
+                    case 1: {
+                            message.name = reader.string();
+                            break;
+                        }
+                    case 2: {
+                            message.options = $root.google.protobuf.OneofOptions.decode(reader, reader.uint32());
+                            break;
+                        }
                     default:
                         reader.skipType(tag & 7);
+                        if (!message.$unknownFields)
+                            message.$unknownFields = [];
+                        message.$unknownFields.push(reader.buf.slice(unknownStartPos, reader.pos));
                         break;
                     }
                 }
@@ -11554,6 +13054,15 @@ $root.google = (function() {
             EnumDescriptorProto.encode = function encode(message, writer) {
                 if (!writer)
                     writer = $Writer.create();
+                var fullyUnknown = [];
+                if (message.$unknownFields && $root.google.protobuf.EnumDescriptorProto.decode)
+                    for (var i = 0; i < message.$unknownFields.length; ++i)
+                        try {
+                            var known = $root.google.protobuf.EnumDescriptorProto.decode(message.$unknownFields[i]);
+                            fullyUnknown = fullyUnknown.concat(known.$unknownFields || []);
+                            message = Object.assign(known, message);
+                        } catch (_) {
+                        }
                 if (message.name != null && Object.hasOwnProperty.call(message, "name"))
                     writer.uint32(/* id 1, wireType 2 =*/10).string(message.name);
                 if (message.value != null && message.value.length)
@@ -11561,6 +13070,8 @@ $root.google = (function() {
                         $root.google.protobuf.EnumValueDescriptorProto.encode(message.value[i], writer.uint32(/* id 2, wireType 2 =*/18).fork()).ldelim();
                 if (message.options != null && Object.hasOwnProperty.call(message, "options"))
                     $root.google.protobuf.EnumOptions.encode(message.options, writer.uint32(/* id 3, wireType 2 =*/26).fork()).ldelim();
+                for (var i = 0; i < fullyUnknown.length; ++i)
+                    writer._unknownField(fullyUnknown[i]);
                 return writer;
             };
 
@@ -11593,21 +13104,28 @@ $root.google = (function() {
                     reader = $Reader.create(reader);
                 var end = length === undefined ? reader.len : reader.pos + length, message = new $root.google.protobuf.EnumDescriptorProto();
                 while (reader.pos < end) {
+                    var unknownStartPos = reader.pos;
                     var tag = reader.uint32();
                     switch (tag >>> 3) {
-                    case 1:
-                        message.name = reader.string();
-                        break;
-                    case 2:
-                        if (!(message.value && message.value.length))
-                            message.value = [];
-                        message.value.push($root.google.protobuf.EnumValueDescriptorProto.decode(reader, reader.uint32()));
-                        break;
-                    case 3:
-                        message.options = $root.google.protobuf.EnumOptions.decode(reader, reader.uint32());
-                        break;
+                    case 1: {
+                            message.name = reader.string();
+                            break;
+                        }
+                    case 2: {
+                            if (!(message.value && message.value.length))
+                                message.value = [];
+                            message.value.push($root.google.protobuf.EnumValueDescriptorProto.decode(reader, reader.uint32()));
+                            break;
+                        }
+                    case 3: {
+                            message.options = $root.google.protobuf.EnumOptions.decode(reader, reader.uint32());
+                            break;
+                        }
                     default:
                         reader.skipType(tag & 7);
+                        if (!message.$unknownFields)
+                            message.$unknownFields = [];
+                        message.$unknownFields.push(reader.buf.slice(unknownStartPos, reader.pos));
                         break;
                     }
                 }
@@ -11827,12 +13345,23 @@ $root.google = (function() {
             EnumValueDescriptorProto.encode = function encode(message, writer) {
                 if (!writer)
                     writer = $Writer.create();
+                var fullyUnknown = [];
+                if (message.$unknownFields && $root.google.protobuf.EnumValueDescriptorProto.decode)
+                    for (var i = 0; i < message.$unknownFields.length; ++i)
+                        try {
+                            var known = $root.google.protobuf.EnumValueDescriptorProto.decode(message.$unknownFields[i]);
+                            fullyUnknown = fullyUnknown.concat(known.$unknownFields || []);
+                            message = Object.assign(known, message);
+                        } catch (_) {
+                        }
                 if (message.name != null && Object.hasOwnProperty.call(message, "name"))
                     writer.uint32(/* id 1, wireType 2 =*/10).string(message.name);
                 if (message.number != null && Object.hasOwnProperty.call(message, "number"))
                     writer.uint32(/* id 2, wireType 0 =*/16).int32(message.number);
                 if (message.options != null && Object.hasOwnProperty.call(message, "options"))
                     $root.google.protobuf.EnumValueOptions.encode(message.options, writer.uint32(/* id 3, wireType 2 =*/26).fork()).ldelim();
+                for (var i = 0; i < fullyUnknown.length; ++i)
+                    writer._unknownField(fullyUnknown[i]);
                 return writer;
             };
 
@@ -11865,19 +13394,26 @@ $root.google = (function() {
                     reader = $Reader.create(reader);
                 var end = length === undefined ? reader.len : reader.pos + length, message = new $root.google.protobuf.EnumValueDescriptorProto();
                 while (reader.pos < end) {
+                    var unknownStartPos = reader.pos;
                     var tag = reader.uint32();
                     switch (tag >>> 3) {
-                    case 1:
-                        message.name = reader.string();
-                        break;
-                    case 2:
-                        message.number = reader.int32();
-                        break;
-                    case 3:
-                        message.options = $root.google.protobuf.EnumValueOptions.decode(reader, reader.uint32());
-                        break;
+                    case 1: {
+                            message.name = reader.string();
+                            break;
+                        }
+                    case 2: {
+                            message.number = reader.int32();
+                            break;
+                        }
+                    case 3: {
+                            message.options = $root.google.protobuf.EnumValueOptions.decode(reader, reader.uint32());
+                            break;
+                        }
                     default:
                         reader.skipType(tag & 7);
+                        if (!message.$unknownFields)
+                            message.$unknownFields = [];
+                        message.$unknownFields.push(reader.buf.slice(unknownStartPos, reader.pos));
                         break;
                     }
                 }
@@ -12080,6 +13616,15 @@ $root.google = (function() {
             ServiceDescriptorProto.encode = function encode(message, writer) {
                 if (!writer)
                     writer = $Writer.create();
+                var fullyUnknown = [];
+                if (message.$unknownFields && $root.google.protobuf.ServiceDescriptorProto.decode)
+                    for (var i = 0; i < message.$unknownFields.length; ++i)
+                        try {
+                            var known = $root.google.protobuf.ServiceDescriptorProto.decode(message.$unknownFields[i]);
+                            fullyUnknown = fullyUnknown.concat(known.$unknownFields || []);
+                            message = Object.assign(known, message);
+                        } catch (_) {
+                        }
                 if (message.name != null && Object.hasOwnProperty.call(message, "name"))
                     writer.uint32(/* id 1, wireType 2 =*/10).string(message.name);
                 if (message.method != null && message.method.length)
@@ -12087,6 +13632,8 @@ $root.google = (function() {
                         $root.google.protobuf.MethodDescriptorProto.encode(message.method[i], writer.uint32(/* id 2, wireType 2 =*/18).fork()).ldelim();
                 if (message.options != null && Object.hasOwnProperty.call(message, "options"))
                     $root.google.protobuf.ServiceOptions.encode(message.options, writer.uint32(/* id 3, wireType 2 =*/26).fork()).ldelim();
+                for (var i = 0; i < fullyUnknown.length; ++i)
+                    writer._unknownField(fullyUnknown[i]);
                 return writer;
             };
 
@@ -12119,21 +13666,28 @@ $root.google = (function() {
                     reader = $Reader.create(reader);
                 var end = length === undefined ? reader.len : reader.pos + length, message = new $root.google.protobuf.ServiceDescriptorProto();
                 while (reader.pos < end) {
+                    var unknownStartPos = reader.pos;
                     var tag = reader.uint32();
                     switch (tag >>> 3) {
-                    case 1:
-                        message.name = reader.string();
-                        break;
-                    case 2:
-                        if (!(message.method && message.method.length))
-                            message.method = [];
-                        message.method.push($root.google.protobuf.MethodDescriptorProto.decode(reader, reader.uint32()));
-                        break;
-                    case 3:
-                        message.options = $root.google.protobuf.ServiceOptions.decode(reader, reader.uint32());
-                        break;
+                    case 1: {
+                            message.name = reader.string();
+                            break;
+                        }
+                    case 2: {
+                            if (!(message.method && message.method.length))
+                                message.method = [];
+                            message.method.push($root.google.protobuf.MethodDescriptorProto.decode(reader, reader.uint32()));
+                            break;
+                        }
+                    case 3: {
+                            message.options = $root.google.protobuf.ServiceOptions.decode(reader, reader.uint32());
+                            break;
+                        }
                     default:
                         reader.skipType(tag & 7);
+                        if (!message.$unknownFields)
+                            message.$unknownFields = [];
+                        message.$unknownFields.push(reader.buf.slice(unknownStartPos, reader.pos));
                         break;
                     }
                 }
@@ -12380,6 +13934,15 @@ $root.google = (function() {
             MethodDescriptorProto.encode = function encode(message, writer) {
                 if (!writer)
                     writer = $Writer.create();
+                var fullyUnknown = [];
+                if (message.$unknownFields && $root.google.protobuf.MethodDescriptorProto.decode)
+                    for (var i = 0; i < message.$unknownFields.length; ++i)
+                        try {
+                            var known = $root.google.protobuf.MethodDescriptorProto.decode(message.$unknownFields[i]);
+                            fullyUnknown = fullyUnknown.concat(known.$unknownFields || []);
+                            message = Object.assign(known, message);
+                        } catch (_) {
+                        }
                 if (message.name != null && Object.hasOwnProperty.call(message, "name"))
                     writer.uint32(/* id 1, wireType 2 =*/10).string(message.name);
                 if (message.inputType != null && Object.hasOwnProperty.call(message, "inputType"))
@@ -12392,6 +13955,8 @@ $root.google = (function() {
                     writer.uint32(/* id 5, wireType 0 =*/40).bool(message.clientStreaming);
                 if (message.serverStreaming != null && Object.hasOwnProperty.call(message, "serverStreaming"))
                     writer.uint32(/* id 6, wireType 0 =*/48).bool(message.serverStreaming);
+                for (var i = 0; i < fullyUnknown.length; ++i)
+                    writer._unknownField(fullyUnknown[i]);
                 return writer;
             };
 
@@ -12424,28 +13989,38 @@ $root.google = (function() {
                     reader = $Reader.create(reader);
                 var end = length === undefined ? reader.len : reader.pos + length, message = new $root.google.protobuf.MethodDescriptorProto();
                 while (reader.pos < end) {
+                    var unknownStartPos = reader.pos;
                     var tag = reader.uint32();
                     switch (tag >>> 3) {
-                    case 1:
-                        message.name = reader.string();
-                        break;
-                    case 2:
-                        message.inputType = reader.string();
-                        break;
-                    case 3:
-                        message.outputType = reader.string();
-                        break;
-                    case 4:
-                        message.options = $root.google.protobuf.MethodOptions.decode(reader, reader.uint32());
-                        break;
-                    case 5:
-                        message.clientStreaming = reader.bool();
-                        break;
-                    case 6:
-                        message.serverStreaming = reader.bool();
-                        break;
+                    case 1: {
+                            message.name = reader.string();
+                            break;
+                        }
+                    case 2: {
+                            message.inputType = reader.string();
+                            break;
+                        }
+                    case 3: {
+                            message.outputType = reader.string();
+                            break;
+                        }
+                    case 4: {
+                            message.options = $root.google.protobuf.MethodOptions.decode(reader, reader.uint32());
+                            break;
+                        }
+                    case 5: {
+                            message.clientStreaming = reader.bool();
+                            break;
+                        }
+                    case 6: {
+                            message.serverStreaming = reader.bool();
+                            break;
+                        }
                     default:
                         reader.skipType(tag & 7);
+                        if (!message.$unknownFields)
+                            message.$unknownFields = [];
+                        message.$unknownFields.push(reader.buf.slice(unknownStartPos, reader.pos));
                         break;
                     }
                 }
@@ -12780,6 +14355,15 @@ $root.google = (function() {
             FileOptions.encode = function encode(message, writer) {
                 if (!writer)
                     writer = $Writer.create();
+                var fullyUnknown = [];
+                if (message.$unknownFields && $root.google.protobuf.FileOptions.decode)
+                    for (var i = 0; i < message.$unknownFields.length; ++i)
+                        try {
+                            var known = $root.google.protobuf.FileOptions.decode(message.$unknownFields[i]);
+                            fullyUnknown = fullyUnknown.concat(known.$unknownFields || []);
+                            message = Object.assign(known, message);
+                        } catch (_) {
+                        }
                 if (message.javaPackage != null && Object.hasOwnProperty.call(message, "javaPackage"))
                     writer.uint32(/* id 1, wireType 2 =*/10).string(message.javaPackage);
                 if (message.javaOuterClassname != null && Object.hasOwnProperty.call(message, "javaOuterClassname"))
@@ -12811,6 +14395,8 @@ $root.google = (function() {
                 if (message.uninterpretedOption != null && message.uninterpretedOption.length)
                     for (var i = 0; i < message.uninterpretedOption.length; ++i)
                         $root.google.protobuf.UninterpretedOption.encode(message.uninterpretedOption[i], writer.uint32(/* id 999, wireType 2 =*/7994).fork()).ldelim();
+                for (var i = 0; i < fullyUnknown.length; ++i)
+                    writer._unknownField(fullyUnknown[i]);
                 return writer;
             };
 
@@ -12843,57 +14429,76 @@ $root.google = (function() {
                     reader = $Reader.create(reader);
                 var end = length === undefined ? reader.len : reader.pos + length, message = new $root.google.protobuf.FileOptions();
                 while (reader.pos < end) {
+                    var unknownStartPos = reader.pos;
                     var tag = reader.uint32();
                     switch (tag >>> 3) {
-                    case 1:
-                        message.javaPackage = reader.string();
-                        break;
-                    case 8:
-                        message.javaOuterClassname = reader.string();
-                        break;
-                    case 10:
-                        message.javaMultipleFiles = reader.bool();
-                        break;
-                    case 20:
-                        message.javaGenerateEqualsAndHash = reader.bool();
-                        break;
-                    case 27:
-                        message.javaStringCheckUtf8 = reader.bool();
-                        break;
-                    case 9:
-                        message.optimizeFor = reader.int32();
-                        break;
-                    case 11:
-                        message.goPackage = reader.string();
-                        break;
-                    case 16:
-                        message.ccGenericServices = reader.bool();
-                        break;
-                    case 17:
-                        message.javaGenericServices = reader.bool();
-                        break;
-                    case 18:
-                        message.pyGenericServices = reader.bool();
-                        break;
-                    case 23:
-                        message.deprecated = reader.bool();
-                        break;
-                    case 31:
-                        message.ccEnableArenas = reader.bool();
-                        break;
-                    case 36:
-                        message.objcClassPrefix = reader.string();
-                        break;
-                    case 37:
-                        message.csharpNamespace = reader.string();
-                        break;
-                    case 999:
-                        if (!(message.uninterpretedOption && message.uninterpretedOption.length))
-                            message.uninterpretedOption = [];
-                        message.uninterpretedOption.push($root.google.protobuf.UninterpretedOption.decode(reader, reader.uint32()));
-                        break;
+                    case 1: {
+                            message.javaPackage = reader.string();
+                            break;
+                        }
+                    case 8: {
+                            message.javaOuterClassname = reader.string();
+                            break;
+                        }
+                    case 10: {
+                            message.javaMultipleFiles = reader.bool();
+                            break;
+                        }
+                    case 20: {
+                            message.javaGenerateEqualsAndHash = reader.bool();
+                            break;
+                        }
+                    case 27: {
+                            message.javaStringCheckUtf8 = reader.bool();
+                            break;
+                        }
+                    case 9: {
+                            message.optimizeFor = reader.int32();
+                            break;
+                        }
+                    case 11: {
+                            message.goPackage = reader.string();
+                            break;
+                        }
+                    case 16: {
+                            message.ccGenericServices = reader.bool();
+                            break;
+                        }
+                    case 17: {
+                            message.javaGenericServices = reader.bool();
+                            break;
+                        }
+                    case 18: {
+                            message.pyGenericServices = reader.bool();
+                            break;
+                        }
+                    case 23: {
+                            message.deprecated = reader.bool();
+                            break;
+                        }
+                    case 31: {
+                            message.ccEnableArenas = reader.bool();
+                            break;
+                        }
+                    case 36: {
+                            message.objcClassPrefix = reader.string();
+                            break;
+                        }
+                    case 37: {
+                            message.csharpNamespace = reader.string();
+                            break;
+                        }
+                    case 999: {
+                            if (!(message.uninterpretedOption && message.uninterpretedOption.length))
+                                message.uninterpretedOption = [];
+                            message.uninterpretedOption.push($root.google.protobuf.UninterpretedOption.decode(reader, reader.uint32()));
+                            break;
+                        }
                     default:
                         reader.skipType(tag & 7);
+                        if (!message.$unknownFields)
+                            message.$unknownFields = [];
+                        message.$unknownFields.push(reader.buf.slice(unknownStartPos, reader.pos));
                         break;
                     }
                 }
@@ -13010,6 +14615,12 @@ $root.google = (function() {
                 if (object.javaStringCheckUtf8 != null)
                     message.javaStringCheckUtf8 = Boolean(object.javaStringCheckUtf8);
                 switch (object.optimizeFor) {
+                default:
+                    if (typeof object.optimizeFor === "number") {
+                        message.optimizeFor = object.optimizeFor;
+                        break;
+                    }
+                    break;
                 case "SPEED":
                 case 1:
                     message.optimizeFor = 1;
@@ -13088,7 +14699,7 @@ $root.google = (function() {
                 if (message.javaOuterClassname != null && message.hasOwnProperty("javaOuterClassname"))
                     object.javaOuterClassname = message.javaOuterClassname;
                 if (message.optimizeFor != null && message.hasOwnProperty("optimizeFor"))
-                    object.optimizeFor = options.enums === String ? $root.google.protobuf.FileOptions.OptimizeMode[message.optimizeFor] : message.optimizeFor;
+                    object.optimizeFor = options.enums === String ? $root.google.protobuf.FileOptions.OptimizeMode[message.optimizeFor] === undefined ? message.optimizeFor : $root.google.protobuf.FileOptions.OptimizeMode[message.optimizeFor] : message.optimizeFor;
                 if (message.javaMultipleFiles != null && message.hasOwnProperty("javaMultipleFiles"))
                     object.javaMultipleFiles = message.javaMultipleFiles;
                 if (message.goPackage != null && message.hasOwnProperty("goPackage"))
@@ -13257,6 +14868,15 @@ $root.google = (function() {
             MessageOptions.encode = function encode(message, writer) {
                 if (!writer)
                     writer = $Writer.create();
+                var fullyUnknown = [];
+                if (message.$unknownFields && $root.google.protobuf.MessageOptions.decode)
+                    for (var i = 0; i < message.$unknownFields.length; ++i)
+                        try {
+                            var known = $root.google.protobuf.MessageOptions.decode(message.$unknownFields[i]);
+                            fullyUnknown = fullyUnknown.concat(known.$unknownFields || []);
+                            message = Object.assign(known, message);
+                        } catch (_) {
+                        }
                 if (message.messageSetWireFormat != null && Object.hasOwnProperty.call(message, "messageSetWireFormat"))
                     writer.uint32(/* id 1, wireType 0 =*/8).bool(message.messageSetWireFormat);
                 if (message.noStandardDescriptorAccessor != null && Object.hasOwnProperty.call(message, "noStandardDescriptorAccessor"))
@@ -13268,6 +14888,8 @@ $root.google = (function() {
                 if (message.uninterpretedOption != null && message.uninterpretedOption.length)
                     for (var i = 0; i < message.uninterpretedOption.length; ++i)
                         $root.google.protobuf.UninterpretedOption.encode(message.uninterpretedOption[i], writer.uint32(/* id 999, wireType 2 =*/7994).fork()).ldelim();
+                for (var i = 0; i < fullyUnknown.length; ++i)
+                    writer._unknownField(fullyUnknown[i]);
                 return writer;
             };
 
@@ -13300,27 +14922,36 @@ $root.google = (function() {
                     reader = $Reader.create(reader);
                 var end = length === undefined ? reader.len : reader.pos + length, message = new $root.google.protobuf.MessageOptions();
                 while (reader.pos < end) {
+                    var unknownStartPos = reader.pos;
                     var tag = reader.uint32();
                     switch (tag >>> 3) {
-                    case 1:
-                        message.messageSetWireFormat = reader.bool();
-                        break;
-                    case 2:
-                        message.noStandardDescriptorAccessor = reader.bool();
-                        break;
-                    case 3:
-                        message.deprecated = reader.bool();
-                        break;
-                    case 7:
-                        message.mapEntry = reader.bool();
-                        break;
-                    case 999:
-                        if (!(message.uninterpretedOption && message.uninterpretedOption.length))
-                            message.uninterpretedOption = [];
-                        message.uninterpretedOption.push($root.google.protobuf.UninterpretedOption.decode(reader, reader.uint32()));
-                        break;
+                    case 1: {
+                            message.messageSetWireFormat = reader.bool();
+                            break;
+                        }
+                    case 2: {
+                            message.noStandardDescriptorAccessor = reader.bool();
+                            break;
+                        }
+                    case 3: {
+                            message.deprecated = reader.bool();
+                            break;
+                        }
+                    case 7: {
+                            message.mapEntry = reader.bool();
+                            break;
+                        }
+                    case 999: {
+                            if (!(message.uninterpretedOption && message.uninterpretedOption.length))
+                                message.uninterpretedOption = [];
+                            message.uninterpretedOption.push($root.google.protobuf.UninterpretedOption.decode(reader, reader.uint32()));
+                            break;
+                        }
                     default:
                         reader.skipType(tag & 7);
+                        if (!message.$unknownFields)
+                            message.$unknownFields = [];
+                        message.$unknownFields.push(reader.buf.slice(unknownStartPos, reader.pos));
                         break;
                     }
                 }
@@ -13588,6 +15219,15 @@ $root.google = (function() {
             FieldOptions.encode = function encode(message, writer) {
                 if (!writer)
                     writer = $Writer.create();
+                var fullyUnknown = [];
+                if (message.$unknownFields && $root.google.protobuf.FieldOptions.decode)
+                    for (var i = 0; i < message.$unknownFields.length; ++i)
+                        try {
+                            var known = $root.google.protobuf.FieldOptions.decode(message.$unknownFields[i]);
+                            fullyUnknown = fullyUnknown.concat(known.$unknownFields || []);
+                            message = Object.assign(known, message);
+                        } catch (_) {
+                        }
                 if (message.ctype != null && Object.hasOwnProperty.call(message, "ctype"))
                     writer.uint32(/* id 1, wireType 0 =*/8).int32(message.ctype);
                 if (message.packed != null && Object.hasOwnProperty.call(message, "packed"))
@@ -13603,6 +15243,8 @@ $root.google = (function() {
                 if (message.uninterpretedOption != null && message.uninterpretedOption.length)
                     for (var i = 0; i < message.uninterpretedOption.length; ++i)
                         $root.google.protobuf.UninterpretedOption.encode(message.uninterpretedOption[i], writer.uint32(/* id 999, wireType 2 =*/7994).fork()).ldelim();
+                for (var i = 0; i < fullyUnknown.length; ++i)
+                    writer._unknownField(fullyUnknown[i]);
                 return writer;
             };
 
@@ -13635,33 +15277,44 @@ $root.google = (function() {
                     reader = $Reader.create(reader);
                 var end = length === undefined ? reader.len : reader.pos + length, message = new $root.google.protobuf.FieldOptions();
                 while (reader.pos < end) {
+                    var unknownStartPos = reader.pos;
                     var tag = reader.uint32();
                     switch (tag >>> 3) {
-                    case 1:
-                        message.ctype = reader.int32();
-                        break;
-                    case 2:
-                        message.packed = reader.bool();
-                        break;
-                    case 6:
-                        message.jstype = reader.int32();
-                        break;
-                    case 5:
-                        message.lazy = reader.bool();
-                        break;
-                    case 3:
-                        message.deprecated = reader.bool();
-                        break;
-                    case 10:
-                        message.weak = reader.bool();
-                        break;
-                    case 999:
-                        if (!(message.uninterpretedOption && message.uninterpretedOption.length))
-                            message.uninterpretedOption = [];
-                        message.uninterpretedOption.push($root.google.protobuf.UninterpretedOption.decode(reader, reader.uint32()));
-                        break;
+                    case 1: {
+                            message.ctype = reader.int32();
+                            break;
+                        }
+                    case 2: {
+                            message.packed = reader.bool();
+                            break;
+                        }
+                    case 6: {
+                            message.jstype = reader.int32();
+                            break;
+                        }
+                    case 5: {
+                            message.lazy = reader.bool();
+                            break;
+                        }
+                    case 3: {
+                            message.deprecated = reader.bool();
+                            break;
+                        }
+                    case 10: {
+                            message.weak = reader.bool();
+                            break;
+                        }
+                    case 999: {
+                            if (!(message.uninterpretedOption && message.uninterpretedOption.length))
+                                message.uninterpretedOption = [];
+                            message.uninterpretedOption.push($root.google.protobuf.UninterpretedOption.decode(reader, reader.uint32()));
+                            break;
+                        }
                     default:
                         reader.skipType(tag & 7);
+                        if (!message.$unknownFields)
+                            message.$unknownFields = [];
+                        message.$unknownFields.push(reader.buf.slice(unknownStartPos, reader.pos));
                         break;
                     }
                 }
@@ -13750,6 +15403,12 @@ $root.google = (function() {
                     return object;
                 var message = new $root.google.protobuf.FieldOptions();
                 switch (object.ctype) {
+                default:
+                    if (typeof object.ctype === "number") {
+                        message.ctype = object.ctype;
+                        break;
+                    }
+                    break;
                 case "STRING":
                 case 0:
                     message.ctype = 0;
@@ -13766,6 +15425,12 @@ $root.google = (function() {
                 if (object.packed != null)
                     message.packed = Boolean(object.packed);
                 switch (object.jstype) {
+                default:
+                    if (typeof object.jstype === "number") {
+                        message.jstype = object.jstype;
+                        break;
+                    }
+                    break;
                 case "JS_NORMAL":
                 case 0:
                     message.jstype = 0;
@@ -13822,7 +15487,7 @@ $root.google = (function() {
                     object.weak = false;
                 }
                 if (message.ctype != null && message.hasOwnProperty("ctype"))
-                    object.ctype = options.enums === String ? $root.google.protobuf.FieldOptions.CType[message.ctype] : message.ctype;
+                    object.ctype = options.enums === String ? $root.google.protobuf.FieldOptions.CType[message.ctype] === undefined ? message.ctype : $root.google.protobuf.FieldOptions.CType[message.ctype] : message.ctype;
                 if (message.packed != null && message.hasOwnProperty("packed"))
                     object.packed = message.packed;
                 if (message.deprecated != null && message.hasOwnProperty("deprecated"))
@@ -13830,7 +15495,7 @@ $root.google = (function() {
                 if (message.lazy != null && message.hasOwnProperty("lazy"))
                     object.lazy = message.lazy;
                 if (message.jstype != null && message.hasOwnProperty("jstype"))
-                    object.jstype = options.enums === String ? $root.google.protobuf.FieldOptions.JSType[message.jstype] : message.jstype;
+                    object.jstype = options.enums === String ? $root.google.protobuf.FieldOptions.JSType[message.jstype] === undefined ? message.jstype : $root.google.protobuf.FieldOptions.JSType[message.jstype] : message.jstype;
                 if (message.weak != null && message.hasOwnProperty("weak"))
                     object.weak = message.weak;
                 if (message.uninterpretedOption && message.uninterpretedOption.length) {
@@ -13959,9 +15624,20 @@ $root.google = (function() {
             OneofOptions.encode = function encode(message, writer) {
                 if (!writer)
                     writer = $Writer.create();
+                var fullyUnknown = [];
+                if (message.$unknownFields && $root.google.protobuf.OneofOptions.decode)
+                    for (var i = 0; i < message.$unknownFields.length; ++i)
+                        try {
+                            var known = $root.google.protobuf.OneofOptions.decode(message.$unknownFields[i]);
+                            fullyUnknown = fullyUnknown.concat(known.$unknownFields || []);
+                            message = Object.assign(known, message);
+                        } catch (_) {
+                        }
                 if (message.uninterpretedOption != null && message.uninterpretedOption.length)
                     for (var i = 0; i < message.uninterpretedOption.length; ++i)
                         $root.google.protobuf.UninterpretedOption.encode(message.uninterpretedOption[i], writer.uint32(/* id 999, wireType 2 =*/7994).fork()).ldelim();
+                for (var i = 0; i < fullyUnknown.length; ++i)
+                    writer._unknownField(fullyUnknown[i]);
                 return writer;
             };
 
@@ -13994,15 +15670,20 @@ $root.google = (function() {
                     reader = $Reader.create(reader);
                 var end = length === undefined ? reader.len : reader.pos + length, message = new $root.google.protobuf.OneofOptions();
                 while (reader.pos < end) {
+                    var unknownStartPos = reader.pos;
                     var tag = reader.uint32();
                     switch (tag >>> 3) {
-                    case 999:
-                        if (!(message.uninterpretedOption && message.uninterpretedOption.length))
-                            message.uninterpretedOption = [];
-                        message.uninterpretedOption.push($root.google.protobuf.UninterpretedOption.decode(reader, reader.uint32()));
-                        break;
+                    case 999: {
+                            if (!(message.uninterpretedOption && message.uninterpretedOption.length))
+                                message.uninterpretedOption = [];
+                            message.uninterpretedOption.push($root.google.protobuf.UninterpretedOption.decode(reader, reader.uint32()));
+                            break;
+                        }
                     default:
                         reader.skipType(tag & 7);
+                        if (!message.$unknownFields)
+                            message.$unknownFields = [];
+                        message.$unknownFields.push(reader.buf.slice(unknownStartPos, reader.pos));
                         break;
                     }
                 }
@@ -14209,6 +15890,15 @@ $root.google = (function() {
             EnumOptions.encode = function encode(message, writer) {
                 if (!writer)
                     writer = $Writer.create();
+                var fullyUnknown = [];
+                if (message.$unknownFields && $root.google.protobuf.EnumOptions.decode)
+                    for (var i = 0; i < message.$unknownFields.length; ++i)
+                        try {
+                            var known = $root.google.protobuf.EnumOptions.decode(message.$unknownFields[i]);
+                            fullyUnknown = fullyUnknown.concat(known.$unknownFields || []);
+                            message = Object.assign(known, message);
+                        } catch (_) {
+                        }
                 if (message.allowAlias != null && Object.hasOwnProperty.call(message, "allowAlias"))
                     writer.uint32(/* id 2, wireType 0 =*/16).bool(message.allowAlias);
                 if (message.deprecated != null && Object.hasOwnProperty.call(message, "deprecated"))
@@ -14218,6 +15908,8 @@ $root.google = (function() {
                         $root.google.protobuf.UninterpretedOption.encode(message.uninterpretedOption[i], writer.uint32(/* id 999, wireType 2 =*/7994).fork()).ldelim();
                 if (message[".jspb.test.IsExtension.simpleOption"] != null && Object.hasOwnProperty.call(message, ".jspb.test.IsExtension.simpleOption"))
                     writer.uint32(/* id 42113038, wireType 2 =*/336904306).string(message[".jspb.test.IsExtension.simpleOption"]);
+                for (var i = 0; i < fullyUnknown.length; ++i)
+                    writer._unknownField(fullyUnknown[i]);
                 return writer;
             };
 
@@ -14250,24 +15942,32 @@ $root.google = (function() {
                     reader = $Reader.create(reader);
                 var end = length === undefined ? reader.len : reader.pos + length, message = new $root.google.protobuf.EnumOptions();
                 while (reader.pos < end) {
+                    var unknownStartPos = reader.pos;
                     var tag = reader.uint32();
                     switch (tag >>> 3) {
-                    case 2:
-                        message.allowAlias = reader.bool();
-                        break;
-                    case 3:
-                        message.deprecated = reader.bool();
-                        break;
-                    case 999:
-                        if (!(message.uninterpretedOption && message.uninterpretedOption.length))
-                            message.uninterpretedOption = [];
-                        message.uninterpretedOption.push($root.google.protobuf.UninterpretedOption.decode(reader, reader.uint32()));
-                        break;
-                    case 42113038:
-                        message[".jspb.test.IsExtension.simpleOption"] = reader.string();
-                        break;
+                    case 2: {
+                            message.allowAlias = reader.bool();
+                            break;
+                        }
+                    case 3: {
+                            message.deprecated = reader.bool();
+                            break;
+                        }
+                    case 999: {
+                            if (!(message.uninterpretedOption && message.uninterpretedOption.length))
+                                message.uninterpretedOption = [];
+                            message.uninterpretedOption.push($root.google.protobuf.UninterpretedOption.decode(reader, reader.uint32()));
+                            break;
+                        }
+                    case 42113038: {
+                            message[".jspb.test.IsExtension.simpleOption"] = reader.string();
+                            break;
+                        }
                     default:
                         reader.skipType(tag & 7);
+                        if (!message.$unknownFields)
+                            message.$unknownFields = [];
+                        message.$unknownFields.push(reader.buf.slice(unknownStartPos, reader.pos));
                         break;
                     }
                 }
@@ -14482,11 +16182,22 @@ $root.google = (function() {
             EnumValueOptions.encode = function encode(message, writer) {
                 if (!writer)
                     writer = $Writer.create();
+                var fullyUnknown = [];
+                if (message.$unknownFields && $root.google.protobuf.EnumValueOptions.decode)
+                    for (var i = 0; i < message.$unknownFields.length; ++i)
+                        try {
+                            var known = $root.google.protobuf.EnumValueOptions.decode(message.$unknownFields[i]);
+                            fullyUnknown = fullyUnknown.concat(known.$unknownFields || []);
+                            message = Object.assign(known, message);
+                        } catch (_) {
+                        }
                 if (message.deprecated != null && Object.hasOwnProperty.call(message, "deprecated"))
                     writer.uint32(/* id 1, wireType 0 =*/8).bool(message.deprecated);
                 if (message.uninterpretedOption != null && message.uninterpretedOption.length)
                     for (var i = 0; i < message.uninterpretedOption.length; ++i)
                         $root.google.protobuf.UninterpretedOption.encode(message.uninterpretedOption[i], writer.uint32(/* id 999, wireType 2 =*/7994).fork()).ldelim();
+                for (var i = 0; i < fullyUnknown.length; ++i)
+                    writer._unknownField(fullyUnknown[i]);
                 return writer;
             };
 
@@ -14519,18 +16230,24 @@ $root.google = (function() {
                     reader = $Reader.create(reader);
                 var end = length === undefined ? reader.len : reader.pos + length, message = new $root.google.protobuf.EnumValueOptions();
                 while (reader.pos < end) {
+                    var unknownStartPos = reader.pos;
                     var tag = reader.uint32();
                     switch (tag >>> 3) {
-                    case 1:
-                        message.deprecated = reader.bool();
-                        break;
-                    case 999:
-                        if (!(message.uninterpretedOption && message.uninterpretedOption.length))
-                            message.uninterpretedOption = [];
-                        message.uninterpretedOption.push($root.google.protobuf.UninterpretedOption.decode(reader, reader.uint32()));
-                        break;
+                    case 1: {
+                            message.deprecated = reader.bool();
+                            break;
+                        }
+                    case 999: {
+                            if (!(message.uninterpretedOption && message.uninterpretedOption.length))
+                                message.uninterpretedOption = [];
+                            message.uninterpretedOption.push($root.google.protobuf.UninterpretedOption.decode(reader, reader.uint32()));
+                            break;
+                        }
                     default:
                         reader.skipType(tag & 7);
+                        if (!message.$unknownFields)
+                            message.$unknownFields = [];
+                        message.$unknownFields.push(reader.buf.slice(unknownStartPos, reader.pos));
                         break;
                     }
                 }
@@ -14728,11 +16445,22 @@ $root.google = (function() {
             ServiceOptions.encode = function encode(message, writer) {
                 if (!writer)
                     writer = $Writer.create();
+                var fullyUnknown = [];
+                if (message.$unknownFields && $root.google.protobuf.ServiceOptions.decode)
+                    for (var i = 0; i < message.$unknownFields.length; ++i)
+                        try {
+                            var known = $root.google.protobuf.ServiceOptions.decode(message.$unknownFields[i]);
+                            fullyUnknown = fullyUnknown.concat(known.$unknownFields || []);
+                            message = Object.assign(known, message);
+                        } catch (_) {
+                        }
                 if (message.deprecated != null && Object.hasOwnProperty.call(message, "deprecated"))
                     writer.uint32(/* id 33, wireType 0 =*/264).bool(message.deprecated);
                 if (message.uninterpretedOption != null && message.uninterpretedOption.length)
                     for (var i = 0; i < message.uninterpretedOption.length; ++i)
                         $root.google.protobuf.UninterpretedOption.encode(message.uninterpretedOption[i], writer.uint32(/* id 999, wireType 2 =*/7994).fork()).ldelim();
+                for (var i = 0; i < fullyUnknown.length; ++i)
+                    writer._unknownField(fullyUnknown[i]);
                 return writer;
             };
 
@@ -14765,18 +16493,24 @@ $root.google = (function() {
                     reader = $Reader.create(reader);
                 var end = length === undefined ? reader.len : reader.pos + length, message = new $root.google.protobuf.ServiceOptions();
                 while (reader.pos < end) {
+                    var unknownStartPos = reader.pos;
                     var tag = reader.uint32();
                     switch (tag >>> 3) {
-                    case 33:
-                        message.deprecated = reader.bool();
-                        break;
-                    case 999:
-                        if (!(message.uninterpretedOption && message.uninterpretedOption.length))
-                            message.uninterpretedOption = [];
-                        message.uninterpretedOption.push($root.google.protobuf.UninterpretedOption.decode(reader, reader.uint32()));
-                        break;
+                    case 33: {
+                            message.deprecated = reader.bool();
+                            break;
+                        }
+                    case 999: {
+                            if (!(message.uninterpretedOption && message.uninterpretedOption.length))
+                                message.uninterpretedOption = [];
+                            message.uninterpretedOption.push($root.google.protobuf.UninterpretedOption.decode(reader, reader.uint32()));
+                            break;
+                        }
                     default:
                         reader.skipType(tag & 7);
+                        if (!message.$unknownFields)
+                            message.$unknownFields = [];
+                        message.$unknownFields.push(reader.buf.slice(unknownStartPos, reader.pos));
                         break;
                     }
                 }
@@ -14983,6 +16717,15 @@ $root.google = (function() {
             MethodOptions.encode = function encode(message, writer) {
                 if (!writer)
                     writer = $Writer.create();
+                var fullyUnknown = [];
+                if (message.$unknownFields && $root.google.protobuf.MethodOptions.decode)
+                    for (var i = 0; i < message.$unknownFields.length; ++i)
+                        try {
+                            var known = $root.google.protobuf.MethodOptions.decode(message.$unknownFields[i]);
+                            fullyUnknown = fullyUnknown.concat(known.$unknownFields || []);
+                            message = Object.assign(known, message);
+                        } catch (_) {
+                        }
                 if (message.deprecated != null && Object.hasOwnProperty.call(message, "deprecated"))
                     writer.uint32(/* id 33, wireType 0 =*/264).bool(message.deprecated);
                 if (message.idempotencyLevel != null && Object.hasOwnProperty.call(message, "idempotencyLevel"))
@@ -14990,6 +16733,8 @@ $root.google = (function() {
                 if (message.uninterpretedOption != null && message.uninterpretedOption.length)
                     for (var i = 0; i < message.uninterpretedOption.length; ++i)
                         $root.google.protobuf.UninterpretedOption.encode(message.uninterpretedOption[i], writer.uint32(/* id 999, wireType 2 =*/7994).fork()).ldelim();
+                for (var i = 0; i < fullyUnknown.length; ++i)
+                    writer._unknownField(fullyUnknown[i]);
                 return writer;
             };
 
@@ -15022,21 +16767,28 @@ $root.google = (function() {
                     reader = $Reader.create(reader);
                 var end = length === undefined ? reader.len : reader.pos + length, message = new $root.google.protobuf.MethodOptions();
                 while (reader.pos < end) {
+                    var unknownStartPos = reader.pos;
                     var tag = reader.uint32();
                     switch (tag >>> 3) {
-                    case 33:
-                        message.deprecated = reader.bool();
-                        break;
-                    case 34:
-                        message.idempotencyLevel = reader.int32();
-                        break;
-                    case 999:
-                        if (!(message.uninterpretedOption && message.uninterpretedOption.length))
-                            message.uninterpretedOption = [];
-                        message.uninterpretedOption.push($root.google.protobuf.UninterpretedOption.decode(reader, reader.uint32()));
-                        break;
+                    case 33: {
+                            message.deprecated = reader.bool();
+                            break;
+                        }
+                    case 34: {
+                            message.idempotencyLevel = reader.int32();
+                            break;
+                        }
+                    case 999: {
+                            if (!(message.uninterpretedOption && message.uninterpretedOption.length))
+                                message.uninterpretedOption = [];
+                            message.uninterpretedOption.push($root.google.protobuf.UninterpretedOption.decode(reader, reader.uint32()));
+                            break;
+                        }
                     default:
                         reader.skipType(tag & 7);
+                        if (!message.$unknownFields)
+                            message.$unknownFields = [];
+                        message.$unknownFields.push(reader.buf.slice(unknownStartPos, reader.pos));
                         break;
                     }
                 }
@@ -15109,6 +16861,12 @@ $root.google = (function() {
                 if (object.deprecated != null)
                     message.deprecated = Boolean(object.deprecated);
                 switch (object.idempotencyLevel) {
+                default:
+                    if (typeof object.idempotencyLevel === "number") {
+                        message.idempotencyLevel = object.idempotencyLevel;
+                        break;
+                    }
+                    break;
                 case "IDEMPOTENCY_UNKNOWN":
                 case 0:
                     message.idempotencyLevel = 0;
@@ -15157,7 +16915,7 @@ $root.google = (function() {
                 if (message.deprecated != null && message.hasOwnProperty("deprecated"))
                     object.deprecated = message.deprecated;
                 if (message.idempotencyLevel != null && message.hasOwnProperty("idempotencyLevel"))
-                    object.idempotencyLevel = options.enums === String ? $root.google.protobuf.MethodOptions.IdempotencyLevel[message.idempotencyLevel] : message.idempotencyLevel;
+                    object.idempotencyLevel = options.enums === String ? $root.google.protobuf.MethodOptions.IdempotencyLevel[message.idempotencyLevel] === undefined ? message.idempotencyLevel : $root.google.protobuf.MethodOptions.IdempotencyLevel[message.idempotencyLevel] : message.idempotencyLevel;
                 if (message.uninterpretedOption && message.uninterpretedOption.length) {
                     object.uninterpretedOption = [];
                     for (var j = 0; j < message.uninterpretedOption.length; ++j)
@@ -15322,6 +17080,15 @@ $root.google = (function() {
             UninterpretedOption.encode = function encode(message, writer) {
                 if (!writer)
                     writer = $Writer.create();
+                var fullyUnknown = [];
+                if (message.$unknownFields && $root.google.protobuf.UninterpretedOption.decode)
+                    for (var i = 0; i < message.$unknownFields.length; ++i)
+                        try {
+                            var known = $root.google.protobuf.UninterpretedOption.decode(message.$unknownFields[i]);
+                            fullyUnknown = fullyUnknown.concat(known.$unknownFields || []);
+                            message = Object.assign(known, message);
+                        } catch (_) {
+                        }
                 if (message.name != null && message.name.length)
                     for (var i = 0; i < message.name.length; ++i)
                         $root.google.protobuf.UninterpretedOption.NamePart.encode(message.name[i], writer.uint32(/* id 2, wireType 2 =*/18).fork()).ldelim();
@@ -15337,6 +17104,8 @@ $root.google = (function() {
                     writer.uint32(/* id 7, wireType 2 =*/58).bytes(message.stringValue);
                 if (message.aggregateValue != null && Object.hasOwnProperty.call(message, "aggregateValue"))
                     writer.uint32(/* id 8, wireType 2 =*/66).string(message.aggregateValue);
+                for (var i = 0; i < fullyUnknown.length; ++i)
+                    writer._unknownField(fullyUnknown[i]);
                 return writer;
             };
 
@@ -15369,33 +17138,44 @@ $root.google = (function() {
                     reader = $Reader.create(reader);
                 var end = length === undefined ? reader.len : reader.pos + length, message = new $root.google.protobuf.UninterpretedOption();
                 while (reader.pos < end) {
+                    var unknownStartPos = reader.pos;
                     var tag = reader.uint32();
                     switch (tag >>> 3) {
-                    case 2:
-                        if (!(message.name && message.name.length))
-                            message.name = [];
-                        message.name.push($root.google.protobuf.UninterpretedOption.NamePart.decode(reader, reader.uint32()));
-                        break;
-                    case 3:
-                        message.identifierValue = reader.string();
-                        break;
-                    case 4:
-                        message.positiveIntValue = reader.uint64();
-                        break;
-                    case 5:
-                        message.negativeIntValue = reader.int64();
-                        break;
-                    case 6:
-                        message.doubleValue = reader.double();
-                        break;
-                    case 7:
-                        message.stringValue = reader.bytes();
-                        break;
-                    case 8:
-                        message.aggregateValue = reader.string();
-                        break;
+                    case 2: {
+                            if (!(message.name && message.name.length))
+                                message.name = [];
+                            message.name.push($root.google.protobuf.UninterpretedOption.NamePart.decode(reader, reader.uint32()));
+                            break;
+                        }
+                    case 3: {
+                            message.identifierValue = reader.string();
+                            break;
+                        }
+                    case 4: {
+                            message.positiveIntValue = reader.uint64();
+                            break;
+                        }
+                    case 5: {
+                            message.negativeIntValue = reader.int64();
+                            break;
+                        }
+                    case 6: {
+                            message.doubleValue = reader.double();
+                            break;
+                        }
+                    case 7: {
+                            message.stringValue = reader.bytes();
+                            break;
+                        }
+                    case 8: {
+                            message.aggregateValue = reader.string();
+                            break;
+                        }
                     default:
                         reader.skipType(tag & 7);
+                        if (!message.$unknownFields)
+                            message.$unknownFields = [];
+                        message.$unknownFields.push(reader.buf.slice(unknownStartPos, reader.pos));
                         break;
                     }
                 }
@@ -15667,8 +17447,19 @@ $root.google = (function() {
                 NamePart.encode = function encode(message, writer) {
                     if (!writer)
                         writer = $Writer.create();
+                    var fullyUnknown = [];
+                    if (message.$unknownFields && $root.google.protobuf.UninterpretedOption.NamePart.decode)
+                        for (var i = 0; i < message.$unknownFields.length; ++i)
+                            try {
+                                var known = $root.google.protobuf.UninterpretedOption.NamePart.decode(message.$unknownFields[i]);
+                                fullyUnknown = fullyUnknown.concat(known.$unknownFields || []);
+                                message = Object.assign(known, message);
+                            } catch (_) {
+                            }
                     writer.uint32(/* id 1, wireType 2 =*/10).string(message.namePart);
                     writer.uint32(/* id 2, wireType 0 =*/16).bool(message.isExtension);
+                    for (var i = 0; i < fullyUnknown.length; ++i)
+                        writer._unknownField(fullyUnknown[i]);
                     return writer;
                 };
 
@@ -15701,16 +17492,22 @@ $root.google = (function() {
                         reader = $Reader.create(reader);
                     var end = length === undefined ? reader.len : reader.pos + length, message = new $root.google.protobuf.UninterpretedOption.NamePart();
                     while (reader.pos < end) {
+                        var unknownStartPos = reader.pos;
                         var tag = reader.uint32();
                         switch (tag >>> 3) {
-                        case 1:
-                            message.namePart = reader.string();
-                            break;
-                        case 2:
-                            message.isExtension = reader.bool();
-                            break;
+                        case 1: {
+                                message.namePart = reader.string();
+                                break;
+                            }
+                        case 2: {
+                                message.isExtension = reader.bool();
+                                break;
+                            }
                         default:
                             reader.skipType(tag & 7);
+                            if (!message.$unknownFields)
+                                message.$unknownFields = [];
+                            message.$unknownFields.push(reader.buf.slice(unknownStartPos, reader.pos));
                             break;
                         }
                     }
@@ -15887,9 +17684,20 @@ $root.google = (function() {
             SourceCodeInfo.encode = function encode(message, writer) {
                 if (!writer)
                     writer = $Writer.create();
+                var fullyUnknown = [];
+                if (message.$unknownFields && $root.google.protobuf.SourceCodeInfo.decode)
+                    for (var i = 0; i < message.$unknownFields.length; ++i)
+                        try {
+                            var known = $root.google.protobuf.SourceCodeInfo.decode(message.$unknownFields[i]);
+                            fullyUnknown = fullyUnknown.concat(known.$unknownFields || []);
+                            message = Object.assign(known, message);
+                        } catch (_) {
+                        }
                 if (message.location != null && message.location.length)
                     for (var i = 0; i < message.location.length; ++i)
                         $root.google.protobuf.SourceCodeInfo.Location.encode(message.location[i], writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
+                for (var i = 0; i < fullyUnknown.length; ++i)
+                    writer._unknownField(fullyUnknown[i]);
                 return writer;
             };
 
@@ -15922,15 +17730,20 @@ $root.google = (function() {
                     reader = $Reader.create(reader);
                 var end = length === undefined ? reader.len : reader.pos + length, message = new $root.google.protobuf.SourceCodeInfo();
                 while (reader.pos < end) {
+                    var unknownStartPos = reader.pos;
                     var tag = reader.uint32();
                     switch (tag >>> 3) {
-                    case 1:
-                        if (!(message.location && message.location.length))
-                            message.location = [];
-                        message.location.push($root.google.protobuf.SourceCodeInfo.Location.decode(reader, reader.uint32()));
-                        break;
+                    case 1: {
+                            if (!(message.location && message.location.length))
+                                message.location = [];
+                            message.location.push($root.google.protobuf.SourceCodeInfo.Location.decode(reader, reader.uint32()));
+                            break;
+                        }
                     default:
                         reader.skipType(tag & 7);
+                        if (!message.$unknownFields)
+                            message.$unknownFields = [];
+                        message.$unknownFields.push(reader.buf.slice(unknownStartPos, reader.pos));
                         break;
                     }
                 }
@@ -16145,6 +17958,15 @@ $root.google = (function() {
                 Location.encode = function encode(message, writer) {
                     if (!writer)
                         writer = $Writer.create();
+                    var fullyUnknown = [];
+                    if (message.$unknownFields && $root.google.protobuf.SourceCodeInfo.Location.decode)
+                        for (var i = 0; i < message.$unknownFields.length; ++i)
+                            try {
+                                var known = $root.google.protobuf.SourceCodeInfo.Location.decode(message.$unknownFields[i]);
+                                fullyUnknown = fullyUnknown.concat(known.$unknownFields || []);
+                                message = Object.assign(known, message);
+                            } catch (_) {
+                            }
                     if (message.path != null && message.path.length) {
                         writer.uint32(/* id 1, wireType 2 =*/10).fork();
                         for (var i = 0; i < message.path.length; ++i)
@@ -16164,6 +17986,8 @@ $root.google = (function() {
                     if (message.leadingDetachedComments != null && message.leadingDetachedComments.length)
                         for (var i = 0; i < message.leadingDetachedComments.length; ++i)
                             writer.uint32(/* id 6, wireType 2 =*/50).string(message.leadingDetachedComments[i]);
+                    for (var i = 0; i < fullyUnknown.length; ++i)
+                        writer._unknownField(fullyUnknown[i]);
                     return writer;
                 };
 
@@ -16196,41 +18020,50 @@ $root.google = (function() {
                         reader = $Reader.create(reader);
                     var end = length === undefined ? reader.len : reader.pos + length, message = new $root.google.protobuf.SourceCodeInfo.Location();
                     while (reader.pos < end) {
+                        var unknownStartPos = reader.pos;
                         var tag = reader.uint32();
                         switch (tag >>> 3) {
-                        case 1:
-                            if (!(message.path && message.path.length))
-                                message.path = [];
-                            if ((tag & 7) === 2) {
-                                var end2 = reader.uint32() + reader.pos;
-                                while (reader.pos < end2)
+                        case 1: {
+                                if (!(message.path && message.path.length))
+                                    message.path = [];
+                                if ((tag & 7) === 2) {
+                                    var end2 = reader.uint32() + reader.pos;
+                                    while (reader.pos < end2)
+                                        message.path.push(reader.int32());
+                                } else
                                     message.path.push(reader.int32());
-                            } else
-                                message.path.push(reader.int32());
-                            break;
-                        case 2:
-                            if (!(message.span && message.span.length))
-                                message.span = [];
-                            if ((tag & 7) === 2) {
-                                var end2 = reader.uint32() + reader.pos;
-                                while (reader.pos < end2)
+                                break;
+                            }
+                        case 2: {
+                                if (!(message.span && message.span.length))
+                                    message.span = [];
+                                if ((tag & 7) === 2) {
+                                    var end2 = reader.uint32() + reader.pos;
+                                    while (reader.pos < end2)
+                                        message.span.push(reader.int32());
+                                } else
                                     message.span.push(reader.int32());
-                            } else
-                                message.span.push(reader.int32());
-                            break;
-                        case 3:
-                            message.leadingComments = reader.string();
-                            break;
-                        case 4:
-                            message.trailingComments = reader.string();
-                            break;
-                        case 6:
-                            if (!(message.leadingDetachedComments && message.leadingDetachedComments.length))
-                                message.leadingDetachedComments = [];
-                            message.leadingDetachedComments.push(reader.string());
-                            break;
+                                break;
+                            }
+                        case 3: {
+                                message.leadingComments = reader.string();
+                                break;
+                            }
+                        case 4: {
+                                message.trailingComments = reader.string();
+                                break;
+                            }
+                        case 6: {
+                                if (!(message.leadingDetachedComments && message.leadingDetachedComments.length))
+                                    message.leadingDetachedComments = [];
+                                message.leadingDetachedComments.push(reader.string());
+                                break;
+                            }
                         default:
                             reader.skipType(tag & 7);
+                            if (!message.$unknownFields)
+                                message.$unknownFields = [];
+                            message.$unknownFields.push(reader.buf.slice(unknownStartPos, reader.pos));
                             break;
                         }
                     }
@@ -16467,9 +18300,20 @@ $root.google = (function() {
             GeneratedCodeInfo.encode = function encode(message, writer) {
                 if (!writer)
                     writer = $Writer.create();
+                var fullyUnknown = [];
+                if (message.$unknownFields && $root.google.protobuf.GeneratedCodeInfo.decode)
+                    for (var i = 0; i < message.$unknownFields.length; ++i)
+                        try {
+                            var known = $root.google.protobuf.GeneratedCodeInfo.decode(message.$unknownFields[i]);
+                            fullyUnknown = fullyUnknown.concat(known.$unknownFields || []);
+                            message = Object.assign(known, message);
+                        } catch (_) {
+                        }
                 if (message.annotation != null && message.annotation.length)
                     for (var i = 0; i < message.annotation.length; ++i)
                         $root.google.protobuf.GeneratedCodeInfo.Annotation.encode(message.annotation[i], writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
+                for (var i = 0; i < fullyUnknown.length; ++i)
+                    writer._unknownField(fullyUnknown[i]);
                 return writer;
             };
 
@@ -16502,15 +18346,20 @@ $root.google = (function() {
                     reader = $Reader.create(reader);
                 var end = length === undefined ? reader.len : reader.pos + length, message = new $root.google.protobuf.GeneratedCodeInfo();
                 while (reader.pos < end) {
+                    var unknownStartPos = reader.pos;
                     var tag = reader.uint32();
                     switch (tag >>> 3) {
-                    case 1:
-                        if (!(message.annotation && message.annotation.length))
-                            message.annotation = [];
-                        message.annotation.push($root.google.protobuf.GeneratedCodeInfo.Annotation.decode(reader, reader.uint32()));
-                        break;
+                    case 1: {
+                            if (!(message.annotation && message.annotation.length))
+                                message.annotation = [];
+                            message.annotation.push($root.google.protobuf.GeneratedCodeInfo.Annotation.decode(reader, reader.uint32()));
+                            break;
+                        }
                     default:
                         reader.skipType(tag & 7);
+                        if (!message.$unknownFields)
+                            message.$unknownFields = [];
+                        message.$unknownFields.push(reader.buf.slice(unknownStartPos, reader.pos));
                         break;
                     }
                 }
@@ -16714,6 +18563,15 @@ $root.google = (function() {
                 Annotation.encode = function encode(message, writer) {
                     if (!writer)
                         writer = $Writer.create();
+                    var fullyUnknown = [];
+                    if (message.$unknownFields && $root.google.protobuf.GeneratedCodeInfo.Annotation.decode)
+                        for (var i = 0; i < message.$unknownFields.length; ++i)
+                            try {
+                                var known = $root.google.protobuf.GeneratedCodeInfo.Annotation.decode(message.$unknownFields[i]);
+                                fullyUnknown = fullyUnknown.concat(known.$unknownFields || []);
+                                message = Object.assign(known, message);
+                            } catch (_) {
+                            }
                     if (message.path != null && message.path.length) {
                         writer.uint32(/* id 1, wireType 2 =*/10).fork();
                         for (var i = 0; i < message.path.length; ++i)
@@ -16726,6 +18584,8 @@ $root.google = (function() {
                         writer.uint32(/* id 3, wireType 0 =*/24).int32(message.begin);
                     if (message.end != null && Object.hasOwnProperty.call(message, "end"))
                         writer.uint32(/* id 4, wireType 0 =*/32).int32(message.end);
+                    for (var i = 0; i < fullyUnknown.length; ++i)
+                        writer._unknownField(fullyUnknown[i]);
                     return writer;
                 };
 
@@ -16758,29 +18618,37 @@ $root.google = (function() {
                         reader = $Reader.create(reader);
                     var end = length === undefined ? reader.len : reader.pos + length, message = new $root.google.protobuf.GeneratedCodeInfo.Annotation();
                     while (reader.pos < end) {
+                        var unknownStartPos = reader.pos;
                         var tag = reader.uint32();
                         switch (tag >>> 3) {
-                        case 1:
-                            if (!(message.path && message.path.length))
-                                message.path = [];
-                            if ((tag & 7) === 2) {
-                                var end2 = reader.uint32() + reader.pos;
-                                while (reader.pos < end2)
+                        case 1: {
+                                if (!(message.path && message.path.length))
+                                    message.path = [];
+                                if ((tag & 7) === 2) {
+                                    var end2 = reader.uint32() + reader.pos;
+                                    while (reader.pos < end2)
+                                        message.path.push(reader.int32());
+                                } else
                                     message.path.push(reader.int32());
-                            } else
-                                message.path.push(reader.int32());
-                            break;
-                        case 2:
-                            message.sourceFile = reader.string();
-                            break;
-                        case 3:
-                            message.begin = reader.int32();
-                            break;
-                        case 4:
-                            message.end = reader.int32();
-                            break;
+                                break;
+                            }
+                        case 2: {
+                                message.sourceFile = reader.string();
+                                break;
+                            }
+                        case 3: {
+                                message.begin = reader.int32();
+                                break;
+                            }
+                        case 4: {
+                                message.end = reader.int32();
+                                break;
+                            }
                         default:
                             reader.skipType(tag & 7);
+                            if (!message.$unknownFields)
+                                message.$unknownFields = [];
+                            message.$unknownFields.push(reader.buf.slice(unknownStartPos, reader.pos));
                             break;
                         }
                     }

--- a/tests/data/type_url.js
+++ b/tests/data/type_url.js
@@ -65,8 +65,19 @@ $root.TypeUrlTest = (function() {
     TypeUrlTest.encode = function encode(message, writer) {
         if (!writer)
             writer = $Writer.create();
+        var fullyUnknown = [];
+        if (message.$unknownFields && $root.TypeUrlTest.decode)
+            for (var i = 0; i < message.$unknownFields.length; ++i)
+                try {
+                    var known = $root.TypeUrlTest.decode(message.$unknownFields[i]);
+                    fullyUnknown = fullyUnknown.concat(known.$unknownFields || []);
+                    message = Object.assign(known, message);
+                } catch (_) {
+                }
         if (message.nested != null && Object.hasOwnProperty.call(message, "nested"))
             $root.TypeUrlTest.Nested.encode(message.nested, writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
+        for (var i = 0; i < fullyUnknown.length; ++i)
+            writer._unknownField(fullyUnknown[i]);
         return writer;
     };
 
@@ -99,13 +110,18 @@ $root.TypeUrlTest = (function() {
             reader = $Reader.create(reader);
         var end = length === undefined ? reader.len : reader.pos + length, message = new $root.TypeUrlTest();
         while (reader.pos < end) {
+            var unknownStartPos = reader.pos;
             var tag = reader.uint32();
             switch (tag >>> 3) {
-            case 1:
-                message.nested = $root.TypeUrlTest.Nested.decode(reader, reader.uint32());
-                break;
+            case 1: {
+                    message.nested = $root.TypeUrlTest.Nested.decode(reader, reader.uint32());
+                    break;
+                }
             default:
                 reader.skipType(tag & 7);
+                if (!message.$unknownFields)
+                    message.$unknownFields = [];
+                message.$unknownFields.push(reader.buf.slice(unknownStartPos, reader.pos));
                 break;
             }
         }
@@ -269,8 +285,19 @@ $root.TypeUrlTest = (function() {
         Nested.encode = function encode(message, writer) {
             if (!writer)
                 writer = $Writer.create();
+            var fullyUnknown = [];
+            if (message.$unknownFields && $root.TypeUrlTest.Nested.decode)
+                for (var i = 0; i < message.$unknownFields.length; ++i)
+                    try {
+                        var known = $root.TypeUrlTest.Nested.decode(message.$unknownFields[i]);
+                        fullyUnknown = fullyUnknown.concat(known.$unknownFields || []);
+                        message = Object.assign(known, message);
+                    } catch (_) {
+                    }
             if (message.a != null && Object.hasOwnProperty.call(message, "a"))
                 writer.uint32(/* id 1, wireType 2 =*/10).string(message.a);
+            for (var i = 0; i < fullyUnknown.length; ++i)
+                writer._unknownField(fullyUnknown[i]);
             return writer;
         };
 
@@ -303,13 +330,18 @@ $root.TypeUrlTest = (function() {
                 reader = $Reader.create(reader);
             var end = length === undefined ? reader.len : reader.pos + length, message = new $root.TypeUrlTest.Nested();
             while (reader.pos < end) {
+                var unknownStartPos = reader.pos;
                 var tag = reader.uint32();
                 switch (tag >>> 3) {
-                case 1:
-                    message.a = reader.string();
-                    break;
+                case 1: {
+                        message.a = reader.string();
+                        break;
+                    }
                 default:
                     reader.skipType(tag & 7);
+                    if (!message.$unknownFields)
+                        message.$unknownFields = [];
+                    message.$unknownFields.push(reader.buf.slice(unknownStartPos, reader.pos));
                     break;
                 }
             }

--- a/tests/data/unknown-fields.proto
+++ b/tests/data/unknown-fields.proto
@@ -1,0 +1,11 @@
+message MessageV1 {
+  optional int32 field1 = 1;
+}
+
+message MessageV2 {
+  optional int32 field1 = 1;
+
+  /* New fields */
+  optional bool field2 = 2;
+  optional string field3 = 3;
+}

--- a/tests/unknown-fields.js
+++ b/tests/unknown-fields.js
@@ -1,0 +1,62 @@
+var tape = require("tape");
+
+var protobuf  = require("..");
+
+tape.test("unknown-fields", function(test) {
+
+    protobuf.load("tests/data/unknown-fields.proto", function(err, root) {
+        if (err)
+            return test.fail(err.message);
+
+        var MessageV1 = root.lookup("MessageV1");
+        var MessageV2 = root.lookup("MessageV2");
+
+        test.plan(2);
+
+        test.test("basic v2 to v1 to v2 reencoding", function(test) {
+            var v2 = MessageV2.encode({
+                field1: 1,
+                field2: true,
+                field3: "hello",
+            }).finish();
+
+            var v1 = MessageV1.decode(v2);
+
+            test.equal(v1.field1, 1, "should set field1");
+            test.same(v1.$unknownFields, [
+                MessageV2.encode({ field2: true }).finish(),
+                MessageV2.encode({ field3: "hello" }).finish(),
+            ], "should set $unknownFields");
+
+            var reencoded = MessageV1.encode(v1).finish();
+            var redecoded = MessageV2.decode(reencoded);
+
+            test.equal(redecoded.field1, 1, "should set field1");
+            test.equal(redecoded.field2, true, "should set field2");
+            test.equal(redecoded.field3, "hello", "should set field3");
+
+            test.end();
+        });
+
+        test.test("encoding of recently supported fields", function(test) {
+            var encoded = MessageV2.encode({
+                field1: 1,
+                $unknownFields: [
+                    MessageV2.encode({ field2: true }).finish(),
+                    MessageV2.encode({ field3: "hello" }).finish(),
+                ],
+            }).finish();
+
+            var decoded = MessageV2.decode(encoded);
+
+            test.equal(decoded.field1, 1, "should set field1");
+            test.equal(decoded.field2, true, "should set field2");
+            test.equal(decoded.field3, "hello", "should set field3");
+
+            test.end();
+        });
+
+        test.end();
+    });
+
+});


### PR DESCRIPTION
This add `$unknownFields` property to generated code. It is populated on `.decode()` when decoder encounters currently unknown field, and similarly used by encoder to serialize unknown fields as they are into a binary data.

If user stores unknown fields and then upgrades their protobufs to the latest spec - there is a chance that some of the previously unknown fields will become known. This is handled in the encoder by attempting to decode the fields first.

The name of the field starts with `$` because it is not a valid character for a field name according to protobuf v3 specification.