### PR TITLE
fix: support skip extra semicolons

### DIFF
--- a/src/parse.js
+++ b/src/parse.js
@@ -169,21 +169,21 @@ function parse(source, root, options) {
         } while (skip(",", true));
         var dummy = {options: undefined};
         dummy.setOption = function(name, value) {
-          if (this.options === undefined) this.options = {};
-          this.options[name] = value;
+            if (this.options === undefined) this.options = {};
+            this.options[name] = value;
         };
         ifBlock(
             dummy,
             function parseRange_block(token) {
-              /* istanbul ignore else */
-              if (token === "option") {
-                parseOption(dummy, token);  // skip
-                skip(";");
-              } else
-                throw illegal(token);
+                /* istanbul ignore else */
+                if (token === "option") {
+                    parseOption(dummy, token);  // skip
+                    skip(";");
+                } else
+                    throw illegal(token);
             },
             function parseRange_line() {
-              parseInlineOptions(dummy);  // skip
+                parseInlineOptions(dummy);  // skip
             });
     }
 
@@ -267,7 +267,7 @@ function parse(source, root, options) {
                 break;
             case "public":
                 next();
-                // eslint-disable-next-line no-fallthrough
+            // eslint-disable-next-line no-fallthrough
             default:
                 whichImports = imports || (imports = []);
                 break;
@@ -332,7 +332,7 @@ function parse(source, root, options) {
         var trailingLine = tn.line;
         if (obj) {
             if(typeof obj.comment !== "string") {
-              obj.comment = cmnt(); // try block-type comment
+                obj.comment = cmnt(); // try block-type comment
             }
             obj.filename = parse.filename;
         }
@@ -396,6 +396,10 @@ function parse(source, root, options) {
 
                 case "reserved":
                     readRanges(type.reserved || (type.reserved = []), true);
+                    break;
+
+                case ";":
+                    // Skip extra semicolons
                     break;
 
                 default:
@@ -527,13 +531,17 @@ function parse(source, root, options) {
                     readRanges(type.reserved || (type.reserved = []), true);
                     break;
 
+                case ";":
+                    // Skip extra semicolons
+                    break;
+
                 /* istanbul ignore next */
                 default:
                     throw illegal(token); // there are no groups with proto3 semantics
             }
         });
         parent.add(type)
-              .add(field);
+            .add(field);
     }
 
     function parseMapField(parent) {
@@ -586,6 +594,8 @@ function parse(source, root, options) {
             if (token === "option") {
                 parseOption(oneof, token);
                 skip(";");
+            } else if (token === ";") {
+                // Skip extra semicolons
             } else {
                 push(token);
                 parseField(oneof, "optional");
@@ -603,19 +613,23 @@ function parse(source, root, options) {
         var enm = new Enum(token);
         ifBlock(enm, function parseEnum_block(token) {
           switch(token) {
-            case "option":
-              parseOption(enm, token);
-              skip(";");
-              break;
+                case "option":
+                    parseOption(enm, token);
+                    skip(";");
+                    break;
 
-            case "reserved":
-              readRanges(enm.reserved || (enm.reserved = []), true);
+                case "reserved":
+                    readRanges(enm.reserved || (enm.reserved = []), true);
               if(enm.reserved === undefined) enm.reserved = [];
-              break;
+                    break;
 
-            default:
-              parseEnumValue(enm, token);
-          }
+                case ";":
+                    // Skip extra semicolons
+                    break;
+
+                default:
+                    parseEnumValue(enm, token);
+            }
         });
         parent.add(enm);
         if (parent === ptr) {
@@ -659,38 +673,38 @@ function parse(source, root, options) {
     }
 
     function parseOption(parent, token) {
-            var option;
-            var propName;
-            var isOption = true;
-            if (token === "option") {
-                token = next();
-            }
+        var option;
+        var propName;
+        var isOption = true;
+        if (token === "option") {
+            token = next();
+        }
 
-            while (token !== "=") {
-                if (token === "(") {
-                    var parensValue = next();
-                    skip(")");
-                    token = "(" + parensValue + ")";
-                }
-                if (isOption) {
-                    isOption = false;
-                    if (token.includes(".") && !token.includes("(")) {
-                        var tokens = token.split(".");
-                        option = tokens[0] + ".";
-                        token = tokens[1];
-                        continue;
-                    }
-                    option = token;
-                } else {
-                    propName = propName ? propName += token : token;
-                }
-                token = next();
+        while (token !== "=") {
+            if (token === "(") {
+                var parensValue = next();
+                skip(")");
+                token = "(" + parensValue + ")";
             }
-            var name = propName ? option.concat(propName) : option;
-            var optionValue = parseOptionValue(parent, name);
-            propName = propName && propName[0] === "." ? propName.slice(1) : propName;
-            option = option && option[option.length - 1] === "." ? option.slice(0, -1) : option;
-            setParsedOption(parent, option, optionValue, propName);
+            if (isOption) {
+                isOption = false;
+                if (token.includes(".") && !token.includes("(")) {
+                    var tokens = token.split(".");
+                    option = tokens[0] + ".";
+                    token = tokens[1];
+                    continue;
+                }
+                option = token;
+            } else {
+                propName = propName ? propName += token : token;
+            }
+            token = next();
+        }
+        var name = propName ? option.concat(propName) : option;
+        var optionValue = parseOptionValue(parent, name);
+        propName = propName && propName[0] === "." ? propName.slice(1) : propName;
+        option = option && option[option.length - 1] === "." ? option.slice(0, -1) : option;
+        setParsedOption(parent, option, optionValue, propName);
     }
 
     function parseOptionValue(parent, name) {
@@ -704,7 +718,7 @@ function parse(source, root, options) {
                     throw illegal(token, "name");
                 }
                 if (token === null) {
-                  throw illegal(token, "end of input");
+                    throw illegal(token, "end of input");
                 }
 
                 var value;
@@ -795,6 +809,8 @@ function parse(source, root, options) {
             /* istanbul ignore else */
             if (token === "rpc")
                 parseMethod(service, token);
+            else if (token === ";")
+                ; // Skip extra semicolons
             else
                 throw illegal(token);
         });

--- a/src/parse.js
+++ b/src/parse.js
@@ -169,21 +169,21 @@ function parse(source, root, options) {
         } while (skip(",", true));
         var dummy = {options: undefined};
         dummy.setOption = function(name, value) {
-            if (this.options === undefined) this.options = {};
-            this.options[name] = value;
+          if (this.options === undefined) this.options = {};
+          this.options[name] = value;
         };
         ifBlock(
             dummy,
             function parseRange_block(token) {
-                /* istanbul ignore else */
-                if (token === "option") {
-                    parseOption(dummy, token);  // skip
-                    skip(";");
-                } else
-                    throw illegal(token);
+              /* istanbul ignore else */
+              if (token === "option") {
+                parseOption(dummy, token);  // skip
+                skip(";");
+              } else
+                throw illegal(token);
             },
             function parseRange_line() {
-                parseInlineOptions(dummy);  // skip
+              parseInlineOptions(dummy);  // skip
             });
     }
 
@@ -267,7 +267,7 @@ function parse(source, root, options) {
                 break;
             case "public":
                 next();
-            // eslint-disable-next-line no-fallthrough
+                // eslint-disable-next-line no-fallthrough
             default:
                 whichImports = imports || (imports = []);
                 break;
@@ -332,7 +332,7 @@ function parse(source, root, options) {
         var trailingLine = tn.line;
         if (obj) {
             if(typeof obj.comment !== "string") {
-                obj.comment = cmnt(); // try block-type comment
+              obj.comment = cmnt(); // try block-type comment
             }
             obj.filename = parse.filename;
         }
@@ -541,7 +541,7 @@ function parse(source, root, options) {
             }
         });
         parent.add(type)
-            .add(field);
+              .add(field);
     }
 
     function parseMapField(parent) {
@@ -613,23 +613,23 @@ function parse(source, root, options) {
         var enm = new Enum(token);
         ifBlock(enm, function parseEnum_block(token) {
           switch(token) {
-                case "option":
-                    parseOption(enm, token);
-                    skip(";");
-                    break;
+            case "option":
+              parseOption(enm, token);
+              skip(";");
+              break;
 
-                case "reserved":
-                    readRanges(enm.reserved || (enm.reserved = []), true);
+            case "reserved":
+              readRanges(enm.reserved || (enm.reserved = []), true);
               if(enm.reserved === undefined) enm.reserved = [];
-                    break;
+              break;
 
-                case ";":
-                    // Skip extra semicolons
-                    break;
+            case ";":
+              // Skip extra semicolons
+              break;
 
-                default:
-                    parseEnumValue(enm, token);
-            }
+            default:
+              parseEnumValue(enm, token);
+          }
         });
         parent.add(enm);
         if (parent === ptr) {
@@ -673,38 +673,38 @@ function parse(source, root, options) {
     }
 
     function parseOption(parent, token) {
-        var option;
-        var propName;
-        var isOption = true;
-        if (token === "option") {
-            token = next();
-        }
+            var option;
+            var propName;
+            var isOption = true;
+            if (token === "option") {
+                token = next();
+            }
 
-        while (token !== "=") {
-            if (token === "(") {
-                var parensValue = next();
-                skip(")");
-                token = "(" + parensValue + ")";
-            }
-            if (isOption) {
-                isOption = false;
-                if (token.includes(".") && !token.includes("(")) {
-                    var tokens = token.split(".");
-                    option = tokens[0] + ".";
-                    token = tokens[1];
-                    continue;
+            while (token !== "=") {
+                if (token === "(") {
+                    var parensValue = next();
+                    skip(")");
+                    token = "(" + parensValue + ")";
                 }
-                option = token;
-            } else {
-                propName = propName ? propName += token : token;
+                if (isOption) {
+                    isOption = false;
+                    if (token.includes(".") && !token.includes("(")) {
+                        var tokens = token.split(".");
+                        option = tokens[0] + ".";
+                        token = tokens[1];
+                        continue;
+                    }
+                    option = token;
+                } else {
+                    propName = propName ? propName += token : token;
+                }
+                token = next();
             }
-            token = next();
-        }
-        var name = propName ? option.concat(propName) : option;
-        var optionValue = parseOptionValue(parent, name);
-        propName = propName && propName[0] === "." ? propName.slice(1) : propName;
-        option = option && option[option.length - 1] === "." ? option.slice(0, -1) : option;
-        setParsedOption(parent, option, optionValue, propName);
+            var name = propName ? option.concat(propName) : option;
+            var optionValue = parseOptionValue(parent, name);
+            propName = propName && propName[0] === "." ? propName.slice(1) : propName;
+            option = option && option[option.length - 1] === "." ? option.slice(0, -1) : option;
+            setParsedOption(parent, option, optionValue, propName);
     }
 
     function parseOptionValue(parent, name) {
@@ -718,7 +718,7 @@ function parse(source, root, options) {
                     throw illegal(token, "name");
                 }
                 if (token === null) {
-                    throw illegal(token, "end of input");
+                  throw illegal(token, "end of input");
                 }
 
                 var value;


### PR DESCRIPTION
# Reason
Sometimes, we might write more semicolons in proto, which usually has no impact on the back end. However, when it comes to collaborating with the front end, we need to export the server protocol. At this point, protobuf-js does not support lexical parsing of multiple semicolons, resulting in an error. Now, I have fixed this problem.

# Test Proto File
`test_dir/test.proto`

```proto
syntax = "proto3";

package test;

// Test case 1: Enum with double semicolon
enum Enum_Fruit_App {
    APPLE = 0;
    BANANA = 1;;  // Double semicolon here
    ORANGE = 2;
}

// Test case 2: Multiple double semicolons
enum Status {
    UNKNOWN = 0;   ;
    ACTIVE = 1;;
    INACTIVE = 2;
}

// Test case 3: Triple semicolon (extreme case)
enum Priority {
    LOW = 0;
    MEDIUM = 1; ; ;  // Triple semicolon;
    HIGH = 2;;;;;///;;;;
}

// Test case 4: Message with double semicolon after field
message TestMessage {
    Enum_Fruit_App fruit = 1;;  // Double semicolon after field
    Status status = 2;
    Priority priority = 3;;
}

// Test case 5: Message with option having double semicolon
message ConfigMessage {
    option deprecated = true;;  // Double semicolon after option
    string name = 1;
    int32 value = 2;;
}

// Test case 6: Service with double semicolon
service TestService {
    rpc GetStatus(TestMessage) returns (ConfigMessage);;  ;;// Double semicolon after method;;
}

// Test case 7: Nested message with double semicolons
message OuterMessage {
    message InnerMessage {
        string data = 1; ;
    }
    InnerMessage inner = 1; ; // ;
}
```

# Test Js File
`test_dir/test.js`
run check: node test_dir/test.js
```javascript
#!/usr/bin/env node

// Test script to reproduce and verify fix for double semicolon bug

var protobuf = require("..");

console.log("=".repeat(60));
console.log("Testing double semicolon bug in enum definition");
console.log("=".repeat(60));
console.log();

try {
    console.log("Loading test.proto with double/triple semicolons...");
    var root = protobuf.loadSync("test-double-semicolon/test.proto");

    console.log("✓ SUCCESS: Proto file loaded successfully!");
    console.log();
    console.log("Parsed enums:");

    // Display parsed enums
    var enums = ["Enum_Fruit_App", "Status", "Priority"];
    enums.forEach(function (enumName) {
        var enumType = root.lookupEnum("test." + enumName);
        if (enumType) {
            console.log("  - " + enumName + ":");
            Object.keys(enumType.values).forEach(function (key) {
                console.log("      " + key + " = " + enumType.values[key]);
            });
        }
    });

    console.log();
    console.log("Parsed message:");
    var TestMessage = root.lookupType("test.TestMessage");
    if (TestMessage) {
        console.log("  - TestMessage:");
        TestMessage.fieldsArray.forEach(function (field) {
            console.log("      " + field.name + ": " + field.type + " (id: " + field.id + ")");
        });
    }

    console.log();
    console.log("=".repeat(60));
    console.log("✓ All tests passed! Bug is fixed.");
    console.log("=".repeat(60));

} catch (err) {
    console.log("✗ ERROR: Failed to parse proto file");
    console.log();
    console.log("Error message:");
    console.log("  " + err.message);
    console.log();

    if (err.stack) {
        console.log("Stack trace:");
        var stackLines = err.stack.split('\n').slice(0, 8);
        stackLines.forEach(function (line) {
            console.log("  " + line);
        });
    }

    console.log();
    console.log("=".repeat(60));
    console.log("✗ Bug still exists - fix not working");
    console.log("=".repeat(60));

    process.exit(1);
}

```