### PR TITLE
Fix line accounting for `alternateCommentMode`

### DIFF
--- a/src/tokenize.js
+++ b/src/tokenize.js
@@ -274,6 +274,7 @@ function tokenize(source, alternateCommentMode) {
                                     break;
                                 }
                                 offset++;
+                                line++;
                                 if (!isLeadingComment) {
                                     // Trailing comment cannot not be multi-line
                                     break;
@@ -281,12 +282,12 @@ function tokenize(source, alternateCommentMode) {
                             } while (isDoubleSlashCommentLine(offset));
                         } else {
                             offset = Math.min(length, findEndOfLine(offset) + 1);
+                            line++;
                         }
                         if (isDoc) {
                             setComment(start, offset, isLeadingComment);
                             isLeadingComment = true;
                         }
-                        line++;
                         repeat = true;
                     }
                 } else if ((curr = charAt(offset)) === "*") { /* Block */


### PR DESCRIPTION
When `alternateCommentMode` is enabled, the tokenizer treats a block of multiple end-of-line (`//`) comments as a single line when keeping track of line numbers, making error messages very difficult to understand, since they refer to the wrong line number.

This change increments the line number in the inner loop, so that each line is accounted correctly.

To reproduce the bug:
```
$ npm install protobufjs

$ cat > broken.proto <<EOF
syntax = "proto3";

// Multiple lines of
// end-of-line comments
// seem to mess up
// the tokenizer's
// bookkeeping.

message Foo {};a
EOF

$ cat > load.js <<EOF
const {Root} = require('protobufjs');
new Root().load('broken.proto', {alternateCommentMode: true});
EOF

$ node load.js
```
This reports an error at broken.js line 5, rather than line 9 where the error actually is.
