### PR TITLE
fix(types): reserved field in IType can contain reserved names

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1698,7 +1698,7 @@ export interface IType extends INamespace {
     extensions?: number[][];
 
     /** Reserved ranges */
-    reserved?: number[][];
+    reserved?: (number[]|string)[];
 
     /** Whether a legacy group or not */
     group?: boolean;

--- a/src/type.js
+++ b/src/type.js
@@ -224,7 +224,7 @@ function clearCache(type) {
  * @property {Object.<string,IOneOf>} [oneofs] Oneof descriptors
  * @property {Object.<string,IField>} fields Field descriptors
  * @property {number[][]} [extensions] Extension ranges
- * @property {number[][]} [reserved] Reserved ranges
+ * @property {Array.<number[]|string>} [reserved] Reserved ranges
  * @property {boolean} [group=false] Whether a legacy group or not
  */
 


### PR DESCRIPTION
This is causing downstream problems with some recent descriptor.proto changes that add reserved names.