### PR TITLE
fix: Update CLI peer dependency (7.x)

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -21,7 +21,7 @@
     "pbts": "bin/pbts"
   },
   "peerDependencies": {
-    "protobufjs": "^7.0.0"
+    "protobufjs": ">=7.5.6 <8"
   },
   "dependencies": {
     "chalk": "^4.0.0",


### PR DESCRIPTION
Updates the protobufjs-cli peer dependency to require a protobufjs 7.x version that includes the utility APIs used by the current CLI.

Fixes incompatible installs such as protobufjs-cli@1.2.1 with protobufjs@7.5.5.

Reported in https://github.com/protobufjs/protobuf.js/pull/2173#issuecomment-4336586255
