### PR TITLE
Update pbts.js: use spawn instead of exec

### DIFF
--- a/cli/pbts.js
+++ b/cli/pbts.js
@@ -98,12 +98,12 @@ exports.main = function(args, callback) {
         var basedir = path.join(__dirname, ".");
         var moduleName = argv.name || "null";
         var nodePath = process.execPath;
-        var cmd = "\"" + nodePath + "\" \"" + require.resolve("jsdoc/jsdoc.js") + "\" -c \"" + path.join(basedir, "lib", "tsd-jsdoc.json") + "\" -q \"module=" + encodeURIComponent(moduleName) + "&comments=" + Boolean(argv.comments) + "\" " + files.map(function(file) { return "\"" + file + "\""; }).join(" ");
-        var child = child_process.exec(cmd, {
+        var cmd = nodePath;
+        const args = [require.resolve("jsdoc/jsdoc.js"), "-c", path.join(basedir, "lib", "tsd-jsdoc.json"), "-q", "module=" + encodeURIComponent(moduleName) + "&comments=" + Boolean(argv.comments), ...files];
+        var child = child_process.spawn(cmd, args, {
             cwd: process.cwd(),
             argv0: "node",
             stdio: "pipe",
-            maxBuffer: 1 << 26 // 67mb
         });
         var out = [];
         var ended = false;


### PR DESCRIPTION
Fixes https://github.com/protobufjs/protobuf.js/issues/2081 "pbts does not properly handle filepaths with special characters in it"