### PR TITLE
fix: Restore lazy type resolution during load

### DIFF
--- a/src/root.js
+++ b/src/root.js
@@ -62,7 +62,7 @@ Root.fromJSON = function fromJSON(json, root) {
         root = new Root();
     if (json.options)
         root.setOptions(json.options);
-    return root.addJSON(json.nested).resolveAll();
+    return root.addJSON(json.nested)._resolveFeaturesRecursive(root._edition);
 };
 
 /**
@@ -118,7 +118,7 @@ Root.prototype.load = function load(filename, options, callback) {
             throw err;
         }
         if (root) {
-            root.resolveAll();
+            root._resolveFeaturesRecursive(root._edition);
         }
         var cb = callback;
         callback = null;
@@ -230,7 +230,7 @@ Root.prototype.load = function load(filename, options, callback) {
         if (resolved = self.resolvePath("", filename[i]))
             fetch(resolved);
     if (sync) {
-        self.resolveAll();
+        self._resolveFeaturesRecursive(self._edition);
         return self;
     }
     if (!queued) {

--- a/tests/api_root.js
+++ b/tests/api_root.js
@@ -49,6 +49,33 @@ tape.test("reflected roots", function(test) {
         });
     });
 
+    test.test(test.name + " - fromJSON resolves features", function(test) {
+        var root = Root.fromJSON({
+            nested: {
+                Message: {
+                    edition: "proto2",
+                    fields: {
+                        child: { type: "Child", id: 1 },
+                        required: { rule: "required", type: "string", id: 2 }
+                    },
+                    nested: {
+                        Child: {
+                            fields: {}
+                        }
+                    }
+                }
+            }
+        });
+        var Message = root.lookupType("Message");
+
+        test.notOk(Message.fields.child.resolved, "should not resolve field types eagerly");
+        test.ok(Message.fields.required.required, "should resolve field features");
+
+        root.resolveAll();
+        test.ok(Message.fields.child.resolved, "should resolve field types explicitly");
+        test.end();
+    });
+
     test.test(test.name + " - weak", function(test) {
         var root = new Root();
         test.plan(1);        

--- a/tests/comp_import_extend.js
+++ b/tests/comp_import_extend.js
@@ -10,6 +10,7 @@ var descriptor = require("../ext/descriptor");
 tape.test("extensions - proto2 to proto3", function (test) {
     // load document with extended field imported multiple times
     var root = protobuf.loadSync(path.resolve(__dirname, "data/test.proto"));
+    root.resolveAll();
 
     // convert to Descriptor Set
     var decodedDescriptorSet = root.toDescriptor("proto3");

--- a/tests/node/api_load-sync.js
+++ b/tests/node/api_load-sync.js
@@ -36,6 +36,19 @@ tape.test("load sync", function(test) {
     test.end();
 });
 
+tape.test("load sync resolves features", function(test) {
+    var root = protobuf.loadSync("tests/data/test.proto");
+    var Complex = root.lookupType("jspb.test.Complex");
+    var Simple1 = root.lookupType("jspb.test.Simple1");
+
+    test.notOk(Complex.fields.aNestedMessage.resolved, "should not resolve field types eagerly");
+    test.ok(Simple1.fields.aString.required, "should resolve field features");
+
+    root.resolveAll();
+    test.ok(Complex.fields.aNestedMessage.resolved, "should resolve field types explicitly");
+    test.end();
+});
+
 tape.test("should load bundled definitions even if resolvePath method was overrided", function(test) {
     var protoFilePath = "tests/data/common.proto";
     var root = new protobuf.Root();


### PR DESCRIPTION
Restores pre-editions lazy type resolution for `Root.fromJSON()`, `Root.load()`, and `Root.loadSync()` while still resolving editions features after loading.

The context here is that before editions, we did not eagerly call `resolveAll`. During work on editions, which required feature resolution, this was changed to call `resolveAll` eagerly, in turn introducing performance regressions. It has since been attempted to mitigate some of the fallout, but to me it appears that eagerly calling `resolveAll` is the root cause here. Hence this PR aims at bringing us back to pre-editions baseline by resolving only features eagerly but defer type resolution as usual.

This is technically a breaking change for anyone already relying on eager type resolution after load. As far as I can tell, that behavior was not documented, and callers that need full validation can still call `resolveAll()` explicitly.

Related to #2123.

Follow-up to #2063 and #2066.
Partially reverts the eager load-time type resolution introduced by #2068.