### PR TITLE
chore(ci): Disable npm audit during installs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,7 @@ on:
     types: [assigned, opened, synchronize, reopened, labeled]
 env:
   MIN_NODE_VERSION: &min_node_version "12"
+  NPM_CONFIG_AUDIT: "false"
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Disables npm audit for CI dependency installation. Audit is slow/noisy on older npm versions and does not add much in automated test jobs anyway.