### PR TITLE
fix: Correct ES6 wrapper imports in static-module output

### DIFF
--- a/cli/targets/static-module.js
+++ b/cli/targets/static-module.js
@@ -18,7 +18,11 @@ function static_module_target(root, options, callback) {
             return;
         }
         try {
-            output = util.wrap(output, protobuf.util.merge({ dependency: "protobufjs/minimal" }, options));
+            output = util.wrap(output, protobuf.util.merge({
+                dependency: options.wrap === "es6"
+                    ? "protobufjs/minimal.js"
+                    : "protobufjs/minimal"
+            }, options));
         } catch (e) {
             callback(e);
             return;

--- a/cli/wrappers/es6.js
+++ b/cli/wrappers/es6.js
@@ -1,4 +1,4 @@
-import * as $protobuf from $DEPENDENCY;
+import $protobuf from $DEPENDENCY;
 
 $OUTPUT;
 

--- a/tests/cli.js
+++ b/tests/cli.js
@@ -93,6 +93,23 @@ tape.test("pbjs generates static code", function(test) {
     });
 });
 
+tape.test("pbjs generates correct ES6 static-module imports", function(test) {
+    cliTest(test, function() {
+        var root = protobuf.loadSync("tests/data/cli/test.proto");
+        root.resolveAll();
+
+        var staticModuleTarget = require("../cli/targets/static-module");
+
+        staticModuleTarget(root, {
+            wrap: "es6",
+        }, function(err, jsCode) {
+            test.error(err, "static-module code generation worked");
+            test.ok(jsCode.includes("import $protobuf from \"protobufjs/minimal.js\";"), "es6 wrapper uses a default import and explicit .js extension");
+            test.end();
+        });
+    });
+});
+
 tape.test("without null-defaults, absent optional fields have zero values", function(test) {
     cliTest(test, function() {
         var root = protobuf.loadSync("tests/data/cli/null-defaults.proto");


### PR DESCRIPTION
Updates ES6 static-module output to import `protobufjs/minimal.js` via a default import, which makes the generated code work in native ESM runtimes without the need to add a package `exports` field just yet.

Fixes #1657
Fixes #1862
Fixes #1929
Fixes #2040
Fixes #2048
Fixes #2086

Supersedes #2084

Related to #1930
Related to #1931