### PR TITLE
Improve decoding performance by 40% by preallocating arrays of known length

### DIFF
--- a/src/converter.js
+++ b/src/converter.js
@@ -132,7 +132,7 @@ converter.fromObject = function fromObject(mtype) {
     ("if(d%s){", prop)
         ("if(!Array.isArray(d%s))", prop)
             ("throw TypeError(%j)", field.fullName + ": array expected")
-        ("m%s=[]", prop)
+        ("m%s=Array(d%s.length)", prop, prop)
         ("for(var i=0;i<d%s.length;++i){", prop);
             genValuePartial_fromObject(gen, field, /* not sorted */ i, prop + "[i]")
         ("}")
@@ -281,7 +281,7 @@ converter.toObject = function toObject(mtype) {
         ("}");
         } else if (field.repeated) { gen
     ("if(m%s&&m%s.length){", prop, prop)
-        ("d%s=[]", prop)
+        ("d%s=Array(m%s.length)", prop, prop)
         ("for(var j=0;j<m%s.length;++j){", prop);
             genValuePartial_toObject(gen, field, /* sorted */ index, prop + "[j]")
         ("}");


### PR DESCRIPTION
Currently the generated `.fromObject` methods contain code like this:

```
                if (m.properties && m.properties.length) {
                    d.properties = [];
                    for (var j = 0; j < m.properties.length; ++j) {
                        d.properties[j] = $root.firebase.DeviceProperty.toObject(m.properties[j], o);
                    }
                }
```

This is bad, because you're doing `m.properties.length` allocations. We can do better since the size of the array is known:

```
                if (m.properties && m.properties.length) {
                    d.properties = Array(m.properties.length);
                    for (var j = 0; j < m.properties.length; ++j) {
                        d.properties[j] = $root.firebase.DeviceProperty.toObject(m.properties[j], o);
                    }
                }
```

This PR improves decode performance on the benchmark by around 40% (similar gains in the real world, too).

Before:

```
benchmarking decoding performance ...

protobuf.js (reflect) x 1,539,774 ops/sec ±4.99% (75 runs sampled)
```

After:

```
benchmarking decoding performance ...

protobuf.js (reflect) x 2,186,209 ops/sec ±1.41% (90 runs sampled)
```