### PR TITLE
Fix types of sub-messages in class declaration

### DIFF
--- a/cli/targets/static.js
+++ b/cli/targets/static.js
@@ -311,8 +311,12 @@ function buildFunction(type, functionName, gen, scope) {
         push("};");
 }
 
-function toJsType(field) {
+function toJsType(field, asInterface) {
     var type;
+
+    if (asInterface === undefined) {
+        asInterface = true;
+    }
 
     switch (field.type) {
         case "double":
@@ -342,7 +346,7 @@ function toJsType(field) {
             break;
         default:
             if (field.resolve().resolvedType)
-                type = exportName(field.resolvedType, !(field.resolvedType instanceof protobuf.Enum || config.forceMessage));
+                type = exportName(field.resolvedType, asInterface && !(field.resolvedType instanceof protobuf.Enum || config.forceMessage));
             else
                 type = "*"; // should not happen
             break;
@@ -393,7 +397,7 @@ function buildType(ref, type) {
         var prop = util.safeProp(field.name);
         if (config.comments) {
             push("");
-            var jsType = toJsType(field);
+            var jsType = toJsType(field, false);
             if (field.optional && !field.map && !field.repeated && (field.resolvedType instanceof Type || config["null-defaults"]) || field.partOf)
                 jsType = jsType + "|null|undefined";
             pushComment([


### PR DESCRIPTION
Prior to this change the class' jsdoc comments would state the type of the class properties that encode sub-messages as:

    /**
     * Sent editMessage.
     * @member {proto.IEditMessage|null|undefined} editMessage * @memberof proto.SyncMessage.Sent * @instance */

After the change:

    /**
     * Sent editMessage.
     * @member {proto.EditMessage|null|undefined} editMessage * @memberof proto.SyncMessage.Sent * @instance */

The difference is that the latter specifices the class type and not the interface which better reflects the actual type returned by `.decode()` method.

This is a breaking change because constructing the class would now require providing the class instances and not interfaces