### PR TITLE
JSDoc fix root @exports for enum & interface

### DIFF
--- a/cli/targets/static.js
+++ b/cli/targets/static.js
@@ -359,9 +359,13 @@ function buildType(ref, type) {
     if (config.comments) {
         var typeDef = [
             "Properties of " + aOrAn(type.name) + ".",
-            type.parent instanceof protobuf.Root ? "@exports " + escapeName("I" + type.name) : "@memberof " + exportName(type.parent),
-            "@interface " + escapeName("I" + type.name)
+            "@interface " + escapeName("I" + type.name),
         ];
+
+        if (!(type.parent instanceof protobuf.Root)) {
+            typeDef.push("@memberof " + exportName(type.parent));
+        }
+
         type.fieldsArray.forEach(function(field) {
             var prop = util.safeProp(field.name); // either .name or ["name"]
             prop = prop.substring(1, prop.charAt(0) === "[" ? prop.length - 1 : prop.length);
@@ -702,7 +706,7 @@ function buildEnum(ref, enm) {
     push("");
     var comment = [
         enm.comment || enm.name + " enum.",
-        enm.parent instanceof protobuf.Root ? "@exports " + escapeName(enm.name) : "@name " + exportName(enm),
+        "@name " + exportName(enm),
         config.forceEnumString ? "@enum {string}" : "@enum {number}",
     ];
     Object.keys(enm.values).forEach(function(key) {


### PR DESCRIPTION
# Fix Incomplete Type Definitions for .proto Files Without Package

## Problem Description

When a package is not specified in the `.proto` file and types are generated using `pbts`, `jsdoc` does not recognize the `@exports` of the interfaces. This results in an incomplete type definition file.

## Steps to Reproduce

1. Clone the repository:
   ```bash
   git clone https://github.com/jaovitubr/protobuf.js-poc.git
   ```

2. Navigate to the project directory:
   ```bash
   cd protobuf.js-poc
   ```

3. Install the dependencies:
   ```bash
   npm install
   ```

4. Generate the types:
   ```bash
   npm run gen
   ```

5. Observe the generated files:
   - The `sample-root.d.ts` file is incomplete and missing the `IPerson` interface.
   - Compare it with the corrected file `sample-root-fixed.d.ts`, which includes the complete type definitions.

## Solution

To fix this problem, the `@exports` annotation was removed so that Root enums/interfaces are correctly recognized by `jsdoc` even when no package is specified in the `.proto` file.