### PR TITLE
Optimize decoding utf8 buffers to strings.

### DIFF
--- a/bench/utf8_bench.js
+++ b/bench/utf8_bench.js
@@ -1,0 +1,76 @@
+"use strict";
+
+var newSuite = require("./suite");
+var utf8 = require("../lib/utf8");
+
+const textDecoder = new TextDecoder("utf8");
+const textEncoder = new TextEncoder("utf8");
+
+const sizes = {
+    "very small": 7,
+    small: 20,
+    medium: 100,
+    large: 1000,
+};
+
+// Generates a random unicode string in the Basic Multilingual Plane, as a Uint8Array.
+function generateUnicodeBuffer(length) {
+    let unicodeString = "";
+    const minUnicode = 0x0020; // Space
+    const maxUnicode = 0xFFFF; // Last code point in Basic Multilingual Plane.
+    for (let i = 0; i < length; i++) {
+        const randomCodePoint = Math.floor(Math.random() * (maxUnicode - minUnicode + 1)) + minUnicode;
+
+        // Convert the code point to a character and append it
+        unicodeString += String.fromCharCode(randomCodePoint);
+    }
+
+    // Slice it again so we end up with a Uint8Array of the appropriate length.
+    return textEncoder.encode(unicodeString).subarray(0, length);
+}
+
+// Generates a random ascii string, as a Uint8Array.
+function generateAsciiBuffer(length) {
+    let asciiString = "";
+    const minAscii = 32;
+    const maxAscii = 126;
+    for (let i = 0; i < length; i++) {
+        const randomCodePoint = Math.floor(Math.random() * (maxAscii - minAscii + 1)) + minAscii;
+        asciiString += String.fromCharCode(randomCodePoint);
+    }
+    return textEncoder.encode(asciiString);
+}
+
+const bufferGeneratorFunctions = {
+    ascii: generateAsciiBuffer,
+    nonAscii: generateUnicodeBuffer,
+};
+
+
+// Define Suites
+
+for (const [size, length] of Object.entries(sizes)) {
+    for (const [stringType, generatorFunction] of Object.entries(bufferGeneratorFunctions)) {
+        const buffer = generatorFunction(length);
+
+        newSuite(`${stringType} decoding - ${size} strings (${length} bytes)`)
+            .add("Fallback implementation", function () {
+                utf8._utf8_decode_fallback(buffer, 0, buffer.length);
+            })
+            .add("Ascii optimized implementation", function () {
+                utf8._ascii_decode_unrolled(buffer, 0, buffer.length);
+            })
+            .add("Optimized implementation", function () {
+                utf8.read(buffer, 0, buffer.length);
+            })
+            .add("Node Buffer.toString", function () {
+                const nodeBuffer = Buffer.from(buffer);
+                nodeBuffer.toString("utf8", 0, buffer.length);
+            })
+            .add("TextDecoder", function () {
+                textDecoder.decode(buffer);
+            })
+            .run();
+    }
+}
+

