### PR TITLE
fix: Accept imports after declarations

### DIFF
--- a/src/parse.js
+++ b/src/parse.js
@@ -967,10 +967,6 @@ function parse(source, root, options) {
 
             case "import":
 
-                /* istanbul ignore if */
-                if (!head)
-                    throw illegal(token);
-
                 parseImport();
                 break;
 

--- a/tests/comp_import-after-decl.js
+++ b/tests/comp_import-after-decl.js
@@ -1,0 +1,14 @@
+var tape = require("tape");
+var protobuf = require("..");
+
+tape.test("imports after declarations", function(test) {
+    var parsed = protobuf.parse("syntax = \"proto3\";" +
+        "message Foo { string name = 1; }" +
+        "import \"bar.proto\";" +
+        "enum Status { UNKNOWN = 0; }" +
+        "import weak \"baz.proto\";");
+
+    test.deepEqual(parsed.imports, [ "bar.proto" ], "should parse imports after messages");
+    test.deepEqual(parsed.weakImports, [ "baz.proto" ], "should parse weak imports after enums");
+    test.end();
+});


### PR DESCRIPTION
Allows top-level imports to appear after other declarations, matching the proto grammar and protoc behavior.

Fixes #2069