### PR TITLE
fix: backport __proto__ prototype pollution fix to v7.x

### DIFF
--- a/src/message.js
+++ b/src/message.js
@@ -13,8 +13,12 @@ var util = require("./util/minimal");
 function Message(properties) {
     // not used internally
     if (properties)
-        for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-            this[keys[i]] = properties[keys[i]];
+        for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i) {
+            var key = keys[i];
+            if (key === "__proto__")
+                continue;
+            this[key] = properties[key];
+        }
 }
 
 /**


### PR DESCRIPTION
## Summary

Cherry-pick of #2126 (commit f05e3c3b) onto the `ProtoBuf7` branch.

The fix filters out `__proto__` keys in the `Message` constructor to prevent prototype pollution (AIKIDO-2026-10467). This was merged to `master` and released in 8.0.1-experimental, but the 7.x line (latest 7.5.4) remains unpatched.

Many consumers are pinned to protobufjs ^7 via `google-gax` and the broader Google Cloud SDK ecosystem, and cannot upgrade to 8.x until those SDKs migrate. A 7.5.5 patch release would resolve the vulnerability for the entire ^7 ecosystem.

## Changes

Single file: `src/message.js` — skip `__proto__` key when iterating over properties in the Message constructor. Identical to #2126.

## Request

Would it be possible to publish a `7.5.5` release from the ProtoBuf7 branch with this fix included?