### PR TITLE
fix: Decode bool values from full varints

### DIFF
--- a/src/reader.js
+++ b/src/reader.js
@@ -201,7 +201,20 @@ function readLongVarint() {
  * @returns {boolean} Value read
  */
 Reader.prototype.bool = function read_bool() {
-    return this.uint32() !== 0;
+    var value = false,
+        b;
+    for (var i = 0; i < 10; ++i) {
+        /* istanbul ignore if */
+        if (this.pos >= this.len)
+            throw indexOutOfRange(this);
+        b = this.buf[this.pos++];
+        if (b & 127)
+            value = true;
+        if (b < 128)
+            return value;
+    }
+    /* istanbul ignore next */
+    throw Error("invalid varint encoding");
 };
 
 function readFixed32_end(buf, end) { // note that this uses `end`, not `pos`

--- a/tests/api_writer-reader.js
+++ b/tests/api_writer-reader.js
@@ -90,6 +90,7 @@ tape.test("writer & reader", function(test) {
 
     test.ok(expect("bool", true, [1]), "should write true as a varint of length 1 and read it back equally");
     test.ok(expect("bool", false, [0]), "should write false as a varint of length 1 and read it back equally");
+    test.equal(Reader.create([ 128, 128, 128, 128, 16 ]).bool(), true, "should read 64 bit non-zero bool varints as true");
 
     // string, see also util_utf8
 


### PR DESCRIPTION
Reads boolean values as full varints instead of truncating them through `uint32()`.

Fixes valid non-zero bool encodings where the lower 32 bits are zero but higher varint bits are set, which should still decode as `true`.