### PR TITLE
Fixed case of struct.proto fields to match protobuf definition

### DIFF
--- a/src/common.js
+++ b/src/common.js
@@ -139,49 +139,49 @@ common("struct", {
      * @interface IValue
      * @type {Object}
      * @property {string} [kind]
-     * @property {0} [nullValue]
-     * @property {number} [numberValue]
-     * @property {string} [stringValue]
-     * @property {boolean} [boolValue]
-     * @property {IStruct} [structValue]
-     * @property {IListValue} [listValue]
+     * @property {0} [null_value]
+     * @property {number} [number_value]
+     * @property {string} [string_value]
+     * @property {boolean} [bool_value]
+     * @property {IStruct} [struct_value]
+     * @property {IListValue} [list_value]
      * @memberof common
      */
     Value: {
         oneofs: {
             kind: {
                 oneof: [
-                    "nullValue",
-                    "numberValue",
-                    "stringValue",
-                    "boolValue",
-                    "structValue",
-                    "listValue"
+                    "null_value",
+                    "number_value",
+                    "string_value",
+                    "bool_value",
+                    "struct_value",
+                    "list_value"
                 ]
             }
         },
         fields: {
-            nullValue: {
+            null_value: {
                 type: "NullValue",
                 id: 1
             },
-            numberValue: {
+            number_value: {
                 type: "double",
                 id: 2
             },
-            stringValue: {
+            string_value: {
                 type: "string",
                 id: 3
             },
-            boolValue: {
+            bool_value: {
                 type: "bool",
                 id: 4
             },
-            structValue: {
+            struct_value: {
                 type: "Struct",
                 id: 5
             },
-            listValue: {
+            list_value: {
                 type: "ListValue",
                 id: 6
             }


### PR DESCRIPTION
changed case of fields in common.js "struct" to match the case in the original struct.proto
https://github.com/protocolbuffers/protobuf/blob/main/src/google/protobuf/struct.proto#L66

Matching the case as the original protobuf allows the json representation to match the protobuf defintion with or without the keepCase option.