### PR TITLE
feat: add Edition 2023 Support

### DIFF
--- a/cli/targets/proto.js
+++ b/cli/targets/proto.js
@@ -102,7 +102,7 @@ function buildRoot(root) {
     if (pkg.length)
         out.push("", "package " + pkg.join(".") + ";");
 
-    buildOptions(ptr, ["edition", "syntax"]);
+    buildOptions(ptr, ["edition"]);
     ptr.nestedArray.forEach(build);
 }
 

--- a/cli/targets/proto.js
+++ b/cli/targets/proto.js
@@ -102,7 +102,7 @@ function buildRoot(root) {
     if (pkg.length)
         out.push("", "package " + pkg.join(".") + ";");
 
-    buildOptions(ptr, ["edition"]);
+    buildOptions(ptr);
     ptr.nestedArray.forEach(build);
 }
 
@@ -235,7 +235,7 @@ function buildFieldOptions(field) {
     }
     var sb = [];
     keys.forEach(function(key) {
-        if (key === "proto3_optional" || key === "packed" || key.startsWith("features.")) return;
+        if (key === "proto3_optional" || key === "packed" || key === "features") return;
 
         var val = field.options[key];
         switch (key) {
@@ -330,7 +330,7 @@ function buildOptions(object, ignore = []) {
         return;
     first = true;
     Object.keys(object.options).forEach(function(key) {
-        if (ignore.includes(key) || key.startsWith("features.") || key === "edition") return;
+        if (ignore.includes(key) || key === "features") return;
         if (first) {
             first = false;
             push("");

--- a/cli/targets/proto.js
+++ b/cli/targets/proto.js
@@ -257,9 +257,9 @@ function buildFieldOptions(field) {
     });
     var packable = types.packed[field.resolvedType instanceof Enum ? "int32" : field.type];
     if (packable !== undefined) {
-        if (field.packed && syntax == 2) {
+        if (field.packed && syntax === 2) {
             sb.push("packed=true");
-        } else if(!field.packed && syntax == 3) {
+        } else if(!field.packed && syntax === 3) {
             sb.push("packed=false");
         }
     }

--- a/cli/targets/proto.js
+++ b/cli/targets/proto.js
@@ -330,7 +330,7 @@ function buildOptions(object, ignore = []) {
         return;
     first = true;
     Object.keys(object.options).forEach(function(key) {
-        if (ignore.includes(key) || key.startsWith("features.")) return;
+        if (ignore.includes(key) || key.startsWith("features.") || key === "edition") return;
         if (first) {
             first = false;
             push("");

--- a/cli/targets/proto.js
+++ b/cli/targets/proto.js
@@ -102,7 +102,7 @@ function buildRoot(root) {
     if (pkg.length)
         out.push("", "package " + pkg.join(".") + ";");
 
-    buildOptions(ptr);
+    buildOptions(ptr, ["edition", "syntax"]);
     ptr.nestedArray.forEach(build);
 }
 
@@ -184,8 +184,12 @@ function buildType(type) {
 }
 
 function buildField(field, passExtend) {
-    if (field.partOf || field.declaringField || field.extend !== undefined && !passExtend)
+    if (field.partOf && !field.partOf.isProto3Optional) {
         return;
+    }
+    if (field.declaringField || field.extend !== undefined && !passExtend) {
+        return;
+    }
     if (first) {
         first = false;
         push("");
@@ -199,8 +203,10 @@ function buildField(field, passExtend) {
         sb.push("map<" + field.keyType + ", " + field.type + ">");
     else if (field.repeated)
         sb.push("repeated", field.type);
-    else if (syntax === 2 || field.parent.group)
+    else if (syntax === 2)
         sb.push(field.required ? "required" : "optional", field.type);
+    else if (syntax === 3 && field.hasPresence)
+        sb.push("optional", field.type);
     else
         sb.push(field.type);
     sb.push(underScore(field.name), "=", field.id);
@@ -211,7 +217,7 @@ function buildField(field, passExtend) {
 }
 
 function buildGroup(field) {
-    push(field.rule + " group " + field.resolvedType.name + " = " + field.id + " {");
+    push((field.rule || "optional") + " group " + field.resolvedType.name + " = " + field.id + " {");
     ++indent;
     buildOptions(field.resolvedType);
     first = true;
@@ -223,20 +229,16 @@ function buildGroup(field) {
 }
 
 function buildFieldOptions(field) {
-    var keys;
-    if (!field.options || !(keys = Object.keys(field.options)).length)
-        return null;
+    var keys = [];
+    if (field.options) {
+        keys = Object.keys(field.options);
+    }
     var sb = [];
     keys.forEach(function(key) {
+        if (key === "proto3_optional" || key === "packed" || key.startsWith("features.")) return;
+
         var val = field.options[key];
-        var wireType = types.packed[field.resolvedType instanceof Enum ? "int32" : field.type];
         switch (key) {
-            case "packed":
-                val = Boolean(val);
-                // skip when not packable or syntax default
-                if (wireType === undefined || syntax === 3 === val)
-                    return;
-                break;
             case "default":
                 if (syntax === 3)
                     return;
@@ -253,6 +255,14 @@ function buildFieldOptions(field) {
         }
         sb.push(key + "=" + val);
     });
+    var packable = types.packed[field.resolvedType instanceof Enum ? "int32" : field.type];
+    if (packable !== undefined) {
+        if (field.packed && syntax == 2) {
+            sb.push("packed=true");
+        } else if(!field.packed && syntax == 3) {
+            sb.push("packed=false");
+        }
+    }
     return sb.length
         ? "[" + sb.join(", ") + "]"
         : null;
@@ -282,6 +292,10 @@ function consolidateExtends(nested) {
 }
 
 function buildOneOf(oneof) {
+    if (oneof.isProto3Optional) {
+        return;
+    }
+
     push("");
     push("oneof " + underScore(oneof.name) + " {");
     ++indent; first = true;
@@ -311,11 +325,12 @@ function buildMethod(method) {
     push(method.type + " " + method.name + " (" + (method.requestStream ? "stream " : "") + method.requestType + ") returns (" + (method.responseStream ? "stream " : "") + method.responseType + ");");
 }
 
-function buildOptions(object) {
+function buildOptions(object, ignore = []) {
     if (!object.options)
         return;
     first = true;
     Object.keys(object.options).forEach(function(key) {
+        if (ignore.includes(key) || key.startsWith("features.")) return;
         if (first) {
             first = false;
             push("");

--- a/cli/targets/static.js
+++ b/cli/targets/static.js
@@ -363,7 +363,7 @@ function toJsType(field, parentIsInterface = false) {
 }
 
 function isNullable(field) {
-    return field.hasPresence && !field.required
+    return field.hasPresence && !field.required;
 }
 
 function buildType(ref, type) {

--- a/index.d.ts
+++ b/index.d.ts
@@ -182,9 +182,6 @@ export class Enum extends ReflectionObject {
     /** Resolved values features, if any */
     public _valuesFeatures?: { [k: string]: { [k: string]: any } };
 
-    /** Unresolved values features, if any */
-    public _valuesProtoFeatures?: { [k: string]: { [k: string]: any } };
-
     /** Reserved ranges, if any. */
     public reserved: (number[]|string)[];
 

--- a/src/decoder.js
+++ b/src/decoder.js
@@ -16,16 +16,14 @@ function missing(field) {
  */
 function decoder(mtype) {
     /* eslint-disable no-unexpected-multiline */
-    var gen = util.codegen(["r", "l"], mtype.name + "$decode")
+    var gen = util.codegen(["r", "l", "e"], mtype.name + "$decode")
     ("if(!(r instanceof Reader))")
         ("r=Reader.create(r)")
     ("var c=l===undefined?r.len:r.pos+l,m=new this.ctor" + (mtype.fieldsArray.filter(function(field) { return field.map; }).length ? ",k,value" : ""))
     ("while(r.pos<c){")
-        ("var t=r.uint32()");
-    if (mtype.group) gen
-        ("if((t&7)===4)")
-            ("break");
-    gen
+        ("var t=r.uint32()")
+        ("if(t===e)")
+            ("break")
         ("switch(t>>>3){");
 
     var i = 0;
@@ -91,15 +89,15 @@ function decoder(mtype) {
                 ("}else");
 
             // Non-packed
-            if (types.basic[type] === undefined) gen(field.resolvedType.group
-                    ? "%s.push(types[%i].decode(r))"
+            if (types.basic[type] === undefined) gen(field.delimited
+                    ? "%s.push(types[%i].decode(r,undefined,((t&~7)|4)))"
                     : "%s.push(types[%i].decode(r,r.uint32()))", ref, i);
             else gen
                     ("%s.push(r.%s())", ref, type);
 
         // Non-repeated
-        } else if (types.basic[type] === undefined) gen(field.resolvedType.group
-                ? "%s=types[%i].decode(r)"
+        } else if (types.basic[type] === undefined) gen(field.delimited
+                ? "%s=types[%i].decode(r,undefined,((t&~7)|4))"
                 : "%s=types[%i].decode(r,r.uint32())", ref, i);
         else gen
                 ("%s=r.%s()", ref, type);

--- a/src/encoder.js
+++ b/src/encoder.js
@@ -15,7 +15,7 @@ var Enum     = require("./enum"),
  * @ignore
  */
 function genTypePartial(gen, field, fieldIndex, ref) {
-    return field.resolvedType.group
+    return field.delimited
         ? gen("types[%i].encode(%s,w.uint32(%i)).uint32(%i)", fieldIndex, ref, (field.id << 3 | 3) >>> 0, (field.id << 3 | 4) >>> 0)
         : gen("types[%i].encode(%s,w.uint32(%i).fork()).ldelim()", fieldIndex, ref, (field.id << 3 | 2) >>> 0);
 }

--- a/src/enum.js
+++ b/src/enum.js
@@ -85,20 +85,19 @@ function Enum(name, values, options, comment, comments, valuesOptions) {
 }
 
 /**
- * Resolves value features
- * @returns {Enum} `this`
+ * @override
  */
-Enum.prototype.resolve = function resolve() {
-    ReflectionObject.prototype.resolve.call(this);
+Enum.prototype._resolveFeatures = function _resolveFeatures(edition) {
+    var edition = this._edition || edition;
+    ReflectionObject.prototype._resolveFeatures.call(this, edition);
 
-    for (var key of Object.keys(this._valuesProtoFeatures)) {
+    Object.keys(this._valuesProtoFeatures).forEach(key => {
         var parentFeaturesCopy = Object.assign({}, this._features);
         this._valuesFeatures[key] = Object.assign(parentFeaturesCopy, this._valuesProtoFeatures[key] || {});
-    }
+    });
 
     return this;
 };
-
 
 /**
  * Enum descriptor.
@@ -117,6 +116,9 @@ Enum.prototype.resolve = function resolve() {
 Enum.fromJSON = function fromJSON(name, json) {
     var enm = new Enum(name, json.values, json.options, json.comment, json.comments);
     enm.reserved = json.reserved;
+    if (json.edition)
+        enm._edition = json.edition;
+    enm._defaultEdition = "proto3";  // For backwards-compatibility.
     return enm;
 };
 
@@ -128,6 +130,7 @@ Enum.fromJSON = function fromJSON(name, json) {
 Enum.prototype.toJSON = function toJSON(toJSONOptions) {
     var keepComments = toJSONOptions ? Boolean(toJSONOptions.keepComments) : false;
     return util.toObject([
+        "edition"       , this._editionToJSON(),
         "options"       , this.options,
         "valuesOptions" , this.valuesOptions,
         "values"        , this.values,

--- a/src/enum.js
+++ b/src/enum.js
@@ -63,12 +63,6 @@ function Enum(name, values, options, comment, comments, valuesOptions) {
     this._valuesFeatures = {};
 
     /**
-     * Unresolved values features, if any
-     * @type {Object<string, Object<string, *>>|undefined}
-     */
-    this._valuesProtoFeatures = {};
-
-    /**
      * Reserved ranges, if any.
      * @type {Array.<number[]|string>}
      */
@@ -88,12 +82,12 @@ function Enum(name, values, options, comment, comments, valuesOptions) {
  * @override
  */
 Enum.prototype._resolveFeatures = function _resolveFeatures(edition) {
-    var edition = this._edition || edition;
+    edition = this._edition || edition;
     ReflectionObject.prototype._resolveFeatures.call(this, edition);
 
-    Object.keys(this._valuesProtoFeatures).forEach(key => {
+    Object.keys(this.values).forEach(key => {
         var parentFeaturesCopy = Object.assign({}, this._features);
-        this._valuesFeatures[key] = Object.assign(parentFeaturesCopy, this._valuesProtoFeatures[key] || {});
+        this._valuesFeatures[key] = Object.assign(parentFeaturesCopy, this.valuesOptions && this.valuesOptions[key] && this.valuesOptions[key].features);
     });
 
     return this;
@@ -179,21 +173,6 @@ Enum.prototype.add = function add(name, id, comment, options) {
         if (this.valuesOptions === undefined)
             this.valuesOptions = {};
         this.valuesOptions[name] = options || null;
-
-        for (var key of Object.keys(this.valuesOptions)) {
-            var features = Array.isArray(this.valuesOptions[key]) ? this.valuesOptions[key].find(x => {return Object.prototype.hasOwnProperty.call(x, "features");}) : this.valuesOptions[key] === "features";
-            if (features) {
-                this._valuesProtoFeatures[key] = features.features;
-            } else {
-                this._valuesProtoFeatures[key] = {};
-            }
-        }
-    }
-
-    for (var enumValue of Object.keys(this.values)) {
-        if (!this._valuesProtoFeatures[enumValue]) {
-            this._valuesProtoFeatures[enumValue] = {};
-        }
     }
 
     this.comments[name] = comment || null;

--- a/src/field.js
+++ b/src/field.js
@@ -375,7 +375,7 @@ Field.prototype._inferLegacyProtoFeatures = function _inferLegacyProtoFeatures(e
         features.repeated_field_encoding = "EXPANDED";
     }
     return features;
-}
+};
 
 /**
  * Decorator function as returned by {@link Field.d} and {@link MapField.d} (TypeScript).

--- a/src/field.js
+++ b/src/field.js
@@ -203,6 +203,20 @@ Object.defineProperty(Field.prototype, "optional", {
 });
 
 /**
+ * Determines whether this field uses tag-delimited encoding.  In proto2 this
+ * corresponded to group syntax.
+ * @name Field#delimited
+ * @type {boolean}
+ * @readonly
+ */
+Object.defineProperty(Field.prototype, "delimited", {
+    get: function() {
+        return this.resolvedType instanceof Type &&
+            this._features.message_encoding === "DELIMITED";
+    }
+});
+
+/**
  * Determines whether this field is packed. Only relevant when repeated.
  * @name Field#packed
  * @type {boolean}
@@ -334,6 +348,9 @@ Field.prototype._inferLegacyProtoFeatures = function _inferLegacyProtoFeatures(e
     var features = {};
     if (this.rule === "required") {
         features.field_presence = "LEGACY_REQUIRED";
+    }
+    if (this.resolvedType instanceof Type && this.resolvedType.group) {
+        features.message_encoding = "DELIMITED";
     }
     if (this.getOption("packed") === true) {
         features.repeated_field_encoding = "PACKED";

--- a/src/field.js
+++ b/src/field.js
@@ -229,6 +229,23 @@ Object.defineProperty(Field.prototype, "packed", {
 });
 
 /**
+ * Determines whether this field tracks presence.
+ * @name Field#hasPresence
+ * @type {boolean}
+ * @readonly
+ */
+Object.defineProperty(Field.prototype, "hasPresence", {
+    get: function() {
+        if (this.repeated || this.map) {
+            return false;
+        }
+        return this.partOf || // oneofs
+            this.declaringField || this.extensionField || // extensions
+            this._features.field_presence !== "IMPLICIT";
+    }
+});
+
+/**
  * @override
  */
 Field.prototype.setOption = function setOption(name, value, ifNotSet) {

--- a/src/field.js
+++ b/src/field.js
@@ -366,7 +366,7 @@ Field.prototype.resolve = function resolve() {
  */
 Field.prototype._inferLegacyProtoFeatures = function _inferLegacyProtoFeatures(edition) {
     if (edition !== "proto2" && edition !== "proto3") {
-        return;
+        return {};
     }
 
     var features = {};

--- a/src/field.js
+++ b/src/field.js
@@ -106,18 +106,6 @@ function Field(name, id, type, rule, extend, options, comment) {
     this.extend = extend || undefined; // toJSON
 
     /**
-     * Whether this field is required.
-     * @type {boolean}
-     */
-    this.required = rule === "required";
-
-    /**
-     * Whether this field is optional.
-     * @type {boolean}
-     */
-    this.optional = !this.required;
-
-    /**
      * Whether this field is repeated.
      * @type {boolean}
      */
@@ -189,6 +177,30 @@ function Field(name, id, type, rule, extend, options, comment) {
      */
     this.comment = comment;
 }
+
+/**
+ * Determines whether this field is required.
+ * @name Field#required
+ * @type {boolean}
+ * @readonly
+ */
+Object.defineProperty(Field.prototype, "required", {
+    get: function() {
+        return this._features.field_presence === "LEGACY_REQUIRED";
+    }
+});
+
+/**
+ * Determines whether this field is not required.
+ * @name Field#optional
+ * @type {boolean}
+ * @readonly
+ */
+Object.defineProperty(Field.prototype, "optional", {
+    get: function() {
+        return !this.required;
+    }
+});
 
 /**
  * Determines whether this field is packed. Only relevant when repeated.
@@ -320,6 +332,9 @@ Field.prototype._inferLegacyProtoFeatures = function _inferLegacyProtoFeatures(e
     if (edition) return {};
 
     var features = {};
+    if (this.rule === "required") {
+        features.field_presence = "LEGACY_REQUIRED";
+    }
     if (this.getOption("packed") === true) {
         features.repeated_field_encoding = "PACKED";
     } else if (this.getOption("packed") === false) {

--- a/src/index-light.js
+++ b/src/index-light.js
@@ -98,7 +98,7 @@ protobuf.types            = require("./types");
 protobuf.util             = require("./util");
 
 // Set up possibly cyclic reflection dependencies
-protobuf.ReflectionObject._configure(protobuf.Root);
+protobuf.ReflectionObject._configure(protobuf.Root, protobuf.Namespace);
 protobuf.Namespace._configure(protobuf.Type, protobuf.Service, protobuf.Enum);
 protobuf.Root._configure(protobuf.Type);
 protobuf.Field._configure(protobuf.Type);

--- a/src/index-light.js
+++ b/src/index-light.js
@@ -98,7 +98,7 @@ protobuf.types            = require("./types");
 protobuf.util             = require("./util");
 
 // Set up possibly cyclic reflection dependencies
-protobuf.ReflectionObject._configure(protobuf.Root, protobuf.Namespace);
+protobuf.ReflectionObject._configure(protobuf.Root);
 protobuf.Namespace._configure(protobuf.Type, protobuf.Service, protobuf.Enum);
 protobuf.Root._configure(protobuf.Type);
 protobuf.Field._configure(protobuf.Type);

--- a/src/namespace.js
+++ b/src/namespace.js
@@ -240,6 +240,15 @@ Namespace.prototype.add = function add(object) {
         }
     }
     this.nested[object.name] = object;
+
+    if (!(this instanceof Type || this instanceof Service || this instanceof Enum || this instanceof Field)) {
+        // This is a package or a root namespace.
+        if (!object._edition) {
+            // Make sure that some edition is set if it hasn't already been specified.
+            object._edition = object._defaultEdition;
+        }
+    }
+
     object.onAdd(this);
     return clearCache(this);
 };
@@ -308,6 +317,19 @@ Namespace.prototype.resolveAll = function resolveAll() {
             nested[i++].resolveAll();
         else
             nested[i++].resolve();
+    return this;
+};
+
+/**
+ * @override
+ */
+Namespace.prototype._resolveFeaturesRecursive = function _resolveFeaturesRecursive(edition) {
+    var edition = this._edition || edition;
+
+    ReflectionObject.prototype._resolveFeaturesRecursive.call(this, edition);
+    this.nestedArray.forEach(nested => {
+        nested._resolveFeaturesRecursive(edition);
+    });
     return this;
 };
 

--- a/src/namespace.js
+++ b/src/namespace.js
@@ -324,7 +324,7 @@ Namespace.prototype.resolveAll = function resolveAll() {
  * @override
  */
 Namespace.prototype._resolveFeaturesRecursive = function _resolveFeaturesRecursive(edition) {
-    var edition = this._edition || edition;
+    edition = this._edition || edition;
 
     ReflectionObject.prototype._resolveFeaturesRecursive.call(this, edition);
     this.nestedArray.forEach(nested => {

--- a/src/object.js
+++ b/src/object.js
@@ -216,10 +216,11 @@ ReflectionObject.prototype._resolveFeatures = function _resolveFeatures() {
  * in older editions.
  * @param {string|undefined} edition The edition this proto is on, or undefined if pre-editions
  * @returns {object} The feature values to override
+ * @abstract
  */
-ReflectionObject.prototype._inferLegacyProtoFeatures = function _inferLegacyProtoFeatures(edition) {
+ReflectionObject.prototype._inferLegacyProtoFeatures = function _inferLegacyProtoFeatures(/*edition*/) {
     return {};
-}
+};
 
 /**
  * Gets an option value.

--- a/src/object.js
+++ b/src/object.js
@@ -197,11 +197,17 @@ ReflectionObject.prototype._resolveFeatures = function _resolveFeatures() {
     } else if (this.partOf instanceof OneOf) {
         var lexicalParentFeaturesCopy = Object.assign({}, this.partOf._features);
         this._features = Object.assign(lexicalParentFeaturesCopy, protoFeatures || {});
+    } else if (this.declaringField) {
+        // Skip feature resolution of sister fields.
     } else if (this.parent) {
         var parentFeaturesCopy = Object.assign({}, this.parent._features);
         this._features = Object.assign(parentFeaturesCopy, protoFeatures || {});
     } else {
         this._features = Object.assign({}, protoFeatures);
+    }
+    if (this.extensionField) {
+        // Sister fields should have the same features as their extensions.
+        this.extensionField._features = this._features;
     }
 };
 

--- a/src/oneof.js
+++ b/src/oneof.js
@@ -172,6 +172,25 @@ OneOf.prototype.onRemove = function onRemove(parent) {
 };
 
 /**
+ * Determines whether this field corresponds to a synthetic oneof created for
+ * a proto3 optional field.  No behavioral logic should depend on this, but it
+ * can be relevant for reflection.
+ * @name OneOf#isProto3Optional
+ * @type {boolean}
+ * @readonly
+ */
+Object.defineProperty(OneOf.prototype, "isProto3Optional", {
+    get: function() {
+        if (this.fieldsArray == null || this.fieldsArray.length !== 1) {
+            return false;
+        }
+
+        var field = this.fieldsArray[0];
+        return field.options != null && field.options["proto3_optional"] === true;
+    }
+});
+
+/**
  * Decorator function as returned by {@link OneOf.d} (TypeScript).
  * @typedef OneOfDecorator
  * @type {function}

--- a/src/parse.js
+++ b/src/parse.js
@@ -96,7 +96,7 @@ function parse(source, root, options) {
             obj._edition = edition;
             Object.keys(topLevelOptions).forEach(opt => {
                 if (obj.getOption(opt) !== undefined) return;
-                obj.setOption(opt, topLevelOptions[opt]);
+                obj.setOption(opt, topLevelOptions[opt], true);
             });
         });
     }
@@ -628,18 +628,13 @@ function parse(source, root, options) {
             dummy = {
                 options: undefined
             };
-        dummy.setOption = function(name, value) {
-            if (this.options === undefined)
-                this.options = {};
-
-            this.options[name] = value;
+        dummy.getOption = function(name) {
+            return this.options[name];
         };
-        dummy.setParsedOption = function(name, value, propName) {
-            // In order to not change existing behavior, only calling
-            // this for features
-            if (/^features$/.test(name)) {
-                return ReflectionObject.prototype.setParsedOption.call(dummy, name, value, propName);
-            }
+        dummy.setOption = function(name, value) {
+            ReflectionObject.prototype.setOption.call(dummy, name, value);
+        };
+        dummy.setParsedOption = function() {
             return undefined;
         };
         ifBlock(dummy, function parseEnumValue_block(token) {

--- a/src/parse.js
+++ b/src/parse.js
@@ -88,7 +88,6 @@ function parse(source, root, options) {
 
     var topLevelObjects = [];
     var topLevelOptions = {};
-    var topLevelParsedOptions = {};
 
     var applyCase = options.keepCase ? function(name) { return name; } : util.camelCase;
 
@@ -98,9 +97,6 @@ function parse(source, root, options) {
             Object.keys(topLevelOptions).forEach(opt => {
                 if (obj.getOption(opt) !== undefined) return;
                 obj.setOption(opt, topLevelOptions[opt]);
-                if (topLevelParsedOptions[opt.substring("features.".length)]) {
-                    obj.setParsedOption("features", topLevelParsedOptions[opt.substring("features.".length)], opt.substring("features.".length));
-                }
             });
         });
     }
@@ -769,10 +765,6 @@ function parse(source, root, options) {
     }
 
     function setParsedOption(parent, name, value, propName) {
-        if (ptr === parent && /^features$/.test(name)) {
-            topLevelParsedOptions[propName] = value;
-            return;
-        }
         if (parent.setParsedOption)
             parent.setParsedOption(name, value, propName);
     }

--- a/src/parse.js
+++ b/src/parse.js
@@ -657,7 +657,7 @@ function parse(source, root, options) {
                     isOption = false;
                     if (token.includes(".") && !token.includes("(")) {
                         var tokens = token.split(".");
-                        option = tokens[0];
+                        option = tokens[0] + ".";
                         token = tokens[1];
                         continue;
                     }

--- a/src/parse.js
+++ b/src/parse.js
@@ -460,12 +460,6 @@ function parse(source, root, options) {
         } else {
             parent.add(field);
         }
-
-        // JSON defaults to packed=true if not set so we have to set packed=false explicity when
-        // parsing proto2 descriptors without the option, where applicable. This must be done for
-        // all known packable types and anything that could be an enum (= is not a basic type).
-        if (!isProto3 && field.repeated && (types.packed[type] !== undefined || types.basic[type] === undefined))
-            field.setOption("packed", false, /* ifNotSet */ true);
     }
 
     function parseGroup(parent, rule) {

--- a/src/root.js
+++ b/src/root.js
@@ -36,8 +36,8 @@ function Root(options) {
      */
     this.files = [];
 
-    // Default to proto2 if not specified.
-    this.setOption("edition", "proto2", true);
+    // Default to proto2 if unspecified.
+    this._edition = "proto2";
 }
 
 /**

--- a/src/root.js
+++ b/src/root.js
@@ -51,7 +51,7 @@ Root.fromJSON = function fromJSON(json, root) {
         root = new Root();
     if (json.options)
         root.setOptions(json.options);
-    return root.addJSON(json.nested);
+    return root.addJSON(json.nested).resolveAll();
 };
 
 /**

--- a/src/root.js
+++ b/src/root.js
@@ -35,6 +35,9 @@ function Root(options) {
      * @type {string[]}
      */
     this.files = [];
+
+    // Default to proto2 if not specified.
+    this.setOption("edition", "proto2", true);
 }
 
 /**

--- a/src/service.js
+++ b/src/service.js
@@ -121,11 +121,11 @@ Service.prototype.resolveAll = function resolveAll() {
  * @override
  */
 Service.prototype._resolveFeaturesRecursive = function _resolveFeaturesRecursive(edition) {
-    var edition = this._edition || edition;
+    edition = this._edition || edition;
 
     Namespace.prototype._resolveFeaturesRecursive.call(this, edition);
     this.methodsArray.forEach(method => {
-        method._resolveFeaturesRecursive(edition);        
+        method._resolveFeaturesRecursive(edition);
     });
     return this;
 };

--- a/src/service.js
+++ b/src/service.js
@@ -57,7 +57,10 @@ Service.fromJSON = function fromJSON(name, json) {
             service.add(Method.fromJSON(names[i], json.methods[names[i]]));
     if (json.nested)
         service.addJSON(json.nested);
+    if (json.edition)
+        service._edition = json.edition;
     service.comment = json.comment;
+    service._defaultEdition = "proto3";  // For backwards-compatibility.
     return service;
 };
 
@@ -70,6 +73,7 @@ Service.prototype.toJSON = function toJSON(toJSONOptions) {
     var inherited = Namespace.prototype.toJSON.call(this, toJSONOptions);
     var keepComments = toJSONOptions ? Boolean(toJSONOptions.keepComments) : false;
     return util.toObject([
+        "edition" , this._editionToJSON(),
         "options" , inherited && inherited.options || undefined,
         "methods" , Namespace.arrayToJSON(this.methodsArray, toJSONOptions) || /* istanbul ignore next */ {},
         "nested"  , inherited && inherited.nested || undefined,
@@ -110,6 +114,19 @@ Service.prototype.resolveAll = function resolveAll() {
     var methods = this.methodsArray;
     for (var i = 0; i < methods.length; ++i)
         methods[i].resolve();
+    return this;
+};
+
+/**
+ * @override
+ */
+Service.prototype._resolveFeaturesRecursive = function _resolveFeaturesRecursive(edition) {
+    var edition = this._edition || edition;
+
+    Namespace.prototype._resolveFeaturesRecursive.call(this, edition);
+    this.methodsArray.forEach(method => {
+        method._resolveFeaturesRecursive(edition);        
+    });
     return this;
 };
 

--- a/src/type.js
+++ b/src/type.js
@@ -234,7 +234,7 @@ function clearCache(type) {
  * @param {IType} json Message type descriptor
  * @returns {Type} Created message type
  */
-Type.fromJSON = function fromJSON(name, json, nested) {
+Type.fromJSON = function fromJSON(name, json) {
     var type = new Type(name, json.options);
     type.extensions = json.extensions;
     type.reserved = json.reserved;
@@ -317,14 +317,14 @@ Type.prototype.resolveAll = function resolveAll() {
  * @override
  */
 Type.prototype._resolveFeaturesRecursive = function _resolveFeaturesRecursive(edition) {
-    var edition = this._edition || edition;
+    edition = this._edition || edition;
 
     Namespace.prototype._resolveFeaturesRecursive.call(this, edition);
     this.oneofsArray.forEach(oneof => {
-        oneof._resolveFeatures(edition);        
+        oneof._resolveFeatures(edition);
     });
     this.fieldsArray.forEach(field => {
-        field._resolveFeatures(edition);        
+        field._resolveFeatures(edition);
     });
     return this;
 };

--- a/src/type.js
+++ b/src/type.js
@@ -234,7 +234,7 @@ function clearCache(type) {
  * @param {IType} json Message type descriptor
  * @returns {Type} Created message type
  */
-Type.fromJSON = function fromJSON(name, json) {
+Type.fromJSON = function fromJSON(name, json, nested) {
     var type = new Type(name, json.options);
     type.extensions = json.extensions;
     type.reserved = json.reserved;
@@ -272,6 +272,9 @@ Type.fromJSON = function fromJSON(name, json) {
         type.group = true;
     if (json.comment)
         type.comment = json.comment;
+    if (json.edition)
+        type._edition = json.edition;
+    type._defaultEdition = "proto3";  // For backwards-compatibility.
     return type;
 };
 
@@ -284,6 +287,7 @@ Type.prototype.toJSON = function toJSON(toJSONOptions) {
     var inherited = Namespace.prototype.toJSON.call(this, toJSONOptions);
     var keepComments = toJSONOptions ? Boolean(toJSONOptions.keepComments) : false;
     return util.toObject([
+        "edition"    , this._editionToJSON(),
         "options"    , inherited && inherited.options || undefined,
         "oneofs"     , Namespace.arrayToJSON(this.oneofsArray, toJSONOptions),
         "fields"     , Namespace.arrayToJSON(this.fieldsArray.filter(function(obj) { return !obj.declaringField; }), toJSONOptions) || {},
@@ -306,6 +310,22 @@ Type.prototype.resolveAll = function resolveAll() {
     var fields = this.fieldsArray, i = 0;
     while (i < fields.length)
         fields[i++].resolve();
+    return this;
+};
+
+/**
+ * @override
+ */
+Type.prototype._resolveFeaturesRecursive = function _resolveFeaturesRecursive(edition) {
+    var edition = this._edition || edition;
+
+    Namespace.prototype._resolveFeaturesRecursive.call(this, edition);
+    this.oneofsArray.forEach(oneof => {
+        oneof._resolveFeatures(edition);        
+    });
+    this.fieldsArray.forEach(field => {
+        field._resolveFeatures(edition);        
+    });
     return this;
 };
 

--- a/src/util.js
+++ b/src/util.js
@@ -171,10 +171,10 @@ util.decorateEnum = function decorateEnum(object) {
  * @param {Object.<string,*>} dst Destination object
  * @param {string} path dot '.' delimited path of the property to set
  * @param {Object} value the value to set
- * @param {boolean} overWrite whether or not to concatenate the values into an array or overwrite; defaults to false.
+ * @param {boolean|undefined} [ifNotSet] Sets the option only if it isn't currently set
  * @returns {Object.<string,*>} Destination object
  */
-util.setProperty = function setProperty(dst, path, value) {
+util.setProperty = function setProperty(dst, path, value, ifNotSet) {
     function setProp(dst, path, value) {
         var part = path.shift();
         if (part === "__proto__" || part === "prototype") {
@@ -184,6 +184,8 @@ util.setProperty = function setProperty(dst, path, value) {
             dst[part] = setProp(dst[part] || {}, path, value);
         } else {
             var prevValue = dst[part];
+            if (prevValue && ifNotSet)
+                return dst;
             if (prevValue)
                 value = [].concat(prevValue).concat(value);
             dst[part] = value;

--- a/tests/api_enum.js
+++ b/tests/api_enum.js
@@ -6,7 +6,7 @@ tape.test("reflected enums", function(test) {
 
     var enm = new protobuf.Enum("Test", {
         a: 1,
-        b: 2
+        b: 2,
     });
 
     var enm_allow_alias = new protobuf.Enum( 'AliasTest',
@@ -86,6 +86,17 @@ tape.test("reflected enums", function(test) {
             '(test_option)': 'test_value'
         }
     });
+    enm.remove("e");
+    test.same( enm.valuesOptions, {}, "should clean up value options");
+
+    enm.reserved = [[100,200], "BAD_NAME"];
+    test.throws(function() {
+        enm.add("d", 101);
+    }, Error, "should throw if id is a reserved number");
+
+    test.throws(function() {
+        enm.add("BAD_NAME", 5);
+    }, Error, "should throw if id is a reserved name");
 
     test.end();
 });

--- a/tests/api_enum.js
+++ b/tests/api_enum.js
@@ -89,3 +89,101 @@ tape.test("reflected enums", function(test) {
 
     test.end();
 });
+
+tape.test("feature resolution legacy proto3", function(test) {
+    var json = {
+        values: {
+            a: 0, b: 1
+        }
+    };
+    var messageJson = {
+        fields: {},
+        nested: { Enum: { values: {
+            a: 0, b:1
+        } } }
+    };
+    var root = new protobuf.Root();
+    var Enum = protobuf.Enum.fromJSON("Enum", json);
+    var Message = protobuf.Type.fromJSON("Message", messageJson)
+    var Nested = Message.nested.Enum;
+    root.add(Enum).add(Message).resolveAll();
+
+    test.same(Enum.toJSON(), json, "JSON should roundtrip");
+    test.same(Message.toJSON(), messageJson, "container JSON should roundtrip");
+    test.same(Nested.toJSON(), messageJson.nested.Enum, "nested JSON should roundtrip");
+
+    test.equal(Enum._edition, "proto3", "should infer proto3 syntax");
+    test.equal(Enum._features.enum_type, "OPEN", "should be open by default");
+
+    test.equal(Nested._edition, null, "should not set edition");
+    test.equal(Nested._features.enum_type, "OPEN", "should be open by default");
+
+    test.end();
+});
+
+tape.test("feature resolution proto2", function(test) {
+    var json = {
+        edition: "proto2",
+        values: {
+            a: 0, b: 1
+        }
+    };
+    var messageJson = {
+        edition: "proto2",
+        fields: {},
+        nested: { Enum: { values: {
+            a: 0, b: 1
+        } } }
+    };
+    var root = new protobuf.Root();
+    var Enum = protobuf.Enum.fromJSON("Enum", json);
+    var Message = protobuf.Type.fromJSON("Message", messageJson)
+    var Nested = Message.nested.Enum;
+    root.add(Enum).add(Message).resolveAll();
+
+    test.same(Enum.toJSON(), json, "JSON should roundtrip");
+    test.same(Message.toJSON(), messageJson, "container JSON should roundtrip");
+    test.same(Nested.toJSON(), messageJson.nested.Enum, "nested JSON should roundtrip");
+
+    test.equal(Enum._edition, "proto2", "should set edition");
+    test.equal(Enum._features.enum_type, "CLOSED", "should be closed by default");
+
+    test.equal(Nested._edition, null, "should not set edition");
+    test.equal(Nested._features.enum_type, "CLOSED", "should be closed by default");
+
+    test.end();
+});
+
+tape.test("feature resolution legacy proto3", function(test) {
+    var json = {
+        edition: "2023",
+        values: {
+            a: 0, b: 1
+        }
+    };
+    var messageJson = {
+        edition: "2023",
+        options: { features: { enum_type: "CLOSED" } },
+        fields: {},
+        nested: { Enum: { values: {
+            a: 0, b: 1
+        } } }
+    };
+    var root = new protobuf.Root();
+    var Enum = protobuf.Enum.fromJSON("Enum", json);
+    var Message = protobuf.Type.fromJSON("Message", messageJson)
+    var Nested = Message.nested.Enum;
+    root.add(Enum).add(Message).resolveAll();
+
+    test.same(Enum.toJSON(), json, "JSON should roundtrip");
+    test.same(Message.toJSON(), messageJson, "container JSON should roundtrip");
+    test.same(Nested.toJSON(), messageJson.nested.Enum, "nested JSON should roundtrip");
+
+    test.equal(Enum._edition, "2023", "should set edition");
+    test.equal(Enum._features.enum_type, "OPEN", "should be open by default");
+
+    test.equal(Nested._edition, null, "should not set edition");
+    test.equal(Nested._features.enum_type, "CLOSED", "should inherit override");
+
+    test.end();
+});

--- a/tests/api_service.js
+++ b/tests/api_service.js
@@ -45,3 +45,104 @@ tape.test("reflected services", function(test) {
 
     test.end();
 });
+
+tape.test("feature resolution legacy proto3", function(test) {
+    var json = {
+        methods: {
+            Method: {
+                requestType: "Empty",
+                responseType: "Empty",
+            }
+        },
+        nested: {
+            Empty: { fields: {} }
+        }
+    };
+    var root = new protobuf.Root();
+    var Service = protobuf.Service.fromJSON("Service", json);
+    root.add(Service).resolveAll();
+
+    var Method = Service.methods.Method;
+
+    test.same(Service.toJSON(), json, "JSON should roundtrip");
+    test.same(Method.toJSON(), json.methods.Method, "method JSON should roundtrip");
+
+    test.equal(Service._edition, "proto3", "should infer proto3 syntax");
+    test.equal(Service._features.field_presence, "IMPLICIT", "should have implicit presence by default");
+
+    test.equal(Method._edition, null, "should not infer proto3 syntax");
+    test.equal(Method._features.field_presence, "IMPLICIT", "should have implicit presence by default");
+
+    test.end();
+});
+
+tape.test("feature resolution proto2", function(test) {
+    var json = {
+        edition: "proto2",
+        methods: {
+            Method: {
+                requestType: "Empty",
+                responseType: "Empty",
+            }
+        },
+        nested: {
+            Empty: { fields: {} }
+        }
+    };
+    var root = new protobuf.Root();
+    var Service = protobuf.Service.fromJSON("Service", json);
+    root.add(Service).resolveAll();
+
+    var Method = Service.methods.Method;
+
+    test.same(Service.toJSON(), json, "JSON should roundtrip");
+    test.same(Method.toJSON(), json.methods.Method, "method JSON should roundtrip");
+
+    test.equal(Service._edition, "proto2", "should infer proto2 syntax");
+    test.equal(Service._features.field_presence, "EXPLICIT", "should have explicit presence by default");
+
+    test.equal(Method._edition, null, "should not infer proto2 syntax");
+    test.equal(Method._features.field_presence, "EXPLICIT", "should have explicit presence by default");
+
+    test.end();
+});
+
+
+tape.test("feature resolution edition 2023", function(test) {
+    var json = {
+        edition: "2023",
+        options: { features: { "(foo)": { "bar": "VALUE" } } },
+        methods: {
+            Method: {
+                requestType: "Empty",
+                responseType: "Empty",
+            }
+        },
+        nested: {
+            Empty: { fields: {} }
+        }
+    };
+    var root = new protobuf.Root();
+    var Service = protobuf.Service.fromJSON("Service", json);
+    root.add(Service).resolveAll();
+
+    var Method = Service.methods.Method;
+    var Empty = Service.nested.Empty;
+
+    test.same(Service.toJSON(), json, "JSON should roundtrip");
+    test.same(Method.toJSON(), json.methods.Method, "method JSON should roundtrip");
+
+    test.equal(Service._edition, "2023", "should set edition");
+    test.equal(Service._features.field_presence, "EXPLICIT", "should have explicit presence by default");
+    test.equal(Service._features["(foo)"].bar, "VALUE", "should get file features");
+
+    test.equal(Method._edition, null, "should not set edition");
+    test.equal(Method._features.field_presence, "EXPLICIT", "should have explicit presence by default");
+    test.equal(Method._features["(foo)"].bar, "VALUE", "should get file features");
+
+    test.equal(Empty._edition, null, "should not set edition");
+    test.equal(Empty._features.field_presence, "EXPLICIT", "should have explicit presence by default");
+    test.equal(Empty._features["(foo)"].bar, "VALUE", "should get file features");
+
+    test.end();
+});

--- a/tests/api_type.js
+++ b/tests/api_type.js
@@ -100,3 +100,121 @@ tape.test("reflected types", function(test) {
 
     test.end();
 });
+
+tape.test("feature resolution legacy proto3", function(test) {
+    var json = {
+        fields: {
+            regular: { type: "string", id: 1 },
+            packed: { type: "int32", id: 2, rule: "repeated" },
+            unpacked: { type: "int32", id: 3, rule: "repeated", options: { packed: false } }
+        },
+        nested: { Nested: { fields: {
+            regular: { type: "string", id: 1 },
+            packed: { type: "int32", id: 2, rule: "repeated" },
+            unpacked: { type: "int32", id: 3, rule: "repeated", options: { packed: false } }
+        } } }
+    };
+    var root = new protobuf.Root();
+    var Type = protobuf.Type.fromJSON("My", json);
+    root.add(Type).resolveAll();
+
+    var Nested = Type.nested.Nested;
+
+    test.same(Type.toJSON(), json, "JSON should roundtrip");
+    test.same(Nested.toJSON(), json.nested.Nested, "nested JSON should roundtrip");
+
+    test.same(Type._edition, "proto3", "should infer proto3 syntax");
+    test.notOk(Type.fields.regular.hasPresence, "should have implicit presence by default");
+    test.ok(Type.fields.packed.packed, "should have packed encoding by default");
+    test.notOk(Type.fields.unpacked.packed, "should override expanded encoding");
+
+    test.same(Type._edition, "proto3", "should not infer proto3 syntax");
+    test.notOk(Nested.fields.regular.hasPresence, "nested should have implicit presence by default");
+    test.ok(Nested.fields.packed.packed, "nested should have packed encoding by default");
+    test.notOk(Nested.fields.unpacked.packed, "nested should override expanded encoding");
+
+    test.end();
+});
+
+tape.test("feature resolution proto2", function(test) {
+    var json = {
+        edition: "proto2",
+        fields: {
+            regular: { type: "string", id: 1 },
+            required: { type: "string", id: 2, rule: "required" },
+            packed: { type: "int32", id: 3, rule: "repeated", options: { packed: true } },
+            unpacked: { type: "int32", id: 4, rule: "repeated"}
+        },
+        nested: { Nested: { fields: {
+            regular: { type: "string", id: 1 },
+            packed: { type: "int32", id: 2, rule: "repeated", options: { packed: true } },
+            unpacked: { type: "int32", id: 3, rule: "repeated" }
+        } } }
+    };
+    var root = new protobuf.Root();
+    var Type = protobuf.Type.fromJSON("My", json);
+    root.add(Type).resolveAll();
+
+    var Nested = Type.nested.Nested;
+
+    test.same(Type.toJSON(), json, "JSON should roundtrip");
+    test.same(Nested.toJSON(), json.nested.Nested, "nested JSON should roundtrip");
+
+    test.same(Type._edition, "proto2", "should infer proto2 syntax");
+    test.ok(Type.fields.regular.hasPresence, "should have explicit presence by default");
+    test.ok(Type.fields.required.required, "should have required fields");
+    test.ok(Type.fields.packed.packed, "should override packed encoding");
+    test.notOk(Type.fields.unpacked.packed, "should have expanded encoding by default");
+
+    test.same(Type._edition, "proto2", "should not infer proto2 syntax");
+    test.ok(Nested.fields.regular.hasPresence, "nested should have explicit presence by default");
+    test.notOk(Nested.fields.unpacked.packed, "nested should have expanded encoding by default");
+    test.ok(Nested.fields.packed.packed, "nested should override packed encoding");
+
+    test.end();
+});
+
+
+tape.test("feature resolution edition 2023", function(test) {
+    var json = {
+        edition: "2023",
+        fields: {
+            explicit: { type: "string", id: 1 },
+            implicit: { type: "string", id: 2, options: { "features.field_presence": "IMPLICIT" } },
+            required: { type: "string", id: 3, rule: "required", options: { "features.field_presence": "LEGACY_REQUIRED" } },
+            packed: { type: "int32", id: 4, rule: "repeated" },
+            unpacked: { type: "int32", id: 5, rule: "repeated", options: { "features.repeated_field_encoding": "EXPANDED" } }
+        },
+        nested: { Nested: { fields: {
+            explicit: { type: "string", id: 1 },
+            implicit: { type: "string", id: 2, options: { "features.field_presence": "IMPLICIT" } },
+            packed: { type: "int32", id: 3, rule: "repeated" },
+            unpacked: { type: "int32", id: 4, rule: "repeated", options: { "features.repeated_field_encoding": "EXPANDED" } }
+        } } }
+    };
+    var root = new protobuf.Root();
+    var Type = protobuf.Type.fromJSON("My", json);
+    root.add(Type).resolveAll();
+
+    var Nested = Type.nested.Nested;
+
+    test.same(Type.toJSON(), json, "JSON should roundtrip");
+    test.same(Nested.toJSON(), json.nested.Nested, "nested JSON should roundtrip");
+
+    console.log(Type.fields.implicit._features);
+    console.log(Type.fields.implicit._protoFeatures);
+    test.same(Type._edition, "2023", "should infer proto2 syntax");
+    test.ok(Type.fields.explicit.hasPresence, "should have explicit presence");
+    test.notOk(Type.fields.implicit.hasPresence, "should have implicit presence");
+    test.ok(Type.fields.required.required, "should have required presence");
+    test.ok(Type.fields.packed.packed, "should have packed encoding");
+    test.notOk(Type.fields.unpacked.packed, "should have expanded encoding");
+
+    test.same(Type._edition, "2023", "should not infer proto2 syntax");
+    test.ok(Nested.fields.explicit.hasPresence, "nested should have explicit presence");
+    test.notOk(Nested.fields.implicit.hasPresence, "nested should have implicit presence");
+    test.ok(Nested.fields.packed.packed, "nested should have packed encoding");
+    test.notOk(Nested.fields.unpacked.packed, "nested should have expanded encoding");
+
+    test.end();
+});

--- a/tests/api_type.js
+++ b/tests/api_type.js
@@ -123,12 +123,12 @@ tape.test("feature resolution legacy proto3", function(test) {
     test.same(Type.toJSON(), json, "JSON should roundtrip");
     test.same(Nested.toJSON(), json.nested.Nested, "nested JSON should roundtrip");
 
-    test.same(Type._edition, "proto3", "should infer proto3 syntax");
+    test.equal(Type._edition, "proto3", "should infer proto3 syntax");
     test.notOk(Type.fields.regular.hasPresence, "should have implicit presence by default");
     test.ok(Type.fields.packed.packed, "should have packed encoding by default");
     test.notOk(Type.fields.unpacked.packed, "should override expanded encoding");
 
-    test.same(Type._edition, "proto3", "should not infer proto3 syntax");
+    test.equal(Nested._edition, null, "should not infer proto3 syntax");
     test.notOk(Nested.fields.regular.hasPresence, "nested should have implicit presence by default");
     test.ok(Nested.fields.packed.packed, "nested should have packed encoding by default");
     test.notOk(Nested.fields.unpacked.packed, "nested should override expanded encoding");
@@ -160,13 +160,13 @@ tape.test("feature resolution proto2", function(test) {
     test.same(Type.toJSON(), json, "JSON should roundtrip");
     test.same(Nested.toJSON(), json.nested.Nested, "nested JSON should roundtrip");
 
-    test.same(Type._edition, "proto2", "should infer proto2 syntax");
+    test.equal(Type._edition, "proto2", "should set edition");
     test.ok(Type.fields.regular.hasPresence, "should have explicit presence by default");
     test.ok(Type.fields.required.required, "should have required fields");
     test.ok(Type.fields.packed.packed, "should override packed encoding");
     test.notOk(Type.fields.unpacked.packed, "should have expanded encoding by default");
 
-    test.same(Type._edition, "proto2", "should not infer proto2 syntax");
+    test.equal(Nested._edition, null, "should not set edition");
     test.ok(Nested.fields.regular.hasPresence, "nested should have explicit presence by default");
     test.notOk(Nested.fields.unpacked.packed, "nested should have expanded encoding by default");
     test.ok(Nested.fields.packed.packed, "nested should override packed encoding");
@@ -180,16 +180,16 @@ tape.test("feature resolution edition 2023", function(test) {
         edition: "2023",
         fields: {
             explicit: { type: "string", id: 1 },
-            implicit: { type: "string", id: 2, options: { "features.field_presence": "IMPLICIT" } },
-            required: { type: "string", id: 3, rule: "required", options: { "features.field_presence": "LEGACY_REQUIRED" } },
+            implicit: { type: "string", id: 2, options: { "features": { "field_presence": "IMPLICIT" } } },
+            required: { type: "string", id: 3, rule: "required", options: { "features": { "field_presence": "LEGACY_REQUIRED" } } },
             packed: { type: "int32", id: 4, rule: "repeated" },
-            unpacked: { type: "int32", id: 5, rule: "repeated", options: { "features.repeated_field_encoding": "EXPANDED" } }
+            unpacked: { type: "int32", id: 5, rule: "repeated", options: { "features": { "repeated_field_encoding": "EXPANDED" } } }
         },
         nested: { Nested: { fields: {
             explicit: { type: "string", id: 1 },
-            implicit: { type: "string", id: 2, options: { "features.field_presence": "IMPLICIT" } },
+            implicit: { type: "string", id: 2, options: { "features": { "field_presence": "IMPLICIT" } } },
             packed: { type: "int32", id: 3, rule: "repeated" },
-            unpacked: { type: "int32", id: 4, rule: "repeated", options: { "features.repeated_field_encoding": "EXPANDED" } }
+            unpacked: { type: "int32", id: 4, rule: "repeated", options: { "features": { "repeated_field_encoding": "EXPANDED" } } }
         } } }
     };
     var root = new protobuf.Root();
@@ -201,16 +201,14 @@ tape.test("feature resolution edition 2023", function(test) {
     test.same(Type.toJSON(), json, "JSON should roundtrip");
     test.same(Nested.toJSON(), json.nested.Nested, "nested JSON should roundtrip");
 
-    console.log(Type.fields.implicit._features);
-    console.log(Type.fields.implicit._protoFeatures);
-    test.same(Type._edition, "2023", "should infer proto2 syntax");
+    test.equal(Type._edition, "2023", "should set edition");
     test.ok(Type.fields.explicit.hasPresence, "should have explicit presence");
     test.notOk(Type.fields.implicit.hasPresence, "should have implicit presence");
     test.ok(Type.fields.required.required, "should have required presence");
     test.ok(Type.fields.packed.packed, "should have packed encoding");
     test.notOk(Type.fields.unpacked.packed, "should have expanded encoding");
 
-    test.same(Type._edition, "2023", "should not infer proto2 syntax");
+    test.equal(Nested._edition, null, "should not set edition");
     test.ok(Nested.fields.explicit.hasPresence, "nested should have explicit presence");
     test.notOk(Nested.fields.implicit.hasPresence, "nested should have implicit presence");
     test.ok(Nested.fields.packed.packed, "nested should have packed encoding");

--- a/tests/cli.js
+++ b/tests/cli.js
@@ -323,3 +323,228 @@ tape.test("pbjs generates static code with message filter", function (test) {
         });
     });
 });
+
+tape.test("proto3 roundtrip", function(test) {
+    const proto = `syntax = "proto3";
+
+message OptionalFields {
+
+    optional SubMessage a = 1;
+    optional string b = 2;
+    repeated uint32 c = 3 [packed=false];
+    uint32 d = 4;
+
+    message SubMessage {
+
+        string a = 1;
+    }
+}`;
+    cliTest(test, function() {
+        var root = protobuf.parse(proto).root.resolveAll();
+        var protoTarget = require("../cli/targets/proto3");
+
+        protoTarget(root, {}, function(err, output) {
+            test.error(err, 'proto code generation worked');
+
+            test.equal(output, proto);
+
+            test.end();
+        });
+    });
+});
+
+tape.test("proto2 roundtrip", function(test) {
+    const proto = `syntax = "proto2";
+
+message OptionalFields {
+
+    optional OptionalFields a = 1;
+    required string b = 2;
+    repeated uint32 c = 3 [packed=true];
+    optional float d = 4 [default=0.1];
+    optional group OptionalGroup = 5 {
+
+        optional string a = 1;
+    }
+    repeated group RepeatedGroup = 6 {
+
+        optional string a = 1;
+    }
+    required group RequiredGroup = 7 {
+
+        optional string a = 1;
+    }
+}`;
+    cliTest(test, function() {
+        var root = protobuf.parse(proto).root.resolveAll();
+        var protoTarget = require("../cli/targets/proto2");
+
+        protoTarget(root, {}, function(err, output) {
+            test.error(err, 'proto code generation worked');
+
+            test.equal(output, proto);
+
+            test.end();
+        });
+    });
+});
+
+tape.test("proto3 to proto2 valid", function(test) {
+    const proto3 = `syntax = "proto3";
+
+message OptionalFields {
+    message SubMessage {
+        optional string a = 1;
+    }
+
+    optional SubMessage a = 1;
+    repeated int32 b = 2;
+    repeated uint32 c = 3 [packed=false];
+
+}`;
+    const proto2 = `syntax = "proto2";
+
+message OptionalFields {
+
+    optional SubMessage a = 1;
+    repeated int32 b = 2 [packed=true];
+    repeated uint32 c = 3;
+
+    message SubMessage {
+
+        optional string a = 1;
+    }
+}`;
+    cliTest(test, function() {
+        var root = protobuf.parse(proto3).root.resolveAll();
+        var protoTarget = require("../cli/targets/proto2");
+
+        protoTarget(root, {}, function(err, output) {
+            test.error(err, 'proto code generation worked');
+
+            test.equal(output, proto2);
+
+            test.end();
+        });
+    });
+});
+
+tape.test("proto2 to proto3 valid", function(test) {
+    const proto2 = `syntax = "proto2";
+
+message OptionalFields {
+    message SubMessage {
+        optional string a = 1;
+    }
+
+    optional SubMessage a = 1;
+    repeated int32 b = 2;
+    repeated uint32 c = 3 [packed=true];
+}`;
+    const proto3 = `syntax = "proto3";
+
+message OptionalFields {
+
+    optional SubMessage a = 1;
+    repeated int32 b = 2 [packed=false];
+    repeated uint32 c = 3;
+
+    message SubMessage {
+
+        optional string a = 1;
+    }
+}`;
+    cliTest(test, function() {
+        var root = protobuf.parse(proto2).root.resolveAll();
+        var protoTarget = require("../cli/targets/proto3");
+
+        protoTarget(root, {}, function(err, output) {
+            test.error(err, 'proto code generation worked');
+
+            test.equal(output, proto3);
+
+            test.end();
+        });
+    });
+});
+
+
+tape.test("edition 2023 to proto2 valid", function(test) {
+    const editions = `edition = "2023";
+option features.repeated_field_encoding = EXPANDED;
+
+message OptionalFields {
+    message SubMessage {
+        string a = 1 [features.field_presence = LEGACY_REQUIRED];
+    }
+
+    SubMessage a = 1;
+    repeated int32 b = 2 [features.repeated_field_encoding = PACKED];
+    repeated uint32 c = 3;
+}`;
+    const proto2 = `syntax = "proto2";
+
+message OptionalFields {
+
+    optional SubMessage a = 1;
+    repeated int32 b = 2 [packed=true];
+    repeated uint32 c = 3;
+
+    message SubMessage {
+
+        required string a = 1;
+    }
+}`;
+    cliTest(test, function() {
+        var root = protobuf.parse(editions).root.resolveAll();
+        var protoTarget = require("../cli/targets/proto2");
+
+        protoTarget(root, {}, function(err, output) {
+            test.error(err, 'proto code generation worked');
+
+            test.equal(output, proto2);
+
+            test.end();
+        });
+    });
+});
+
+tape.test("edition 2023 to proto3 valid", function(test) {
+    const editions = `edition = "2023";
+option features.repeated_field_encoding = EXPANDED;
+
+message OptionalFields {
+    message SubMessage {
+        string a = 1 [features.field_presence = IMPLICIT];
+    }
+
+    SubMessage a = 1;
+    repeated int32 b = 2 [features.repeated_field_encoding = PACKED];
+    repeated uint32 c = 3;
+}`;
+    const proto3 = `syntax = "proto3";
+
+message OptionalFields {
+
+    optional SubMessage a = 1;
+    repeated int32 b = 2;
+    repeated uint32 c = 3 [packed=false];
+
+    message SubMessage {
+
+        string a = 1;
+    }
+}`;
+    cliTest(test, function() {
+        var root = protobuf.parse(editions).root.resolveAll();
+        var protoTarget = require("../cli/targets/proto3");
+
+        protoTarget(root, {}, function(err, output) {
+            test.error(err, 'proto code generation worked');
+
+            test.equal(output, proto3);
+
+            test.end();
+        });
+    });
+});

--- a/tests/cli.js
+++ b/tests/cli.js
@@ -236,6 +236,45 @@ tape.test("with --null-semantics, optional fields are handled correctly in proto
     });
 });
 
+tape.test("with --null-semantics, optional fields are handled correctly in editions", function(test) {
+    cliTest(test, function() {
+        var root = protobuf.loadSync("tests/data/cli/null-defaults-edition2023.proto");
+        root.resolveAll();
+
+        var staticTarget = require("../cli/targets/static");
+
+        staticTarget(root, {
+            create: true,
+            decode: true,
+            encode: true,
+            convert: true,
+            comments: true,
+            "null-semantics": true,
+        }, function(err, jsCode) {
+
+            test.error(err, 'static code generation worked');
+
+            test.ok(jsCode.includes("@property {OptionalFields.ISubMessage|null|undefined} [a] OptionalFields a"), "Property for a should use an interface")
+            test.ok(jsCode.includes("@member {OptionalFields.SubMessage|null} a"), "Member for a should use a message type")
+            test.ok(jsCode.includes("OptionalFields.prototype.a = null;"), "Initializer for a should be null")
+
+            test.ok(jsCode.includes("@property {string|null|undefined} [e] OptionalFields e"), "Property for e should be nullable")
+            test.ok(jsCode.includes("@member {string|null} e"), "Member for e should be nullable")
+            test.ok(jsCode.includes("OptionalFields.prototype.e = null;"), "Initializer for e should be null")
+
+            test.ok(jsCode.includes("@property {number} r OptionalFields r"), "Property for r should not be nullable")
+            test.ok(jsCode.includes("@member {number} r"), "Member for r should not be nullable")
+            test.ok(jsCode.includes("OptionalFields.prototype.r = 0;"), "Initializer for r should be zero")
+
+            test.ok(jsCode.includes("@property {number|undefined} [i] OptionalFields i"), "Property for i should be optional but not nullable")
+            test.ok(jsCode.includes("@member {number} i"), "Member for i should not be nullable")
+            test.ok(jsCode.includes("OptionalFields.prototype.i = 0;"), "Initializer for i should be zero")
+
+            test.end();
+        });
+    });
+});
+
 
 tape.test("pbjs generates static code with message filter", function (test) {
     cliTest(test, function () {

--- a/tests/comp_google_protobuf_any.js
+++ b/tests/comp_google_protobuf_any.js
@@ -2,26 +2,24 @@ var tape = require("tape");
 
 var protobuf = require("..");
 
-var root = protobuf.Root.fromJSON({
-    nested: {
-        Foo: {
-            fields: {
-                foo: {
-                    id: 1,
-                    type: "google.protobuf.Any"
-                }
+var root = new protobuf.Root().addJSON(protobuf.common["google/protobuf/any.proto"].nested).addJSON({
+    Foo: {
+        fields: {
+            foo: {
+                id: 1,
+                type: "google.protobuf.Any"
             }
-        },
-        Bar: {
-            fields: {
-                bar: {
-                    id: 1,
-                    type: "string"
-                }
+        }
+    },
+    Bar: {
+        fields: {
+            bar: {
+                id: 1,
+                type: "string"
             }
         }
     }
-}).addJSON(protobuf.common["google/protobuf/any.proto"].nested).resolveAll();
+}).resolveAll();
 
 var Any = root.lookupType("protobuf.Any"),
     Foo = root.lookupType(".Foo"),

--- a/tests/comp_packed-repeated.js
+++ b/tests/comp_packed-repeated.js
@@ -95,3 +95,17 @@ tape.test("packed repeated values encode", function(top) {
 
     top.end()
 });
+
+tape.test("packed unpackable fields", function(test) {
+    var root = protobuf.parse(`message Test {
+      repeated Test a = 1 [packed = true];
+      repeated Test b = 2 [packed = true, foo = true];
+    }`).root.resolveAll();
+    var Test = root.lookup("Test");
+
+    test.equal(Test.fields.a.options, undefined, "should have no options")
+    test.equal(Test.fields.b.options.packed, undefined, "should have no packed option")
+    test.equal(Test.fields.b.options.foo, true, "should retain other option")
+
+    test.end();
+});

--- a/tests/comp_packed-repeated.js
+++ b/tests/comp_packed-repeated.js
@@ -2,28 +2,96 @@ var tape = require("tape");
 
 var protobuf = require("..");
 
-var proto1 = "message Test {\
+var packedOption = "message Test {\
   repeated uint32 a = 1 [packed = true];\
 }";
 
-var proto2 = "message Test {\
+var unpackedOption = "message Test {\
   repeated uint32 a = 1 [packed = false];\
+}";
+
+var packedFeature = "edition = \"2023\";\
+message Test {\
+  repeated uint32 a = 1 [features.repeated_field_encoding = PACKED];\
+}";
+
+var unpackedFeature = "edition = \"2023\";\
+message Test {\
+  repeated uint32 a = 1 [features.repeated_field_encoding = EXPANDED];\
+}";
+
+var regular = "message Test {\
+  repeated uint32 a = 1;\
 }";
 
 var msg = {
     a: [1,2,3]
 };
 
-tape.test("packed repeated values", function(test) {
-    var root1 = protobuf.parse(proto1).root,
-        root2 = protobuf.parse(proto2).root;
+tape.test("packed repeated values roundtrip", function(test) {
+    var root1 = protobuf.parse(packedOption).root.resolveAll(),
+        root2 = protobuf.parse(unpackedOption).root.resolveAll();
     var Test1 = root1.lookup("Test"),
         Test2 = root2.lookup("Test");
-    
+
     var dec1 = Test2.decode(Test1.encode(msg).finish());
     test.same(dec1, msg, "should decode packed even if defined non-packed");
     var dec2 = Test1.decode(Test2.encode(msg).finish());
     test.same(dec2, msg, "should decode non-packed even if defined packed");
 
     test.end();
+});
+
+tape.test("packed repeated values encode", function(top) {
+    [
+        packedOption,
+        `syntax = "proto3";\n` + regular,
+        `syntax = "proto3";\n` + packedOption,
+        `edition = "2023";\n` + regular,
+        packedFeature,
+    ].forEach(function(proto, index) {
+        tape.test("proto " + index, function(test) {
+            var root = protobuf.parse(proto).root.resolveAll();
+            var Test = root.lookup("Test");
+
+            var buf = Test.encode(msg).finish();
+            test.equal(buf.length, 5, "a total of 4 bytes");
+            test.equal(buf[0], 1 << 3 | 2, "id 1, wireType 2");
+            test.equal(buf[1], 3, "length 3");
+            test.equal(buf[2], 1, "element 1");
+            test.equal(buf[3], 2, "element 2");
+            test.equal(buf[4], 3, "element 3");
+
+            test.end();
+        });
+    });
+
+    top.end()
+});
+
+tape.test("packed repeated values encode", function(top) {
+    [
+        unpackedOption,
+        regular,
+        `syntax = "proto3";\n` + unpackedOption,
+        unpackedFeature,
+    ].forEach(function(proto, index) {
+        tape.test("proto " + index, function(test) {
+            var root = protobuf.parse(proto).root.resolveAll();
+            var Test = root.lookup("Test");
+
+            var buf = Test.encode(msg).finish();
+            test.equal(buf.length, 6, "a total of 6 bytes");
+            test.equal(buf[0], 1 << 3 | 0, "id 1, wireType 0");
+            test.equal(buf[1], 1, "element 1");
+            test.equal(buf[2], 1 << 3 | 0, "id 1, wireType 0");
+            test.equal(buf[3], 2, "element 2");
+            test.equal(buf[4], 1 << 3 | 0, "id 1, wireType 0");
+            test.equal(buf[5], 3, "element 3");
+
+            test.end()
+        });
+    });
+
+    top.end()
 });

--- a/tests/data/cli/null-defaults-edition2023.proto
+++ b/tests/data/cli/null-defaults-edition2023.proto
@@ -1,0 +1,12 @@
+edition = "2023";
+
+message OptionalFields {
+  message SubMessage {
+    string a = 1 [features.field_presence = IMPLICIT];
+  }
+
+  SubMessage a = 1;
+  string e = 2;
+  uint32 r = 3 [features.field_presence = LEGACY_REQUIRED];
+  uint32 i = 4  [features.field_presence = IMPLICIT];
+}

--- a/tests/data/uncommon.proto
+++ b/tests/data/uncommon.proto
@@ -71,6 +71,17 @@ enum Test4_1{
     OPTION = 1;
 }
 
+enum ReservedEnum{
+    RESERVED_UNKNOWN = 0;
+
+    reserved 1 to 5;
+    reserved "abc", "INVALID";
+    reserved 10;
+    reserved 11 to 20 {
+        option foo = true;
+    }
+}
+
 service Test5;
 
 service Test6 { option (custom).bar = "";

--- a/tests/feature_grammar.js
+++ b/tests/feature_grammar.js
@@ -8,7 +8,7 @@ tape.test("editions required keyword", function(test) {
     message A {\
         required uint32 a = 1;\
     }`);
-    }, Error, "Error: illegal token 'required'");
+    }, /Error: illegal token 'required'/);
     
     test.end();
 });
@@ -19,7 +19,7 @@ tape.test("editions optional keyword", function(test) {
         message A {\
         optional uint32 a = 1;\
     }`);
-    }, Error, "Error: illegal token 'optional'");
+    }, /Error: illegal token 'optional'/);
 
     test.end();
 });
@@ -28,9 +28,9 @@ tape.test("editions group keyword", function(test) {
     test.throws(function() {
         protobuf.parse(`edition = "2023";
         message A {\
-        group uint32 a = 1;\
-    }`);
-    }, Error, "Error: illegal token 'group'");
+            group uint32 a = 1;\
+        }`);
+    }, /Error: illegal token 'group'/);
 
     test.end();
 });
@@ -44,3 +44,47 @@ tape.test("editions no quote", function(test) {
     test.end();
 });
 
+
+tape.test("edition 2023 reserved", function(test) {
+    var root = protobuf.parse(`edition = "2023";
+    message Foo {
+        reserved bar, baz;
+    }`).root.resolveAll();
+    test.same(root.Foo.reserved, ["bar", "baz"], "reserved fields should be parsed");
+
+    root = protobuf.parse(`edition = "2023";
+    enum Foo {
+        reserved BAR, BAZ_BAZ;
+    }`).root.resolveAll();
+    test.same(root.nested.Foo.reserved, ["BAR", "BAZ_BAZ"], "reserved values should be parsed");
+
+    test.throws(function() {
+        protobuf.parse(`edition = "2023";
+        message Foo {
+            reserved "bar", "baz";
+        }`);
+    }, /Error: illegal id 'bar'/, "reserved field strings should be banned");
+
+    test.throws(function() {
+        protobuf.parse(`edition = "2023";
+        enum Foo {
+            reserved "BAR", "BAZ";
+        }`);
+    }, /Error: illegal id 'BAR'/, "reserved enum value strings should be banned");
+
+    test.throws(function() {
+        protobuf.parse(`syntax = "proto3";
+        message Foo {
+            reserved bar, baz;
+        }`);
+    }, /Error: illegal id 'bar'/, "reserved field strings should be banned");
+
+    test.throws(function() {
+        protobuf.parse(`syntax = "proto3";
+        enum Foo {
+            reserved BAR, BAZ;
+        }`);
+    }, /Error: illegal id 'BAR'/, "reserved enum value strings should be banned");
+
+    test.end();
+});

--- a/tests/feature_resolution_editions.js
+++ b/tests/feature_resolution_editions.js
@@ -492,7 +492,7 @@ tape.test("feature resolution extension sister", function(test) {
             message B {
                 message One {
                     extensions 1000 to max;
-                    reserved 900 to 999, 899, "a", 'b';
+                    reserved 900 to 999, 899, a, b;
                 }
             }
             message C {

--- a/tests/feature_resolution_editions.js
+++ b/tests/feature_resolution_editions.js
@@ -66,11 +66,11 @@ var tape = require("tape");
 
 var protobuf = require("..");
 
-var protoEditions2023 = `edition = "2023";`;
+var protoEditions2023 = `edition = "2023";  message Foo {}`;
 
-var proto2 = `syntax = "proto2";`;
+var proto2 = `syntax = "proto2";  message Foo {}`;
 
-var proto3 = `syntax = "proto3";`;
+var proto3 = `syntax = "proto3";  message Foo {}`;
 
 var editions2023Defaults = {enum_type: 'OPEN', field_presence: 'EXPLICIT', json_format: 'ALLOW', message_encoding: 'LENGTH_PREFIXED', repeated_field_encoding: 'PACKED', utf8_validation: 'VERIFY'}
 var proto2Defaults = {enum_type: 'CLOSED', field_presence: 'EXPLICIT', json_format: 'LEGACY_BEST_EFFORT', message_encoding: 'LENGTH_PREFIXED', repeated_field_encoding: 'EXPANDED', utf8_validation: 'NONE'}
@@ -79,15 +79,15 @@ var proto3Defaults = {enum_type: 'OPEN', field_presence: 'IMPLICIT', json_format
 tape.test("feature resolution defaults", function(test) {
     var rootEditions = protobuf.parse(protoEditions2023).root;
     rootEditions.resolveAll();
-    test.same(rootEditions._features, editions2023Defaults);
+    test.same(rootEditions.Foo._features, editions2023Defaults);
 
     var rootProto2 = protobuf.parse(proto2).root;
     rootProto2.resolveAll();
-    test.same(rootProto2._features, proto2Defaults);
+    test.same(rootProto2.Foo._features, proto2Defaults);
 
     var rootProto3 = protobuf.parse(proto3).root;
     rootProto3.resolveAll();
-    test.same(rootProto3._features, proto3Defaults);
+    test.same(rootProto3.Foo._features, proto3Defaults);
 
     test.end();
 })
@@ -105,9 +105,6 @@ tape.test("unresolved feature options", function(test) {
 
     test.same(root.lookup("Message").options, {
         "features.enum_type": "CLOSED",
-    });
-    test.same(root.options, {
-        "edition": "2023",
         "features.json_format": "LEGACY_BEST_EFFORT",
         "features.(abc).d_e": "deeply_nested_false",
     });
@@ -606,27 +603,6 @@ tape.test("feature resolution mixed file features different package", function(t
     test.end();
 });
 
-tape.test("feature resolution mixed syntax same package", function(test) {
-    var root = protobuf.parse(`syntax = "proto2";
-    package foo;
-    message Message2 {
-        optional int32 default = 1;
-        required int32 required = 2;
-        repeated int32 unpacked = 3;
-    }`).root;
-    test.throws(
-        () => {
-            protobuf.parse(`syntax = "proto3";
-            package foo;`, root);
-        }, /incompatible editions/);
-
-    test.end();
-});
-
-/*
-// TODO: fix this!
-// These cases are bugged, because they dump file features into the same namespace!
-
 tape.test("feature resolution mixed file features same package", function(test) {
     var root = protobuf.parse(`edition = "2023";
     option features.repeated_field_encoding = EXPANDED;
@@ -706,4 +682,4 @@ tape.test("feature resolution mixed syntax same package", function(test) {
 
     test.end();
 });
-*/
+

--- a/tests/feature_resolution_editions.js
+++ b/tests/feature_resolution_editions.js
@@ -115,12 +115,16 @@ tape.test("unresolved feature options", function(test) {
 tape.test("aggregate feature parsing", function(test) {
     var rootEditionsOverriden = protobuf.parse(`edition = "2023";
     option features = {
+        utf8_validation: VERIFY
         json_format: LEGACY_BEST_EFFORT
         field_presence: IMPLICIT
     };
 
     message Message {
-        option features = { utf8_validation: NONE };
+        option features = {
+            utf8_validation: NONE
+            enum_type: OPEN
+        };
         string string_val = 1;
         string string_repeated = 2 [features = { enum_type: CLOSED field_presence: LEGACY_REQUIRED }];
     }`).root.resolveAll();
@@ -557,15 +561,17 @@ tape.test("feature resolution inferred proto2 presence", function(test) {
     message Message {
         optional int32 default = 1;
         required int32 required = 2;
+        repeated int32 repeated = 3;
     }`).root.resolveAll();
 
     var msg = root.lookup("Message");
-    test.ok(msg.fields.default.optional)
-    test.notOk(msg.fields.default.required)
-    test.equal(msg.fields.default._features.field_presence, "EXPLICIT")
-    test.notOk(msg.fields.required.optional)
-    test.ok(msg.fields.required.required)
-    test.equal(msg.fields.required._features.field_presence, "LEGACY_REQUIRED")
+    test.ok(msg.fields.default.optional);
+    test.notOk(msg.fields.default.required);
+    test.ok(msg.fields.default.hasPresence);
+    test.notOk(msg.fields.required.optional);
+    test.ok(msg.fields.required.required);
+    test.equal(msg.fields.required._features.field_presence, "LEGACY_REQUIRED");
+    test.notOk(msg.fields.repeated.hasPresence, "repeated fields never have presence");
 
     test.end();
 });

--- a/tests/feature_resolution_editions.js
+++ b/tests/feature_resolution_editions.js
@@ -445,12 +445,13 @@ tape.test("feature resolution inferred proto2 repeated encoding", function(test)
         repeated int32 unpacked = 3 [packed = false];
     }`).root.resolveAll();
 
-    test.notOk(root.lookup("Message").fields.default.packed)
-    test.equal(root.lookup("Message").fields.default._features.repeated_field_encoding, "EXPANDED")
-    test.ok(root.lookup("Message").fields.packed.packed)
-    test.equal(root.lookup("Message").fields.packed._features.repeated_field_encoding, "PACKED")
-    test.notOk(root.lookup("Message").fields.unpacked.packed)
-    test.equal(root.lookup("Message").fields.unpacked._features.repeated_field_encoding, "EXPANDED")
+    var msg = root.lookup("Message");
+    test.notOk(msg.fields.default.packed)
+    test.equal(msg.fields.default._features.repeated_field_encoding, "EXPANDED")
+    test.ok(msg.fields.packed.packed)
+    test.equal(msg.fields.packed._features.repeated_field_encoding, "PACKED")
+    test.notOk(msg.fields.unpacked.packed)
+    test.equal(msg.fields.unpacked._features.repeated_field_encoding, "EXPANDED")
 
     test.end();
 });
@@ -463,13 +464,32 @@ tape.test("feature resolution inferred proto3 repeated encoding", function(test)
         repeated int32 unpacked = 3 [packed = false];
     }`).root.resolveAll();
 
-    test.ok(root.lookup("Message").fields.default.packed)
-    test.equal(root.lookup("Message").fields.default._features.repeated_field_encoding, "PACKED")
-    test.ok(root.lookup("Message").fields.packed.packed)
-    test.equal(root.lookup("Message").fields.packed._features.repeated_field_encoding, "PACKED")
-    test.notOk(root.lookup("Message").fields.unpacked.packed)
-    test.equal(root.lookup("Message").fields.unpacked._features.repeated_field_encoding, "EXPANDED")
+    var msg = root.lookup("Message");
+    test.ok(msg.fields.default.packed)
+    test.equal(msg.fields.default._features.repeated_field_encoding, "PACKED")
+    test.ok(msg.fields.packed.packed)
+    test.equal(msg.fields.packed._features.repeated_field_encoding, "PACKED")
+    test.notOk(msg.fields.unpacked.packed)
+    test.equal(msg.fields.unpacked._features.repeated_field_encoding, "EXPANDED")
 
     test.end();
 });
 
+
+tape.test("feature resolution inferred proto2 presence", function(test) {
+    var root = protobuf.parse(`syntax = "proto2";
+    message Message {
+        optional int32 default = 1;
+        required int32 required = 2;
+    }`).root.resolveAll();
+
+    var msg = root.lookup("Message");
+    test.ok(msg.fields.default.optional)
+    test.notOk(msg.fields.default.required)
+    test.equal(msg.fields.default._features.field_presence, "EXPLICIT")
+    test.notOk(msg.fields.required.optional)
+    test.ok(msg.fields.required.required)
+    test.equal(msg.fields.required._features.field_presence, "LEGACY_REQUIRED")
+
+    test.end();
+});

--- a/tests/feature_resolution_editions.js
+++ b/tests/feature_resolution_editions.js
@@ -92,6 +92,29 @@ tape.test("feature resolution defaults", function(test) {
     test.end();
 })
 
+tape.test("unresolved feature options", function(test) {
+    var root = protobuf.parse(`edition = "2023";
+    option features.json_format = LEGACY_BEST_EFFORT;
+    option features.(abc).d_e = deeply_nested_false;
+
+    message Message {
+        option features.enum_type = CLOSED;
+        string string_val = 1;
+        string string_repeated = 2;
+    }`).root.resolveAll();
+
+    test.same(root.lookup("Message").options, {
+        "features.enum_type": "CLOSED",
+    });
+    test.same(root.options, {
+        "edition": "2023",
+        "features.json_format": "LEGACY_BEST_EFFORT",
+        "features.(abc).d_e": "deeply_nested_false",
+    });
+
+    test.end();
+});
+
 tape.test("feature resolution inheritance file to message", function(test) {
     var rootEditionsOverriden = protobuf.parse(`edition = "2023";
     option features.json_format = LEGACY_BEST_EFFORT;

--- a/tests/other_protocolerror.js
+++ b/tests/other_protocolerror.js
@@ -15,7 +15,7 @@ tape.test("a protocol error", function(test) {
         ).add(
             new protobuf.Field("bar", 2, "string", "required")
         )
-    );
+    ).resolveAll();
     
     var Test = root.lookup("Test");
     var buf  = protobuf.util.newBuffer(2);

--- a/tests/other_protocolerror.js
+++ b/tests/other_protocolerror.js
@@ -21,6 +21,7 @@ tape.test("a protocol error", function(test) {
     var buf  = protobuf.util.newBuffer(2);
     buf[0] = 1 << 3 | 0;
     buf[1] = 0x02;
+    test.ok(root.Test.fields.foo.hasPresence);
 
     try {
         Test.decode(buf);


### PR DESCRIPTION
Protobuf.js was audited for the following features:

*  Field presence - Full support of all 3 presence modes, although the behavior appears to be non-conformant in general.  The feature values were hooked up to the existing behaviors, with new tests added for edition 2023.
* Packed encoding - Both packed and expanded encoding are supported and conformant.  Some opportunistic cleanup was done, but was behavior-preserving.
* Delimited encoding - Proto2 groups are supported but mark a property on the *message* rather than the field.  This information was moved to the field and the more general delimited logic was added (with tests).
* Enum type - All enums are open, this was left untouched.  CLOSED enum_type will be ignored in edition 2023 (which is consistent with our long-term goal anyway).
* UTF8 validation - There doesn't seem to be any explicit validation of utf8, beyond what javascript may provide by default.  This would treat proto2/proto3 and edition 2023 the same regardless of features.

The proto target CLI appeared to be broken in a number of edge cases related to editions features, so these were fixed and tested were added.  It now supports proto2 and proto3 roundtrips, and conversions to proto2/proto3 (even *from* edition 2023) as long as they're valid.  No extra validation layer was added, so impossible conversions will just produce invalid protos.  A new target for edition 2023 wasn't added, but could be pretty easily if necessary in the future.

One major design flaw in protobuf.js, that's common in proto3-based code, is that the concept of files was largely dropped.  The in-memory and JSON representation of descriptors puts all of the file metadata into the most-nested package namespace object, but this object may be shared by multiple files.  This results in possible clobbering and merging, leading to malformed file metadata.  In proto2/proto3, this largely doesn't matter outside of custom file options, but the effects can be seen in the hack that forces `packed = false` for proto2 descriptors to get the repeated field encoding correct.  This problem was made worse in editions, where we store important metadata at the file level (edition + features).  The solution implemented here collapses all of this information into the top-level objects instead of putting it on the namespace.  This results in some minimal duplication, but has the ability to properly support proto2, proto3, and editions in addition to fixing some pre-existing bugs (demonstrated by some newly added tests).

Other changes:
* Group decoding will now look for the proper matching end-group tag instead of *any* end-group tag
* A bug in feature resolution for extensions was fixed
* A bug in how unresolved features showed up in the options struct was fixed
* Standard reflection helpers were added that are compatible with editions and proto2/proto3
* Proto2 and proto3 are now treated as special editions (with full feature resolution).  This substantially increases test coverage of all of the new editions logic
* The JSON spec now fully supports proto2 descriptors, instead of the previous hack of forcing `packed=false` to make them behave properly

**Migration Guide**
* Code must always ensure `.resolveAll()` is called on dynamic built protos.  This is needed when building from constructors directly or individual fromJSON/addJSON methods.  Top-level builders like `Root.fromJSON`, `Root.load`, and `protobuf.parse` do not need to explicitly call this