### PR TITLE
Docs: Update readme to correct command for creating types

### DIFF
--- a/README.md
+++ b/README.md
@@ -717,7 +717,7 @@ $> npm run docs
 Building the TypeScript definition to `index.d.ts`:
 
 ```
-$> npm run types
+$> npm run build:types
 ```
 
 ### Browserify integration


### PR DESCRIPTION
Update to correct command for building typescript definitions tp `npm run build:types` 