### PR TITLE
fix: Correct alternate comment mode line numbers

### DIFF
--- a/src/tokenize.js
+++ b/src/tokenize.js
@@ -225,6 +225,7 @@ function tokenize(source, alternateCommentMode) {
             curr,
             start,
             isDoc,
+            nextLineIsComment,
             isLeadingComment = offset === 0;
         do {
             if (offset === length)
@@ -278,7 +279,11 @@ function tokenize(source, alternateCommentMode) {
                                     // Trailing comment cannot not be multi-line
                                     break;
                                 }
-                            } while (isDoubleSlashCommentLine(offset));
+                                nextLineIsComment = isDoubleSlashCommentLine(offset);
+                                if (nextLineIsComment) {
+                                    line++;
+                                }
+                            } while (nextLineIsComment);
                         } else {
                             offset = Math.min(length, findEndOfLine(offset) + 1);
                         }

--- a/tests/docs_comments_alternate_parse.js
+++ b/tests/docs_comments_alternate_parse.js
@@ -84,3 +84,24 @@ tape.test("proto comments in alternate-parse mode with trailing comment preferre
         test.end();
     });
 });
+
+tape.test("proto comments in alternate-parse mode maintain line numbers", function(test) {
+    var source = [
+        "syntax = \"proto3\";",
+        "",
+        "// Multiple lines of",
+        "// end-of-line comments",
+        "// should keep the tokenizer",
+        "// line count correct.",
+        "",
+        "message Foo {};a"
+    ].join("\n");
+
+    try {
+        protobuf.parse(source, { alternateCommentMode: true });
+        test.fail("should throw on invalid token");
+    } catch (err) {
+        test.equal(err.message, "illegal token 'a' (line 8)");
+    }
+    test.end();
+});


### PR DESCRIPTION
Narrower alternative to #2018. While the originally proposed fix corrected parser error line numbers, it also caused comments to be attached to the wrong line. This change keeps comment line numbers intact while still accounting for additional `//` lines in `alternateCommentMode`.

Closes #2018