### PR TITLE
fix: Support .cjs and .mjs extensions in pbts

### DIFF
--- a/cli/lib/tsd-jsdoc.json
+++ b/cli/lib/tsd-jsdoc.json
@@ -2,6 +2,9 @@
     "tags": {
         "allowUnknownTags": false
     },
+    "source": {
+        "includePattern": ".+\\.(?:[cm]?js|jsdoc|jsx)$"
+    },
     "plugins": [
         "./tsd-jsdoc/plugin"
     ],


### PR DESCRIPTION
Updates the JSDoc include pattern used by `pbts` to accept `.cjs` and `.mjs` files.

Narrower alternative to #2089, where it turned out that we are already relying on/supporting running `pbts` on directories (in our CI), which would otherwise try to parse non-JS files in the given directory.

Fixes #2088