### PR TITLE
Use import instead of require for Long

### DIFF
--- a/cli/pbts.js
+++ b/cli/pbts.js
@@ -170,7 +170,7 @@ exports.main = function(args, callback) {
                     output.push("import * as " + key + " from \"" + imports[key] + "\";");
                 });
 
-                output.push("import Long = require(\"long\");");
+                output.push("import type Long from \"long\";");
             }
 
             output = output.join("\n") + "\n" + out.join("");


### PR DESCRIPTION
When using `moduleResolution: bundler` with typescript, the complier doesn't properly resolve conditional import the `Long` package causing this module to fail to build. This PR fixes this issue, using a traditional ESM import statement. 