### PR TITLE
Remove jsdoc includePattern

### DIFF
--- a/cli/lib/tsd-jsdoc.json
+++ b/cli/lib/tsd-jsdoc.json
@@ -2,6 +2,9 @@
     "tags": {
         "allowUnknownTags": false
     },
+    "source": {
+        "includePattern": false
+    },
     "plugins": [
         "./tsd-jsdoc/plugin"
     ],


### PR DESCRIPTION
As explained at https://jsdoc.app/about-configuring-jsdoc#specifying-input-files, jsdoc uses a default includePattern of ".+\\.js(doc|x)?$" and filters out files (even files explicitly given on the command line) that do not match this pattern.

pbts always runs on a single, explicitly given file, so it should disable includePattern.

Fixes #2088