### PR TITLE
fix: missing valuesOptions in the fromJSON parser function (#1961)

### DIFF
--- a/src/enum.js
+++ b/src/enum.js
@@ -87,7 +87,7 @@ function Enum(name, values, options, comment, comments, valuesOptions) {
  * @throws {TypeError} If arguments are invalid
  */
 Enum.fromJSON = function fromJSON(name, json) {
-    var enm = new Enum(name, json.values, json.options, json.comment, json.comments);
+    var enm = new Enum(name, json.values, json.options, json.comment, json.comments, json.valuesOptions);
     enm.reserved = json.reserved;
     return enm;
 };


### PR DESCRIPTION
I've found out that the "valuesOptions" option in the Enum class is missing when parsed from the JSON.

This PR should fix the issue: https://github.com/protobufjs/protobuf.js/issues/1961