### PR TITLE
Fix for checking web worker env

### DIFF
--- a/src/util/minimal.js
+++ b/src/util/minimal.js
@@ -42,8 +42,8 @@ util.isNode = Boolean(typeof global !== "undefined"
  * @type {Object}
  */
 util.global = util.isNode && global
-           || typeof window !== "undefined" && window
            || typeof self   !== "undefined" && self
+           || typeof window !== "undefined" && window
            || this; // eslint-disable-line no-invalid-this
 
 /**


### PR DESCRIPTION
In web workers, `typeof window` returns a `object` but not `undefined`.

Fix:

Try to detect if the env is a web worker by checking `self` first.