### PR TITLE
fix: Generate TypeScript class properties for extensions

### DIFF
--- a/cli/lib/tsd-jsdoc/publish.js
+++ b/cli/lib/tsd-jsdoc/publish.js
@@ -397,9 +397,11 @@ function writeInterfaceBody(element) {
     write("}");
 }
 
-function writeProperty(property, declare) {
+function writeProperty(property, declare, inClass) {
     writeComment(property.description);
-    if (declare)
+    if (inClass)
+        write("public ");
+    else if (declare)
         write("let ");
     write(property.name);
     if (property.optional)
@@ -543,9 +545,9 @@ function handleClass(element, parent) {
         handleFunction(element, parent, true);
 
     // properties
-    if (is_interface && element.properties)
+    if (element.properties)
         element.properties.forEach(function(property) {
-            writeProperty(property);
+            writeProperty(property, false, !is_interface);
         });
 
     // class-compatible members

--- a/cli/targets/static.js
+++ b/cli/targets/static.js
@@ -367,6 +367,29 @@ function toJsType(field, parentIsInterface = false) {
     return type;
 }
 
+function toJsTypeWithNullability(field) {
+    var jsType = toJsType(field, /* parentIsInterface = */ false);
+    if (config["null-semantics"]) {
+        // With semantic nulls, fields are nullable if they are explicitly optional or part of a one-of
+        // Maps, repeated values and fields with implicit defaults are never null after construction
+        // Members are never undefined, at a minimum they are initialized to null
+        if (isNullable(field))
+            jsType = jsType + "|null";
+    } else {
+        // Without semantic nulls, everything is optional in proto3
+        // Keep |undefined for backwards compatibility
+        if (field.optional && !field.map && !field.repeated && (field.resolvedType instanceof protobuf.Type || config["null-defaults"]) || field.partOf)
+            jsType = jsType + "|null|undefined";
+    }
+    return jsType;
+}
+
+function toPropName(field, optional) {
+    var prop = util.safeProp(field.name); // either .name or ["name"]
+    prop = prop.substring(1, prop.charAt(0) === "[" ? prop.length - 1 : prop.length);
+    return optional ? "[" + prop + "]" : prop;
+}
+
 function isNullable(field) {
     return field.hasPresence && !field.required;
 }
@@ -380,8 +403,6 @@ function buildType(ref, type) {
             "@interface " + escapeName("I" + type.name)
         ];
         type.fieldsArray.forEach(function(field) {
-            var prop = util.safeProp(field.name); // either .name or ["name"]
-            prop = prop.substring(1, prop.charAt(0) === "[" ? prop.length - 1 : prop.length);
             var jsType = toJsType(field, /* parentIsInterface = */ true);
             var nullable = false;
             if (config["null-semantics"]) {
@@ -407,7 +428,7 @@ function buildType(ref, type) {
                     nullable = true;
                 }
             }
-            typeDef.push("@property {" + jsType + "} " + (nullable ? "[" + prop + "]" : prop) + " " + (field.comment || type.name + " " + field.name));
+            typeDef.push("@property {" + jsType + "} " + toPropName(field, nullable) + " " + (field.comment || type.name + " " + field.name));
         });
         push("");
         pushComment(typeDef);
@@ -415,14 +436,25 @@ function buildType(ref, type) {
 
     // constructor
     push("");
-    pushComment([
+    var classDef = [
         "Constructs a new " + type.name + ".",
         type.parent instanceof protobuf.Root ? "@exports " + escapeName(type.name) : "@memberof " + exportName(type.parent),
         "@classdesc " + (type.comment || "Represents " + aOrAn(type.name) + "."),
         config.comments ? "@implements " + escapeName("I" + type.name) : null,
         "@constructor",
         "@param {" + exportName(type, true) + "=} [" + (config.beautify ? "properties" : "p") + "] Properties to set"
-    ]);
+    ];
+    if (config.comments) {
+        type.fieldsArray.forEach(function(field) {
+            if (!field.declaringField)
+                return;
+            var jsType = toJsTypeWithNullability(field);
+            var optional = /\bundefined\b/.test(jsType);
+            var propType = optional ? jsType.replace(/\|undefined\b/g, "") : jsType;
+            classDef.push("@property {" + propType + "} " + toPropName(field, optional) + " " + (field.comment || type.name + " " + field.name));
+        });
+    }
+    pushComment(classDef);
     buildFunction(type, type.name, Type.generateConstructor(type));
 
     // default values
@@ -430,24 +462,9 @@ function buildType(ref, type) {
     type.fieldsArray.forEach(function(field) {
         field.resolve();
         var prop = util.safeProp(field.name);
-        if (config.comments) {
+        if (config.comments && !field.declaringField) {
             push("");
-            var jsType = toJsType(field, /* parentIsInterface = */ false);
-            if (config["null-semantics"]) {
-                // With semantic nulls, fields are nullable if they are explicitly optional or part of a one-of
-                // Maps, repeated values and fields with implicit defaults are never null after construction
-                // Members are never undefined, at a minimum they are initialized to null
-                if (isNullable(field)) {
-                    jsType = jsType + "|null";
-                }
-            }
-            else {
-                // Without semantic nulls, everything is optional in proto3
-                // Keep |undefined for backwards compatibility
-                if (field.optional && !field.map && !field.repeated && (field.resolvedType instanceof Type || config["null-defaults"]) || field.partOf) {
-                    jsType = jsType + "|null|undefined";
-                }
-            }
+            var jsType = toJsTypeWithNullability(field);
             pushComment([
                 field.comment || type.name + " " + field.name + ".",
                 "@member {" + jsType + "} " + field.name,

--- a/tests/cli.js
+++ b/tests/cli.js
@@ -165,6 +165,17 @@ tape.test("pbts passes jsdoc arguments without a shell", function(test) {
     });
 });
 
+tape.test("pbts emits class properties for extension fields", function(test) {
+    var pbts = require("../cli/pbts");
+
+    pbts.main(["tests/data/test.js"], function(err, tsCode) {
+        test.error(err, "definition generation worked");
+        test.ok(tsCode.indexOf('public ".jspb.test.IndirectExtension.str": string;') >= 0, "should emit scalar extension property on the class");
+        test.ok(tsCode.indexOf('public ".jspb.test.CloneExtension.extField"?: (jspb.test.ICloneExtension|null);') >= 0, "should emit message extension property on the class");
+        test.end();
+    });
+});
+
 tape.test("without null-defaults, absent optional fields have zero values", function(test) {
     cliTest(test, function() {
         var root = protobuf.loadSync("tests/data/cli/null-defaults.proto");

--- a/tests/data/test.d.ts
+++ b/tests/data/test.d.ts
@@ -177,6 +177,12 @@ export namespace jspb {
 
         class HasExtensions implements IHasExtensions {
             constructor(properties?: jspb.test.IHasExtensions);
+            public ".jspb.test.IsExtension.extField"?: (jspb.test.IIsExtension|null);
+            public ".jspb.test.IndirectExtension.simple"?: (jspb.test.ISimple1|null);
+            public ".jspb.test.IndirectExtension.str": string;
+            public ".jspb.test.IndirectExtension.repeatedStr": string[];
+            public ".jspb.test.IndirectExtension.repeatedSimple": jspb.test.ISimple1[];
+            public ".jspb.test.simple1"?: (jspb.test.ISimple1|null);
             public str1: string;
             public str2: string;
             public str3: string;
@@ -397,6 +403,7 @@ export namespace jspb {
 
         class TestClone implements ITestClone {
             constructor(properties?: jspb.test.ITestClone);
+            public ".jspb.test.CloneExtension.extField"?: (jspb.test.ICloneExtension|null);
             public str: string;
             public simple1?: (jspb.test.ISimple1|null);
             public simple2: jspb.test.ISimple1[];
@@ -622,6 +629,7 @@ export namespace jspb {
 
         class TestReservedNames implements ITestReservedNames {
             constructor(properties?: jspb.test.ITestReservedNames);
+            public ".jspb.test.TestReservedNamesExtension.foo": number;
             public extension: number;
             public static create(properties?: jspb.test.ITestReservedNames): jspb.test.TestReservedNames;
             public static encode(message: jspb.test.ITestReservedNames, writer?: $protobuf.Writer): $protobuf.Writer;
@@ -1544,6 +1552,7 @@ export namespace google {
 
         class EnumOptions implements IEnumOptions {
             constructor(properties?: google.protobuf.IEnumOptions);
+            public ".jspb.test.IsExtension.simpleOption": string;
             public allowAlias: boolean;
             public deprecated: boolean;
             public deprecatedLegacyJsonFieldConflicts: boolean;

--- a/tests/data/test.js
+++ b/tests/data/test.js
@@ -1886,6 +1886,12 @@ $root.jspb = (function() {
              * @implements IHasExtensions
              * @constructor
              * @param {jspb.test.IHasExtensions=} [properties] Properties to set
+             * @property {jspb.test.IIsExtension|null} [".jspb.test.IsExtension.extField"] HasExtensions .jspb.test.IsExtension.extField
+             * @property {jspb.test.ISimple1|null} [".jspb.test.IndirectExtension.simple"] HasExtensions .jspb.test.IndirectExtension.simple
+             * @property {string} ".jspb.test.IndirectExtension.str" HasExtensions .jspb.test.IndirectExtension.str
+             * @property {Array.<string>} ".jspb.test.IndirectExtension.repeatedStr" HasExtensions .jspb.test.IndirectExtension.repeatedStr
+             * @property {Array.<jspb.test.ISimple1>} ".jspb.test.IndirectExtension.repeatedSimple" HasExtensions .jspb.test.IndirectExtension.repeatedSimple
+             * @property {jspb.test.ISimple1|null} [".jspb.test.simple1"] HasExtensions .jspb.test.simple1
              */
             function HasExtensions(properties) {
                 this[".jspb.test.IndirectExtension.repeatedStr"] = [];
@@ -1920,52 +1926,11 @@ $root.jspb = (function() {
              */
             HasExtensions.prototype.str3 = "";
 
-            /**
-             * HasExtensions .jspb.test.IsExtension.extField.
-             * @member {jspb.test.IIsExtension|null|undefined} .jspb.test.IsExtension.extField
-             * @memberof jspb.test.HasExtensions
-             * @instance
-             */
             HasExtensions.prototype[".jspb.test.IsExtension.extField"] = null;
-
-            /**
-             * HasExtensions .jspb.test.IndirectExtension.simple.
-             * @member {jspb.test.ISimple1|null|undefined} .jspb.test.IndirectExtension.simple
-             * @memberof jspb.test.HasExtensions
-             * @instance
-             */
             HasExtensions.prototype[".jspb.test.IndirectExtension.simple"] = null;
-
-            /**
-             * HasExtensions .jspb.test.IndirectExtension.str.
-             * @member {string} .jspb.test.IndirectExtension.str
-             * @memberof jspb.test.HasExtensions
-             * @instance
-             */
             HasExtensions.prototype[".jspb.test.IndirectExtension.str"] = "";
-
-            /**
-             * HasExtensions .jspb.test.IndirectExtension.repeatedStr.
-             * @member {Array.<string>} .jspb.test.IndirectExtension.repeatedStr
-             * @memberof jspb.test.HasExtensions
-             * @instance
-             */
             HasExtensions.prototype[".jspb.test.IndirectExtension.repeatedStr"] = $util.emptyArray;
-
-            /**
-             * HasExtensions .jspb.test.IndirectExtension.repeatedSimple.
-             * @member {Array.<jspb.test.ISimple1>} .jspb.test.IndirectExtension.repeatedSimple
-             * @memberof jspb.test.HasExtensions
-             * @instance
-             */
             HasExtensions.prototype[".jspb.test.IndirectExtension.repeatedSimple"] = $util.emptyArray;
-
-            /**
-             * HasExtensions .jspb.test.simple1.
-             * @member {jspb.test.ISimple1|null|undefined} .jspb.test.simple1
-             * @memberof jspb.test.HasExtensions
-             * @instance
-             */
             HasExtensions.prototype[".jspb.test.simple1"] = null;
 
             /**
@@ -4538,6 +4503,7 @@ $root.jspb = (function() {
              * @implements ITestClone
              * @constructor
              * @param {jspb.test.ITestClone=} [properties] Properties to set
+             * @property {jspb.test.ICloneExtension|null} [".jspb.test.CloneExtension.extField"] TestClone .jspb.test.CloneExtension.extField
              */
             function TestClone(properties) {
                 this.simple2 = [];
@@ -4587,12 +4553,6 @@ $root.jspb = (function() {
              */
             TestClone.prototype.unused = "";
 
-            /**
-             * TestClone .jspb.test.CloneExtension.extField.
-             * @member {jspb.test.ICloneExtension|null|undefined} .jspb.test.CloneExtension.extField
-             * @memberof jspb.test.TestClone
-             * @instance
-             */
             TestClone.prototype[".jspb.test.CloneExtension.extField"] = null;
 
             /**
@@ -7166,6 +7126,7 @@ $root.jspb = (function() {
              * @implements ITestReservedNames
              * @constructor
              * @param {jspb.test.ITestReservedNames=} [properties] Properties to set
+             * @property {number} ".jspb.test.TestReservedNamesExtension.foo" TestReservedNames .jspb.test.TestReservedNamesExtension.foo
              */
             function TestReservedNames(properties) {
                 if (properties)
@@ -7182,12 +7143,6 @@ $root.jspb = (function() {
              */
             TestReservedNames.prototype.extension = 0;
 
-            /**
-             * TestReservedNames .jspb.test.TestReservedNamesExtension.foo.
-             * @member {number} .jspb.test.TestReservedNamesExtension.foo
-             * @memberof jspb.test.TestReservedNames
-             * @instance
-             */
             TestReservedNames.prototype[".jspb.test.TestReservedNamesExtension.foo"] = 0;
 
             /**
@@ -18531,6 +18486,7 @@ $root.google = (function() {
              * @implements IEnumOptions
              * @constructor
              * @param {google.protobuf.IEnumOptions=} [properties] Properties to set
+             * @property {string} ".jspb.test.IsExtension.simpleOption" EnumOptions .jspb.test.IsExtension.simpleOption
              */
             function EnumOptions(properties) {
                 this.uninterpretedOption = [];
@@ -18580,12 +18536,6 @@ $root.google = (function() {
              */
             EnumOptions.prototype.uninterpretedOption = $util.emptyArray;
 
-            /**
-             * EnumOptions .jspb.test.IsExtension.simpleOption.
-             * @member {string} .jspb.test.IsExtension.simpleOption
-             * @memberof google.protobuf.EnumOptions
-             * @instance
-             */
             EnumOptions.prototype[".jspb.test.IsExtension.simpleOption"] = "";
 
             /**


### PR DESCRIPTION
Emits extension fields as class properties in generated TypeScript definitions, preserving extension field names instead of losing them through JSDoc member-name parsing.

Fixes #1559
Fixes #1423