### PR TITLE
fix: invalid syntax in descriptor.proto

### DIFF
--- a/google/protobuf/descriptor.json
+++ b/google/protobuf/descriptor.json
@@ -588,11 +588,11 @@
                   42,
                   42
                 ],
-                "php_generic_services",
                 [
                   38,
                   38
-                ]
+                ],
+                "php_generic_services"
               ],
               "nested": {
                 "OptimizeMode": {

--- a/google/protobuf/descriptor.proto
+++ b/google/protobuf/descriptor.proto
@@ -229,7 +229,8 @@ message FileOptions {
 
     extensions 1000 to max;
 
-    reserved 42, "php_generic_services", 38;
+    reserved 42, 38;
+    reserved "php_generic_services";
 }
 
 message MessageOptions {


### PR DESCRIPTION
A recent change (#2075) edited descriptor.proto to include a `reserved` statement that combines a field number and field name in the same line. This is specifically called out in the proto language guide as invalid.

https://protobuf.dev/programming-guides/editions/#reserved

> Note that you can’t mix field names and numeric values in the same
> `reserved` statement.

Protobuf.js itself seems to handle this syntax just fine, but other tools like protoc will choke on it.