### PR TITLE
chore(ci): Fix 7.x release please configuration

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,4 +11,4 @@ jobs:
         with:
           command: manifest
           package-name: release-please-action
-          target-branch: ${{ github.ref_name }}
+          default-branch: ${{ github.ref_name }}

--- a/cli/package.json
+++ b/cli/package.json
@@ -13,6 +13,9 @@
   "license": "BSD-3-Clause",
   "main": "index.js",
   "types": "index.d.ts",
+  "publishConfig": {
+    "tag": "latest-1"
+  },
   "bin": {
     "pbjs": "bin/pbjs",
     "pbts": "bin/pbts"

--- a/package.json
+++ b/package.json
@@ -27,6 +27,9 @@
   ],
   "main": "index.js",
   "types": "index.d.ts",
+  "publishConfig": {
+    "tag": "latest-7"
+  },
   "scripts": {
     "bench": "node bench",
     "build": "npm run build:bundle && npm run build:types",


### PR DESCRIPTION
Fixes the 7.x release-please workflow to use v3 `default-branch` instead of `target-branch`.

Also adds npm publish tags for the 7.x packages so publishing from this branch does not move the main `latest` tag:
- `protobufjs`: `latest-7`
- `protobufjs-cli`: `latest-1`
- Micromodules keep the default npm tag