### PR TITLE
fix: Apply oneof last-value wins during decode

### DIFF
--- a/src/decoder.js
+++ b/src/decoder.js
@@ -109,6 +109,8 @@ function decoder(mtype) {
                 : "%s=types[%i].decode(r,r.uint32(),undefined,n+1)", ref, i);
         else gen
                 ("%s=r.%s()", ref, type);
+        if (field.partOf) gen
+                ("m%s=%j", util.safeProp(field.partOf.name), field.name);
         gen
                 ("break")
             ("}");

--- a/tests/comp_oneof.js
+++ b/tests/comp_oneof.js
@@ -53,6 +53,11 @@ tape.test("oneofs", function(test) {
     test.equal(buf[0], 16, "should write id 1, wireType 0");
     test.equal(buf[1], 0, "should write a value of 0");
 
+    message = Message.decode([ 10, 1, 97, 16, 1 ]);
+    test.equal(message.kind, "num", "should decode the last value");
+    test.notOk(message.hasOwnProperty("str"), "should delete previous values while decoding");
+    test.same(Array.prototype.slice.call(Message.encode(message).finish()), [ 16, 1 ], "should re-encode only the last value");
+
     test.end();
 
 });

--- a/tests/data/test.js
+++ b/tests/data/test.js
@@ -7827,18 +7827,22 @@ $root.jspb = (function() {
                     switch (tag >>> 3) {
                     case 3: {
                             message.pone = reader.string();
+                            message.partialOneof = "pone";
                             break;
                         }
                     case 5: {
                             message.pthree = reader.string();
+                            message.partialOneof = "pthree";
                             break;
                         }
                     case 6: {
                             message.rone = $root.jspb.test.TestMessageWithOneof.decode(reader, reader.uint32(), undefined, long + 1);
+                            message.recursiveOneof = "rone";
                             break;
                         }
                     case 7: {
                             message.rtwo = reader.string();
+                            message.recursiveOneof = "rtwo";
                             break;
                         }
                     case 8: {
@@ -7853,18 +7857,22 @@ $root.jspb = (function() {
                         }
                     case 10: {
                             message.aone = reader.int32();
+                            message.defaultOneofA = "aone";
                             break;
                         }
                     case 11: {
                             message.atwo = reader.int32();
+                            message.defaultOneofA = "atwo";
                             break;
                         }
                     case 12: {
                             message.bone = reader.int32();
+                            message.defaultOneofB = "bone";
                             break;
                         }
                     case 13: {
                             message.btwo = reader.int32();
+                            message.defaultOneofB = "btwo";
                             break;
                         }
                     default:


### PR DESCRIPTION
When multiple fields from the same oneof appear on the wire, now clears previously decoded oneof members after reading the later field.