### PR TITLE
chore(ci): Use npm install in release publish job

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -35,11 +35,11 @@ jobs:
 
       - name: Install dependencies
         if: ${{ steps.release.outputs.releases_created == 'true' }}
-        run: npm ci --ignore-scripts
+        run: npm install --ignore-scripts
 
       - name: Install CLI dependencies
         if: ${{ steps.release.outputs.releases_created == 'true' }}
-        run: npm --prefix cli ci --ignore-scripts
+        run: npm --prefix cli install --ignore-scripts
 
       - name: Build
         if: ${{ steps.release.outputs.releases_created == 'true' }}


### PR DESCRIPTION
Uses `npm install` in the release publish job for now, matching the regular CI setup.

The existing lockfile is old enough that modern `npm ci` rejects it during the release workflow before publish validation can run. The lockfile should be refreshed separately, but this keeps the release job unblocked for now.