### PR TITLE
fix: add exports section to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,11 @@
     "typescript"
   ],
   "main": "index.js",
+  "exports": {
+    ".": "index.js",
+    "./light": "./light.js",
+    "./minimal": "./minimal.js"
+  },
   "types": "index.d.ts",
   "bin": {
     "pbjs": "bin/pbjs",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   ],
   "main": "index.js",
   "exports": {
-    ".": "index.js",
+    ".": "./index.js",
     "./light": "./light.js",
     "./minimal": "./minimal.js"
   },


### PR DESCRIPTION
This enables importing "protobufjs/light" and "protobufjs/minimal" in native Node/ESM contexts.

See also: https://github.com/protobufjs/protobuf.js/pull/1930 (for v7)