### PR TITLE
fix: Parse empty repeated options

### DIFF
--- a/src/parse.js
+++ b/src/parse.js
@@ -765,13 +765,15 @@ function parse(source, root, options) {
                     value = [];
                     var lastValue;
                     if (skip("[", true)) {
-                        do {
-                            lastValue = readValue(true);
-                            value.push(lastValue);
-                        } while (skip(",", true));
-                        skip("]");
-                        if (typeof lastValue !== "undefined") {
-                            setOption(parent, name + "." + token, lastValue);
+                        if (!skip("]", true)) {
+                            do {
+                                lastValue = readValue(true);
+                                value.push(lastValue);
+                            } while (skip(",", true));
+                            skip("]");
+                            if (typeof lastValue !== "undefined") {
+                                setOption(parent, name + "." + token, lastValue);
+                            }
                         }
                     }
                 } else {

--- a/tests/comp_options-parse.js
+++ b/tests/comp_options-parse.js
@@ -134,6 +134,7 @@ tape.test("Options", function (test) {
             {
                 "(method_rep_msg)": {
                     value: 1,
+                    empty_repeated: [],
                     nested: {nested: {value: "x"}},
                     rep_nested: [{value: "y"}, {value: "z"}],
                     rep_value: 3
@@ -149,6 +150,7 @@ tape.test("Options", function (test) {
         ];
 
         test.same(TestOptionsRpc.parsedOptions, expectedParsedOptions, "should correctly parse all nested message options");
+        test.equal(TestOptionsRpc.options["(method_rep_msg).empty_repeated"], undefined, "should not set a last value for empty repeated options");
         var jsonTestOptionsRpc = TestOptionsRpc.toJSON();
         test.same(jsonTestOptionsRpc.parsedOptions, expectedParsedOptions, "should correctly store all nested method options in JSON");
         var rootFromJson = protobuf.Root.fromJSON(root.toJSON());

--- a/tests/data/options_test.proto
+++ b/tests/data/options_test.proto
@@ -119,6 +119,7 @@ service TestOptionsService {
     rpc TestOptionsRpc(Msg) returns (Msg) {
         option (method_rep_msg) = {
             value: 1
+            empty_repeated: []
             nested {
                 nested {
                     value: "x"


### PR DESCRIPTION
Allows empty repeated options like `empty: []` to be parsed without treating `]` as a value.

Closes #1943 (same goal, but avoids writing an incorrect flat option value)