### PR TITLE
fix: Add check for existing array before reading

### DIFF
--- a/ext/descriptor/index.js
+++ b/ext/descriptor/index.js
@@ -485,7 +485,7 @@ Field.prototype.toDescriptor = function toDescriptor(syntax) {
 
     // Handle part of oneof
     if (this.partOf)
-        if ((descriptor.oneofIndex = this.parent.oneofsArray.indexOf(this.partOf)) < 0)
+        if (this.parent.oneofsArray && (descriptor.oneofIndex = this.parent.oneofsArray.indexOf(this.partOf)) < 0)
             throw Error("missing oneof");
 
     if (this.options) {


### PR DESCRIPTION
When parsing a proto and handling oneofs there is no check if the array actually exists before reading it, causing the code to throw errors some times.

This change add a check if the oneoffsArray exist before trying to read it.

Seems to be the samme issue as described in: https://github.com/protobufjs/protobuf.js/issues/1958