### PR TITLE
fix: add exports section to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,11 @@
   ],
   "main": "index.js",
   "types": "index.d.ts",
+  "exports": {
+    ".": "./index.js",
+    "./light": "./light.js",
+    "./minimal": "./minimal.js"
+  },
   "scripts": {
     "bench": "node bench",
     "build": "npm run build:bundle && npm run build:types",


### PR DESCRIPTION
This enables importing "protobufjs/light" and "protobufjs/minimal" in native Node/ESM contexts.

See also: https://github.com/protobufjs/protobuf.js/pull/1931 (for v6)