### PR TITLE
fix: possible infinite loop when parsing option

### DIFF
--- a/bench/prof.js
+++ b/bench/prof.js
@@ -86,14 +86,14 @@ function setupBrowser() {
 switch (process.argv[2]) {
     case "encode-browser":
         setupBrowser();
-        // eslint-disable-line no-fallthrough
+        // eslint-disable-next-line no-fallthrough
     case "encode":
         for (var i = 0; i < count; ++i)
             Test.encode(data).finish();
         break;
     case "decode-browser":
         setupBrowser();
-        // eslint-disable-line no-fallthrough
+        // eslint-disable-next-line no-fallthrough
     case "decode":
         var buf = Test.encode(data).finish();
         for (var j = 0; j < count; ++j)

--- a/cli/lib/tsd-jsdoc/publish.js
+++ b/cli/lib/tsd-jsdoc/publish.js
@@ -438,7 +438,7 @@ function handleElement(element, parent) {
                 handleEnum(element, parent);
                 break;
             }
-            // eslint-disable-line no-fallthrough
+            // eslint-disable-next-line no-fallthrough
         case "namespace":
             handleNamespace(element, parent);
             break;

--- a/src/converter.js
+++ b/src/converter.js
@@ -62,7 +62,7 @@ function genValuePartial_fromObject(gen, field, fieldIndex, prop) {
                 break;
             case "uint64":
                 isUnsigned = true;
-                // eslint-disable-line no-fallthrough
+                // eslint-disable-next-line no-fallthrough
             case "int64":
             case "sint64":
             case "fixed64":
@@ -176,7 +176,7 @@ function genValuePartial_toObject(gen, field, fieldIndex, prop) {
                 break;
             case "uint64":
                 isUnsigned = true;
-                // eslint-disable-line no-fallthrough
+                // eslint-disable-next-line no-fallthrough
             case "int64":
             case "sint64":
             case "fixed64":

--- a/src/parse.js
+++ b/src/parse.js
@@ -227,7 +227,7 @@ function parse(source, root, options) {
                 break;
             case "public":
                 next();
-                // eslint-disable-line no-fallthrough
+                // eslint-disable-next-line no-fallthrough
             default:
                 whichImports = imports || (imports = []);
                 break;
@@ -620,6 +620,9 @@ function parse(source, root, options) {
                 /* istanbul ignore if */
                 if (!nameRe.test(token = next())) {
                     throw illegal(token, "name");
+                }
+                if (token === null) {
+                  throw illegal(token, "end of input");
                 }
 
                 var value;

--- a/tests/cli.js
+++ b/tests/cli.js
@@ -192,8 +192,6 @@ tape.test("pbjs generates static code with message filter", function (test) {
             var $protobuf = protobuf;
             eval(jsCode);
 
-            console.log(protobuf.roots);
-
             var NeedMessage1 = protobuf.roots.default.filtertest.NeedMessage1;
             var NeedMessage2 = protobuf.roots.default.filtertest.NeedMessage2;
             var DependentMessage1 = protobuf.roots.default.filtertest.DependentMessage1;
@@ -201,7 +199,7 @@ tape.test("pbjs generates static code with message filter", function (test) {
 
             var NotNeedMessageInRootFile = protobuf.roots.default.filtertest.NotNeedMessageInRootFile;
             var NotNeedMessageInImportFile = protobuf.roots.default.NotNeedMessageInImportFile;
-            
+
             test.ok(NeedMessage1, "NeedMessage1 is loaded");
             test.ok(NeedMessage2, "NeedMessage2 is loaded");
             test.ok(DependentMessage1, "DependentMessage1 is loaded");

--- a/tests/comp_options-parse.js
+++ b/tests/comp_options-parse.js
@@ -157,5 +157,10 @@ tape.test("Options", function (test) {
         test.end();
     });
 
+    test.test(test.name + " - invalid option", function (test) {
+        test.throws(() => { protobuf.parse("option (foo).whatever = {")});
+        test.end();
+    });
+
     test.end();
 });


### PR DESCRIPTION
The `while` loop in `parseOptionValue` can be infinite if the closing brace `}` it expects never comes.

```
const protobuf = require('protobufjs');
protobuf.parse("option (foo).whatever = {");
```

Reported by @oetr.

Minor unrelated changes also in this PR, because I'm too lazy to create a separate one:
- changed `eslint-disable-line` to a proper `eslint-disable-next-line` in a few places to fix linting errors;
- removed extra logging in one of the tests.