--- a/index.d.ts
+++ b/index.d.ts
@@ -2498,7 +2498,16 @@ export namespace util {
      */
     function pool(alloc: PoolAllocator, slice: PoolSlicer, size?: number): PoolAllocator;
 
-    /** A minimal UTF8 implementation for number arrays. */
+    /**
+     * A minimal UTF8 implementation for Uint8Arrays.
+     *
+     * This implementation uses a combination of techniques for optimal performance:
+     * - TextDecoder for longer strings and non-ASCII content
+     * - 8-byte unrolling for ASCII-only content
+     * - Inspired by the approach taken in avsc:
+     * https://github.com/mtth/avsc/blob/91d653f72906102448a059cb81692177bb678f52/lib/utils.js#L796
+     *
+     */
     namespace utf8 {
 
         /**
@@ -2509,7 +2518,16 @@ export namespace util {
         function length(string: string): number;
 
         /**
-         * Reads UTF8 bytes as a string.
+         * Reads UTF8 bytes as a string. This attempts to take the most optimal
+         * approach of the above implementations:
+         *
+         * - Special case the empty string
+         * - If the string is long and TextDecoder is available, use TextDecoder
+         * - If the string is ASCII only, use ascii_decode_unrolled
+         * - Otherwise, use utf8_decode_fallback
+         *
+         * See the code in `bench/utf8_bench.js` if attempting to tune this code.
+         *
          * @param buffer Source buffer
          * @param start Source start
          * @param end Source end

--- a/lib/utf8/index.js
+++ b/lib/utf8/index.js
@@ -1,11 +1,22 @@
 "use strict";
 
 /**
- * A minimal UTF8 implementation for number arrays.
+ * A minimal UTF8 implementation for Uint8Arrays.
+ *
+ * This implementation uses a combination of techniques for optimal performance:
+ * - TextDecoder for longer strings and non-ASCII content
+ * - 8-byte unrolling for ASCII-only content
+ * - Inspired by the approach taken in avsc:
+ *   https://github.com/mtth/avsc/blob/91d653f72906102448a059cb81692177bb678f52/lib/utils.js#L796
+ *
  * @memberof util
  * @namespace
  */
 var utf8 = exports;
+
+// TextDecoder is not available in IE or browsers from before 2017.
+var TEXT_DECODER_AVAILABLE = typeof TextDecoder !== "undefined";
+var textDecoder = TEXT_DECODER_AVAILABLE ? new TextDecoder("utf-8") : null;
 
 /**
  * Calculates the UTF8 byte length of a string.
@@ -30,20 +41,13 @@ utf8.length = function utf8_length(string) {
     return len;
 };
 
-/**
- * Reads UTF8 bytes as a string.
- * @param {Uint8Array} buffer Source buffer
- * @param {number} start Source start
- * @param {number} end Source end
- * @returns {string} String read
- */
-utf8.read = function utf8_read(buffer, start, end) {
-    if (end - start < 1) {
-        return "";
-    }
+// Manually decodes UTF8 bytes to string. This function supports old browsers
+// without TextDecoder.
+function utf8_decode_fallback(buffer, start, end, initialStr, initialPos) {
+    var str = initialStr || "";
+    var i = initialPos || start;
 
-    var str = "";
-    for (var i = start; i < end;) {
+    for (; i < end;) {
         var t = buffer[i++];
         if (t <= 0x7F) {
             str += String.fromCharCode(t);
@@ -59,6 +63,97 @@ utf8.read = function utf8_read(buffer, start, end) {
     }
 
     return str;
+}
+
+// Export fallback function for direct benchmarking.
+utf8._utf8_decode_fallback = utf8_decode_fallback;
+
+// Fast path for ASCII-only strings. This falls back to utf8_decode_fallback if
+// it encounters a non-ASCII character. This function works in all browsers,
+// but will only be faster than TextDecoder on short ASCII strings.
+function ascii_decode_unrolled(buffer, start, end, initialStr, initialPos) {
+    var str = initialStr || "";
+    var i = initialPos || start;
+
+    // process 8 bytes at a time when possible
+    for (; i + 7 < end; i += 8) {
+        // Check all 8 bytes at once for non-ASCII using bitwise OR
+        if (buffer[i] > 0x7F || buffer[i + 1] > 0x7F || buffer[i + 2] > 0x7F || buffer[i + 3] > 0x7F || buffer[i + 4] > 0x7F || buffer[i + 5] > 0x7F || buffer[i + 6] > 0x7F || buffer[i + 7] > 0x7F) {
+            // Non-ASCII character detected, fall back to the generic utf8 implementation
+            return utf8_decode_fallback(buffer, start, end, str, i);
+        }
+        // Process 8 ASCII bytes at once
+        str += String.fromCharCode(
+            buffer[i],
+            buffer[i + 1],
+            buffer[i + 2],
+            buffer[i + 3],
+            buffer[i + 4],
+            buffer[i + 5],
+            buffer[i + 6],
+            buffer[i + 7]
+        );
+    }
+
+    // Handle remaining ASCII bytes one by one
+    for (; i < end; i++) {
+        var t = buffer[i];
+        if (t > 0x7F) {
+            // Non-ASCII character detected, fall back to the generic utf8 implementation
+            return utf8_decode_fallback(buffer, start, end, str, i);
+        }
+        str += String.fromCharCode(t);
+    }
+
+    return str;
+}
+
+// Export ascii function for direct benchmarking.
+utf8._ascii_decode_unrolled = ascii_decode_unrolled;
+
+
+// Slices bytes according to a start and an end. This avoids creating a new
+// Uint8Array if start and end already correspond to the start and end of the
+// input.
+//
+// This is an important optimization because `src/reader:Reader` will
+// often create a subarray immediately before passing it to utf8_read. Creating
+// an additional subarray object is expensive and not useful.
+function subarray(buffer, start, end) {
+    if (start === 0 && end === buffer.length) {
+        return buffer;
+    }
+    return buffer.subarray(start, end);
+}
+
+/**
+ * Reads UTF8 bytes as a string. This attempts to take the most optimal
+ * approach of the above implementations:
+ *
+ * - Special case the empty string
+ * - If the string is long and TextDecoder is available, use TextDecoder
+ * - If the string is ASCII only, use ascii_decode_unrolled
+ * - Otherwise, use utf8_decode_fallback
+ *
+ * See the code in `bench/utf8_bench.js` if attempting to tune this code.
+ *
+ * @param {Uint8Array} buffer Source buffer
+ * @param {number} start Source start
+ * @param {number} end Source end
+ * @returns {string} String read
+ */
+utf8.read = function utf8_read(buffer, start, end) {
+    if (end - start < 1) {
+        return "";
+    }
+
+    // Use TextDecoder for strings longer than 24 characters
+    if (end - start > 24 && TEXT_DECODER_AVAILABLE) {
+        return textDecoder.decode(subarray(buffer, start, end));
+    }
+
+    return ascii_decode_unrolled(buffer, start, end);
+
 };
 
 /**

--- a/lib/utf8/index.js
+++ b/lib/utf8/index.js
@@ -75,23 +75,18 @@ function ascii_decode_unrolled(buffer, start, end, initialStr, initialPos) {
     var str = initialStr || "";
     var i = initialPos || start;
 
-    // process 8 bytes at a time when possible
-    for (; i + 7 < end; i += 8) {
-        // Check all 8 bytes at once for non-ASCII using bitwise OR
-        if (buffer[i] > 0x7F || buffer[i + 1] > 0x7F || buffer[i + 2] > 0x7F || buffer[i + 3] > 0x7F || buffer[i + 4] > 0x7F || buffer[i + 5] > 0x7F || buffer[i + 6] > 0x7F || buffer[i + 7] > 0x7F) {
+    // process 4 bytes at a time when possible
+    for (; i + 3 < end; i += 4) {
+        const a = buffer[i], b = buffer[i + 1], c = buffer[i + 2], d = buffer[i + 3];
+
+        // Check all 4 bytes at once for non-ASCII
+        if ((a | b | c | d) & 0x80) {
             // Non-ASCII character detected, fall back to the generic utf8 implementation
             return utf8_decode_fallback(buffer, start, end, str, i);
         }
-        // Process 8 ASCII bytes at once
+        // Process 4 ASCII bytes at once
         str += String.fromCharCode(
-            buffer[i],
-            buffer[i + 1],
-            buffer[i + 2],
-            buffer[i + 3],
-            buffer[i + 4],
-            buffer[i + 5],
-            buffer[i + 6],
-            buffer[i + 7]
+            a, b, c, d
         );
     }
 

--- a/src/reader.js
+++ b/src/reader.js
@@ -327,6 +327,10 @@ Reader.prototype.bytes = function read_bytes() {
  * @returns {string} Value read
  */
 Reader.prototype.string = function read_string() {
+    // Note that we could simply use the `.bytes()` function. However, creating
+    // slices of a Uint8Array tends to be pretty expensive. If we instead just
+    // call utf8.read with appropriate start and end indicies, we can often
+    // avoid creating one of these slices and save some time.
     var length = this.uint32(),
         start  = this.pos,
         end    = this.pos + length;

--- a/src/reader.js
+++ b/src/reader.js
@@ -327,8 +327,17 @@ Reader.prototype.bytes = function read_bytes() {
  * @returns {string} Value read
  */
 Reader.prototype.string = function read_string() {
-    var bytes = this.bytes();
-    return utf8.read(bytes, 0, bytes.length);
+    var length = this.uint32(),
+        start  = this.pos,
+        end    = this.pos + length;
+
+    /* istanbul ignore if */
+    if (end > this.len)
+        throw indexOutOfRange(this, length);
+
+    this.pos += length;
+
+    return utf8.read(this.buf, start, end);
 };
 
 /**


### PR DESCRIPTION
Replace the existing `utf8_read` function with a higher performance approach, which switches between 3 different implementations depending on the contents of the string:

- If the string is long and `TextDecoder` is available, use `TextDecoder`.
- If the string is short and ASCII only, use `String.fromCharCode`, reading 8 bytes at a time.
- Otherwise, use the old implementation, which works everywhere and can handle non-ascii inputs.

Here are the results of `bench/index.js` on my machine. Note that I tweaked `bench/index.js` to use `Uint8Array` rather than Node's `Buffer`, since `Buffer` is not available in browsers.

Before:
```
adamf@fedora ~/o/protobuf.js (master)> node bench/index.js
benchmarking decoding performance ...

protobuf.js (reflect) x 2,293,860 ops/sec ±0.21% (95 runs sampled)
protobuf.js (static) x 2,666,338 ops/sec ±0.48% (97 runs sampled)
JSON (string) x 1,025,987 ops/sec ±0.66% (96 runs sampled)
JSON (buffer) x 842,511 ops/sec ±0.73% (94 runs sampled)
google-protobuf x 656,314 ops/sec ±1.03% (91 runs sampled)

   protobuf.js (static) was fastest
  protobuf.js (reflect) was 13.7% ops/sec slower (factor 1.2)
          JSON (string) was 61.6% ops/sec slower (factor 2.6)
          JSON (buffer) was 68.5% ops/sec slower (factor 3.2)
        google-protobuf was 75.5% ops/sec slower (factor 4.1)

```

After optimizations applied:
```
benchmarking decoding performance ...

protobuf.js (reflect) x 2,740,020 ops/sec ±0.43% (93 runs sampled)
protobuf.js (static) x 2,896,863 ops/sec ±0.47% (98 runs sampled)
JSON (string) x 1,077,209 ops/sec ±0.29% (99 runs sampled)
JSON (buffer) x 932,395 ops/sec ±0.33% (97 runs sampled)
google-protobuf x 710,377 ops/sec ±0.35% (99 runs sampled)

   protobuf.js (static) was fastest
  protobuf.js (reflect) was 5.4% ops/sec slower (factor 1.1)
          JSON (string) was 62.7% ops/sec slower (factor 2.7)
          JSON (buffer) was 67.8% ops/sec slower (factor 3.1)
        google-protobuf was 75.4% ops/sec slower (factor 4.1)

```

The improvement is larger for protobufs that use more strings than the benchmark.


Also, adds a benchmark of these approaches to help convince us that this is an effective strategy. 

<details>
<summary> Output of the benchmark program</summary>


```
benchmarking ascii decoding - very small strings (7 bytes) performance ...

Fallback implementation x 26,555,965 ops/sec ±1.26% (94 runs sampled)
Ascii optimized implementation x 24,544,739 ops/sec ±2.62% (85 runs sampled)
Optimized implementation x 26,341,753 ops/sec ±1.35% (91 runs sampled)
Node Buffer.toString x 9,217,721 ops/sec ±0.84% (93 runs sampled)
TextDecoder x 17,698,933 ops/sec ±0.81% (92 runs sampled)

Fallback implementation was fastest
Optimized implementation was 0.9% ops/sec slower (factor 1.0)
Ascii optimized implementation was 8.8% ops/sec slower (factor 1.1)
            TextDecoder was 33.1% ops/sec slower (factor 1.5)
   Node Buffer.toString was 65.1% ops/sec slower (factor 2.9)

benchmarking nonAscii decoding - very small strings (7 bytes) performance ...

Fallback implementation x 32,865,893 ops/sec ±1.74% (90 runs sampled)
Ascii optimized implementation x 29,602,839 ops/sec ±1.92% (91 runs sampled)
Optimized implementation x 28,114,949 ops/sec ±1.41% (89 runs sampled)
Node Buffer.toString x 7,758,577 ops/sec ±0.66% (93 runs sampled)
TextDecoder x 14,199,077 ops/sec ±1.38% (95 runs sampled)

Fallback implementation was fastest
Ascii optimized implementation was 10.1% ops/sec slower (factor 1.1)
Optimized implementation was 14.2% ops/sec slower (factor 1.2)
            TextDecoder was 56.6% ops/sec slower (factor 2.3)
   Node Buffer.toString was 76.1% ops/sec slower (factor 4.2)

benchmarking ascii decoding - small strings (20 bytes) performance ...

Fallback implementation x 9,660,584 ops/sec ±1.90% (91 runs sampled)
Ascii optimized implementation x 19,055,980 ops/sec ±1.29% (91 runs sampled)
Optimized implementation x 18,972,682 ops/sec ±0.78% (93 runs sampled)
Node Buffer.toString x 9,053,070 ops/sec ±0.71% (94 runs sampled)
TextDecoder x 17,069,260 ops/sec ±1.38% (94 runs sampled)

Optimized implementation was fastest
Ascii optimized implementation was 0.1% ops/sec slower (factor 1.0)
            TextDecoder was 10.6% ops/sec slower (factor 1.1)
Fallback implementation was 49.6% ops/sec slower (factor 2.0)
   Node Buffer.toString was 52.3% ops/sec slower (factor 2.1)

benchmarking nonAscii decoding - small strings (20 bytes) performance ...

Fallback implementation x 13,637,013 ops/sec ±0.48% (94 runs sampled)
Ascii optimized implementation x 11,266,322 ops/sec ±0.42% (97 runs sampled)
Optimized implementation x 11,912,698 ops/sec ±0.51% (97 runs sampled)
Node Buffer.toString x 6,265,259 ops/sec ±0.94% (95 runs sampled)
TextDecoder x 10,559,849 ops/sec ±0.45% (97 runs sampled)

Fallback implementation was fastest
Optimized implementation was 12.7% ops/sec slower (factor 1.1)
Ascii optimized implementation was 17.3% ops/sec slower (factor 1.2)
            TextDecoder was 22.5% ops/sec slower (factor 1.3)
   Node Buffer.toString was 54.3% ops/sec slower (factor 2.2)

benchmarking ascii decoding - medium strings (100 bytes) performance ...

Fallback implementation x 2,349,676 ops/sec ±1.88% (90 runs sampled)
Ascii optimized implementation x 5,222,330 ops/sec ±0.70% (93 runs sampled)
Optimized implementation x 15,518,384 ops/sec ±0.99% (95 runs sampled)
Node Buffer.toString x 7,921,649 ops/sec ±1.31% (90 runs sampled)
TextDecoder x 15,861,131 ops/sec ±0.78% (93 runs sampled)

            TextDecoder was fastest
Optimized implementation was 2.4% ops/sec slower (factor 1.0)
   Node Buffer.toString was 50.3% ops/sec slower (factor 2.0)
Ascii optimized implementation was 67.1% ops/sec slower (factor 3.0)
Fallback implementation was 85.3% ops/sec slower (factor 6.8)

benchmarking nonAscii decoding - medium strings (100 bytes) performance ...

Fallback implementation x 3,921,465 ops/sec ±1.76% (88 runs sampled)
Ascii optimized implementation x 3,273,387 ops/sec ±1.69% (91 runs sampled)
Optimized implementation x 3,885,206 ops/sec ±0.37% (97 runs sampled)
Node Buffer.toString x 3,050,990 ops/sec ±0.53% (98 runs sampled)
TextDecoder x 3,897,128 ops/sec ±0.36% (93 runs sampled)

            TextDecoder was fastest
Optimized implementation was 0.3% ops/sec slower (factor 1.0)
Fallback implementation was 0.8% ops/sec slower (factor 1.0)
Ascii optimized implementation was 17.1% ops/sec slower (factor 1.2)
   Node Buffer.toString was 21.8% ops/sec slower (factor 1.3)

benchmarking ascii decoding - large strings (1000 bytes) performance ...

Fallback implementation x 255,500 ops/sec ±0.80% (94 runs sampled)
Ascii optimized implementation x 561,257 ops/sec ±1.10% (91 runs sampled)
Optimized implementation x 7,401,210 ops/sec ±5.17% (81 runs sampled)
Node Buffer.toString x 2,365,643 ops/sec ±2.59% (85 runs sampled)
TextDecoder x 8,576,388 ops/sec ±0.98% (92 runs sampled)

            TextDecoder was fastest
Optimized implementation was 17.1% ops/sec slower (factor 1.2)
   Node Buffer.toString was 72.8% ops/sec slower (factor 3.7)
Ascii optimized implementation was 93.5% ops/sec slower (factor 15.3)
Fallback implementation was 97.0% ops/sec slower (factor 33.5)

benchmarking nonAscii decoding - large strings (1000 bytes) performance ...

Fallback implementation x 403,076 ops/sec ±0.43% (93 runs sampled)
Ascii optimized implementation x 375,654 ops/sec ±0.39% (99 runs sampled)
Optimized implementation x 450,154 ops/sec ±0.32% (99 runs sampled)
Node Buffer.toString x 398,743 ops/sec ±0.66% (96 runs sampled)
TextDecoder x 454,739 ops/sec ±0.16% (101 runs sampled)

            TextDecoder was fastest
Optimized implementation was 1.2% ops/sec slower (factor 1.0)
Fallback implementation was 11.6% ops/sec slower (factor 1.1)
   Node Buffer.toString was 12.7% ops/sec slower (factor 1.1)
Ascii optimized implementation was 17.6% ops/sec slower (factor 1.2)

```
</details>
