### PR TITLE
Fix toDescriptor for proto3 optional extensions

### DIFF
--- a/ext/descriptor/index.js
+++ b/ext/descriptor/index.js
@@ -518,10 +518,11 @@ Field.prototype.toDescriptor = function toDescriptor(edition) {
     // Handle extension field
     descriptor.extendee = this.extensionField ? this.extensionField.parent.fullName : this.extend;
 
-    // Handle part of oneof
-    if (this.partOf)
+    // Handle part of oneof (only meaningful for message types)
+    if (this.partOf && this.parent instanceof Type) {
         if ((descriptor.oneofIndex = this.parent.oneofsArray.indexOf(this.partOf)) < 0)
             throw Error("missing oneof");
+    }
 
     if (this.options) {
         descriptor.options = toDescriptorOptions(this.options, exports.FieldOptions);

--- a/tests/comp_import_extend.js
+++ b/tests/comp_import_extend.js
@@ -84,6 +84,38 @@ tape.test("extensions - proto3 roundtrip", function (test) {
     test.end();
 });
 
+tape.test("extensions - proto3 optional in extend toDescriptor", function (test) {
+  var root = protobuf.parse(`syntax = "proto3";
+
+    message SomeMessage {
+      string foo = 1;
+    }
+
+    extend SomeMessage {
+      optional string bar = 2;
+    }
+  `).root.resolveAll();
+
+  var decodedDescriptorSet;
+  try {
+    decodedDescriptorSet = root.toDescriptor("proto3");
+    test.pass("toDescriptor should not throw");
+  } catch (err) {
+    test.fail(err);
+    test.end();
+    return;
+  }
+
+  test.ok(decodedDescriptorSet.file[0].extension && decodedDescriptorSet.file[0].extension.length === 1,
+    "should include extension field");
+
+  var ext = decodedDescriptorSet.file[0].extension[0];
+  test.equal(ext.name, "bar", "extension field name is preserved");
+  test.equal(ext.proto3_optional, true, "proto3_optional flag is preserved");
+
+  test.end();
+});
+
 tape.test("extensions - edition 2023 file roundtrip", function (test) {
     var json = {
       nested: { Message: {


### PR DESCRIPTION
- Skip oneof index lookup when the field’s parent is not a Type
- Add regression test for proto3 optional fields in extend blocks

Fixes #1958 