### PR TITLE
fix: Accept empty statements in proto definitions

### DIFF
--- a/src/parse.js
+++ b/src/parse.js
@@ -389,6 +389,9 @@ function parse(source, root, options) {
 
             switch (token) {
 
+                case ";":
+                    break;
+
                 case "map":
                     parseMapField(type, token);
                     break;
@@ -523,6 +526,9 @@ function parse(source, root, options) {
         ifBlock(type, function parseGroup_block(token) {
             switch (token) {
 
+                case ";":
+                    break;
+
                 case "option":
                     parseOption(type, token);
                     skip(";");
@@ -647,6 +653,9 @@ function parse(source, root, options) {
         var enm = new Enum(token);
         ifBlock(enm, function parseEnum_block(token) {
           switch(token) {
+            case ";":
+              break;
+
             case "option":
               parseOption(enm, token);
               skip(";");
@@ -840,6 +849,8 @@ function parse(source, root, options) {
             }
 
             /* istanbul ignore else */
+            if (token === ";")
+                return;
             if (token === "rpc")
                 parseMethod(service, token);
             else
@@ -891,6 +902,8 @@ function parse(source, root, options) {
         ifBlock(method, function parseMethod_block(token) {
 
             /* istanbul ignore else */
+            if (token === ";")
+                return;
             if (token === "option") {
                 parseOption(method, token);
                 skip(";");
@@ -939,6 +952,9 @@ function parse(source, root, options) {
     var token;
     while ((token = next()) !== null) {
         switch (token) {
+
+            case ";":
+                break;
 
             case "package":
 

--- a/tests/comp_empty-statements.js
+++ b/tests/comp_empty-statements.js
@@ -1,0 +1,20 @@
+var tape = require("tape");
+var protobuf = require("..");
+
+tape.test("empty statements", function(test) {
+    var root = protobuf.parse("syntax = \"proto3\";;" +
+        "message Request { string value = 1;; }" +
+        "message Response { oneof result { string value = 1; }; }" +
+        "enum Status { UNKNOWN = 0;; OK = 1; ; }" +
+        "service TestService { ; rpc Get(Request) returns (Response) { ; option deprecated = true;; }; }").root;
+
+    var proto2Root = protobuf.parse("syntax = \"proto2\";" +
+        "message Legacy { optional group Group = 1 { ; optional string value = 2;; } }").root;
+
+    test.ok(root.lookupType("Request").fields.value, "should parse message fields");
+    test.ok(root.lookupType("Response").oneofs.result, "should parse oneof fields");
+    test.equal(root.lookupEnum("Status").values.OK, 1, "should parse enum values");
+    test.ok(root.lookupService("TestService").methods.Get, "should parse service methods");
+    test.ok(proto2Root.lookupType("Legacy.Group").fields.value, "should parse group fields");
+    test.end();
+});


### PR DESCRIPTION
Allows empty statements in proto definition blocks by ignoring extra semicolons where the grammar permits them.

Closes #1051
Closes #2103