### PR TITLE
fix: don't throw on empty repeated options

### DIFF
--- a/src/parse.js
+++ b/src/parse.js
@@ -639,13 +639,18 @@ function parse(source, root, options) {
                     value = [];
                     var lastValue;
                     if (skip("[", true)) {
-                        do {
-                            lastValue = readValue(true);
-                            value.push(lastValue);
-                        } while (skip(",", true));
-                        skip("]");
-                        if (typeof lastValue !== "undefined") {
-                            setOption(parent, name + "." + token, lastValue);
+                        if (peek() === "]") {
+                            setOption(parent, name, "." + token, []);
+                            next();
+                        } else {
+                            do {
+                                lastValue = readValue(true);
+                                value.push(lastValue);
+                            } while (skip(",", true));
+                            skip("]");
+                            if (typeof lastValue !== "undefined") {
+                                setOption(parent, name + "." + token, lastValue);
+                            }
                         }
                     }
                 } else {

--- a/tests/comp_options-parse.js
+++ b/tests/comp_options-parse.js
@@ -134,6 +134,7 @@ tape.test("Options", function (test) {
             {
                 "(method_rep_msg)": {
                     value: 1,
+                    empty_repeated: [],
                     nested: {nested: {value: "x"}},
                     rep_nested: [{value: "y"}, {value: "z"}],
                     rep_value: 3

--- a/tests/data/options_test.proto
+++ b/tests/data/options_test.proto
@@ -119,6 +119,7 @@ service TestOptionsService {
     rpc TestOptionsRpc(Msg) returns (Msg) {
         option (method_rep_msg) = {
             value: 1
+            empty_repeated: []
             nested {
                 nested {
                     value: "x"


### PR DESCRIPTION
I ran into an issue where an empty repeated option was throwing. This resolves it for me.