### PR TITLE
fix: Run pbts jsdoc without a shell

### DIFF
--- a/cli/pbts.js
+++ b/cli/pbts.js
@@ -98,12 +98,17 @@ exports.main = function(args, callback) {
         var basedir = path.join(__dirname, ".");
         var moduleName = argv.name || "null";
         var nodePath = process.execPath;
-        var cmd = "\"" + nodePath + "\" \"" + require.resolve("jsdoc/jsdoc.js") + "\" -c \"" + path.join(basedir, "lib", "tsd-jsdoc.json") + "\" -q \"module=" + encodeURIComponent(moduleName) + "&comments=" + Boolean(argv.comments) + "\" " + files.map(function(file) { return "\"" + file + "\""; }).join(" ");
-        var child = child_process.exec(cmd, {
+        var jsdocArgs = [
+            require.resolve("jsdoc/jsdoc.js"),
+            "-c",
+            path.join(basedir, "lib", "tsd-jsdoc.json"),
+            "-q",
+            "module=" + encodeURIComponent(moduleName) + "&comments=" + Boolean(argv.comments)
+        ].concat(files);
+        var child = child_process.spawn(nodePath, jsdocArgs, {
             cwd: process.cwd(),
             argv0: "node",
-            stdio: "pipe",
-            maxBuffer: 1 << 26 // 67mb
+            stdio: "pipe"
         });
         var out = [];
         var ended = false;

--- a/tests/cli.js
+++ b/tests/cli.js
@@ -5,6 +5,8 @@ var path = require("path");
 var Module = require("module");
 var protobuf = require("..");
 var fs = require("fs");
+var EventEmitter = require("events").EventEmitter;
+var child_process = require("child_process");
 
 function cliTest(test, testFunc) {
     // pbjs does not seem to work with Node v4, so skip this test if we're running on it
@@ -107,6 +109,38 @@ tape.test("pbjs generates correct ES6 static-module imports", function(test) {
             test.ok(jsCode.includes("import $protobuf from \"protobufjs/minimal.js\";"), "es6 wrapper uses a default import and explicit .js extension");
             test.end();
         });
+    });
+});
+
+tape.test("pbts passes jsdoc arguments without a shell", function(test) {
+    var pbts = require("../cli/pbts");
+    var originalSpawn = child_process.spawn;
+    var file = "j\"oker `something` 'cool  streamlit;.js";
+
+    test.plan(5);
+
+    child_process.spawn = function(cmd, args, options) {
+        var child = new EventEmitter();
+        child.stdout = new EventEmitter();
+        child.stderr = { pipe: function() {} };
+
+        test.equal(cmd, process.execPath, "should execute node directly");
+        test.ok(/jsdoc[\\/]jsdoc\.js$/.test(args[0]), "should execute jsdoc directly");
+        test.equal(args[args.length - 1], file, "should pass file path as a single argument");
+        test.equal(options.stdio, "pipe", "should pipe jsdoc output");
+
+        process.nextTick(function() {
+            child.stdout.emit("data", "declare namespace test {}\n");
+            child.stdout.emit("end");
+            child.emit("close", 0);
+        });
+
+        return child;
+    };
+
+    pbts.main([file], function(err) {
+        child_process.spawn = originalSpawn;
+        test.error(err, "should generate definitions");
     });
 });
 

--- a/tests/cli.js
+++ b/tests/cli.js
@@ -115,7 +115,7 @@ tape.test("pbjs generates correct ES6 static-module imports", function(test) {
 tape.test("pbts passes jsdoc arguments without a shell", function(test) {
     var pbts = require("../cli/pbts");
     var originalSpawn = child_process.spawn;
-    var file = "j\"oker `something` 'cool  streamlit;.js";
+    var file = "file with \"quotes\" `backticks` 'apostrophes' and ;.js";
 
     test.plan(5);
 


### PR DESCRIPTION
Uses `spawn` with an argument array when `pbts` invokes JSDoc instead of building a shell command string for `exec`. Avoids shell parsing issues with characters such as quotes, backticks, or semicolons.

Fixes #2081
Closes #2082 (same approach, but style-consistent and covered by a test)