### PR TITLE
release: add lib/ micromodules to release-please

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,1 +1,14 @@
-{".":"8.0.1","cli":"2.0.1"}
+{
+  ".": "8.0.1",
+  "cli": "2.0.1",
+  "lib/aspromise": "1.1.2",
+  "lib/base64": "1.1.2",
+  "lib/codegen": "2.0.4",
+  "lib/eventemitter": "1.1.0",
+  "lib/fetch": "1.1.0",
+  "lib/float": "1.0.2",
+  "lib/inquire": "1.1.0",
+  "lib/path": "1.1.2",
+  "lib/pool": "1.1.0",
+  "lib/utf8": "1.1.0"
+}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,6 +2,16 @@
   "bootstrap-sha": "6fc37d9ea3502cdc08ef988494c041aacd0f7e7f",
   "packages": {
     "cli": {},
-    ".": {}
+    ".": {},
+    "lib/aspromise": {},
+    "lib/base64": {},
+    "lib/codegen": {},
+    "lib/eventemitter": {},
+    "lib/fetch": {},
+    "lib/float": {},
+    "lib/inquire": {},
+    "lib/path": {},
+    "lib/pool": {},
+    "lib/utf8": {}
   }
 }


### PR DESCRIPTION
## Summary

- Add all 10 `lib/` independently-published `@protobufjs/*` packages to release-please manifest mode config
- Seed `.release-please-manifest.json` with current versions from each package's `package.json`
- No workflow changes needed — existing `command: manifest` picks up the new entries

## Motivation

The `lib/` micromodules have never been tracked by release-please, so fixes merged to `master` were never published to npm. This has caused multiple issues:

**Directly addresses:**
- #2094 — Deployment process didn't publish libs after changes
- #1924 — `@protobufjs/utf8` on npm is still the old code version
- #2057 — `@protobufjs/inquire` eval fix merged but never published
- #1892 — `@protobufjs/codegen` and `@protobufjs/fetch` fixes in git but not on npm
- #1754 — Use of eval is strongly discouraged (`@protobufjs/inquire` fix never published)

**Related release pipeline issues:**
- #2131 — protobufjs and protobufjs-cli are not the latest in npm
- #2099 — protobufjs-cli 1.2.0 is not the 'latest' in npm
- #1928 — No changelog / GitHub release for some versions

**Unblocks future releases for open PRs that touch lib/:**
- #2062 — Optimize decoding utf8 buffers (`lib/utf8`)
- #1873 — Make Codegen work when Function prototype is frozen (`lib/codegen`)
- #1548 — Refactor Inquire to avoid eval for CSP (`lib/inquire`)

## Test plan

- [x] Both JSON files validate (`node -e "require('./release-please-config.json'); require('./.release-please-manifest.json')"`)
- [ ] After merge, verify release-please opens release PRs for lib packages with unpublished changes