### PR TITLE
fix: Cannot read properties of undefined (reading 'default')

### DIFF
--- a/cli/wrappers/es6.js
+++ b/cli/wrappers/es6.js
@@ -1,4 +1,4 @@
-import * as $protobuf from $DEPENDENCY;
+import $protobuf from $DEPENDENCY;
 
 $OUTPUT;
 


### PR DESCRIPTION
Fixes #2040

```
const $root = $protobuf.roots["default"] || ($protobuf.roots["default"] = {});
                             ^

TypeError: Cannot read properties of undefined (reading 'default')
    at file:///*.js:8:30
    at ModuleJob.run (node:internal/modules/esm/module_job:274:25)
    at async onImport.tracePromise.__proto__ (node:internal/modules/esm/loader:644:26)
    at async asyncRunEntryPointWithESMLoader (node:internal/modules/run_main:117:5)
```