### PR TITLE
fix: Update CLI peer dependency

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -18,7 +18,7 @@
     "pbts": "bin/pbts"
   },
   "peerDependencies": {
-    "protobufjs": "^8.0.0"
+    "protobufjs": ">=8.0.2 <9"
   },
   "dependencies": {
     "chalk": "^4.0.0",


### PR DESCRIPTION
Updates the protobufjs-cli peer dependency to require a protobufjs version that includes the utility APIs used by the current CLI.

Fixes incompatible installs such as protobufjs-cli@2.0.2 with protobufjs@8.0.1.

Reported in https://github.com/protobufjs/protobuf.js/pull/2163#issuecomment-4336482452