### PR TITLE
fix: report missing import properly in loadSync

### DIFF
--- a/src/root.js
+++ b/src/root.js
@@ -98,10 +98,10 @@ Root.prototype.load = function load(filename, options, callback) {
         /* istanbul ignore if */
         if (!callback)
             return;
-        var cb = callback;
-        callback = null;
         if (sync)
             throw err;
+        var cb = callback;
+        callback = null;
         cb(err, root);
     }
 

--- a/tests/api_root.js
+++ b/tests/api_root.js
@@ -67,6 +67,29 @@ tape.test("reflected roots", function(test) {
         });
     });
 
+    test.test(test.name + " - missing import", function(test) {
+        var root = new Root();
+        test.plan(2);
+        root.load("tests/data/badimport.proto", function(err) {
+            test.ok(err, "should return an error when an imported file does not exist");
+            test.match(err.toString(), /nonexistent\.proto/, "should mention the file name which was not found");
+            test.end();
+        });
+    });
+
+    test.test(test.name + " - missing import, sync load", function(test) {
+        var root = new Root();
+        test.plan(2);
+        try {
+            root.loadSync("tests/data/badimport.proto");
+            root.resolveAll();
+        } catch (err) {
+            test.ok(err, "should return an error when an imported file does not exist");
+            test.match(err.toString(), /nonexistent\.proto/, "should mention the file name which was not found");
+        }
+        test.end();
+    });
+
     test.test(test.name + " - skipped", function(test) {
         var root = new Root();
         root.resolvePath = function() {

--- a/tests/data/badimport.proto
+++ b/tests/data/badimport.proto
@@ -1,0 +1,7 @@
+syntax = "proto3";
+
+import "nonexistent.proto";
+
+message Message {
+  NonExistent field = 1;
+}


### PR DESCRIPTION
Fixes #1954.

The `finish` function can be called in two modes, sync (when it throws an exception), or async (when it calls the callback). It makes sure the callback won't be called twice, but it makes one extra step and clean up the callback even it was called in sync mode. It causes problems such as in #1954 where instead of reporting "file not found" when parsing a proto, it jumps over that error and only reports the next error–or no error if the parsing happens to succeed without a bunch of imports being skipped as a result of the first exception.

Let's avoid clearing the callback if we haven't used it yet.

The problem actually occurs when loading a proto file in sync mode (e.g. by running `root.loadSync(filename)`, which is what `pbjs` does), hence the PR title.