### PR TITLE
fix: remove eval usage so that chrome extension MV3 can run properly

### DIFF
--- a/lib/inquire/index.js
+++ b/lib/inquire/index.js
@@ -8,12 +8,17 @@ module.exports = inquire;
  * @returns {?Object} Required module if available and not empty, otherwise `null`
  */
 function inquire(moduleName) {
-    try {
-        var mod = eval("quire".replace(/^/,"re"))(moduleName); // eslint-disable-line no-eval
-        if (mod && (mod.length || Object.keys(mod).length))
-            return mod;
-    } catch (e) {} // eslint-disable-line no-empty
+  try {
+    if (typeof require !== "function") {
+      return null;
+    }
+    var mod = require(moduleName);
+    if (mod && (mod.length || Object.keys(mod).length)) return mod;
     return null;
+  } catch (err) {
+    // ignore
+    return null;
+  }
 }
 
 /*


### PR DESCRIPTION
AS POST TITLE.

I think this can be published as an alpha version for more tests.