### PR TITLE
Fix the issue with int64 value type in a map

### DIFF
--- a/src/decoder.js
+++ b/src/decoder.js
@@ -45,9 +45,13 @@ function decoder(mtype) {
                 ("k=%j", types.defaults[field.keyType]);
             else gen
                 ("k=null");
-
-            if (types.defaults[type] !== undefined) gen
-                ("value=%j", types.defaults[type]);
+            if (types.defaults[type] !== undefined) {
+                if (types.isLongType(type)) {
+                    gen("value= $util.Long ? $util.Long.fromValue(0) : 0");
+                } else {
+                    gen("value=%j", types.defaults[type]);
+                }
+            }
             else gen
                 ("value=null");
 

--- a/src/types.js
+++ b/src/types.js
@@ -26,6 +26,17 @@ var s = [
     "bytes"     // 14
 ];
 
+/**
+ * Determine whether a data type requires $utils.Long
+ * @param {string} type value types
+ * @returns {boolean} Result
+ */
+function isLongType(type) {
+    return ["int64", "uint64", "sint64", "fixed64", "sfixed64"].indexOf(type) !== -1;
+}
+
+types.isLongType = isLongType;
+
 function bake(values, offset) {
     var i = 0, o = {};
     offset |= 0;


### PR DESCRIPTION
As an employee from ByteDance, we have discovered a bug in our codebase. The issue occurs when a property in a protocol buffer (PB) structure is of type map<int32, int64>. When the value in the map is 0, the corresponding JavaScript value is represented as the number 0 instead of Long.ZERO.

We are working to fix this bug.