### PR TITLE
fix: Decode fields by full wire tag

### DIFF
--- a/bench/data/static_pbjs.js
+++ b/bench/data/static_pbjs.js
@@ -47,20 +47,20 @@ $root.Test = (function() {
             var tag = reader.uint32();
             if (tag === error)
                 break;
-            switch (tag >>> 3) {
-            case 1: {
+            switch (tag) {
+            case 10: {
                     message.string = reader.string();
                     break;
                 }
-            case 2: {
+            case 16: {
                     message.uint32 = reader.uint32();
                     break;
                 }
-            case 3: {
+            case 26: {
                     message.inner = $root.Test.Inner.decode(reader, reader.uint32(), undefined, long + 1);
                     break;
                 }
-            case 4: {
+            case 37: {
                     message.float = reader.float();
                     break;
                 }
@@ -109,16 +109,16 @@ $root.Test = (function() {
                 var tag = reader.uint32();
                 if (tag === error)
                     break;
-                switch (tag >>> 3) {
-                case 1: {
+                switch (tag) {
+                case 8: {
                         message.int32 = reader.int32();
                         break;
                     }
-                case 2: {
+                case 18: {
                         message.innerInner = $root.Test.Inner.InnerInner.decode(reader, reader.uint32(), undefined, long + 1);
                         break;
                     }
-                case 3: {
+                case 26: {
                         message.outer = $root.Outer.decode(reader, reader.uint32(), undefined, long + 1);
                         break;
                     }
@@ -167,16 +167,16 @@ $root.Test = (function() {
                     var tag = reader.uint32();
                     if (tag === error)
                         break;
-                    switch (tag >>> 3) {
-                    case 1: {
+                    switch (tag) {
+                    case 8: {
                             message.long = reader.int64();
                             break;
                         }
-                    case 2: {
+                    case 16: {
                             message["enum"] = reader.int32();
                             break;
                         }
-                    case 3: {
+                    case 24: {
                             message.sint32 = reader.sint32();
                             break;
                         }
@@ -246,8 +246,9 @@ $root.Outer = (function() {
             var tag = reader.uint32();
             if (tag === error)
                 break;
-            switch (tag >>> 3) {
-            case 1: {
+            switch (tag) {
+            case 8:
+            case 10: {
                     if (!(message.bool && message.bool.length))
                         message.bool = [];
                     if ((tag & 7) === 2) {
@@ -258,7 +259,7 @@ $root.Outer = (function() {
                         message.bool.push(reader.bool());
                     break;
                 }
-            case 2: {
+            case 17: {
                     message.double = reader.double();
                     break;
                 }

--- a/src/converter.js
+++ b/src/converter.js
@@ -28,7 +28,7 @@ function genValuePartial_fromObject(gen, field, fieldIndex, prop) {
                 // enum unknown values passthrough
                 if (values[keys[i]] === field.typeDefault && !defaultAlreadyEmitted) { gen
                     ("default:")
-                        ("if(typeof(d%s)===\"number\"){m%s=d%s;break}", prop, prop, prop);
+                        ("if(typeof d%s===\"number\"){m%s=d%s;break}", prop, prop, prop);
                     if (!field.repeated) gen // fallback to default value only for
                                              // arrays, to avoid leaving holes.
                         ("break");           // for non-repeated fields, just ignore
@@ -80,7 +80,7 @@ function genValuePartial_fromObject(gen, field, fieldIndex, prop) {
             case "bytes": gen
                 ("if(typeof d%s===\"string\")", prop)
                     ("util.base64.decode(d%s,m%s=util.newBuffer(util.base64.length(d%s)),0)", prop, prop, prop)
-                ("else if(d%s.length >= 0)", prop)
+                ("else if(d%s.length>=0)", prop)
                     ("m%s=d%s", prop, prop);
                 break;
             case "string": gen

--- a/src/decoder.js
+++ b/src/decoder.js
@@ -27,17 +27,17 @@ function decoder(mtype) {
         ("var t=r.uint32()")
         ("if(t===e)")
             ("break")
-        ("switch(t>>>3){");
+        ("switch(t){");
 
     var i = 0;
     for (; i < /* initializes */ mtype.fieldsArray.length; ++i) {
         var field = mtype._fieldsArray[i].resolve(),
             type  = field.resolvedType instanceof Enum ? "int32" : field.type,
-            ref   = "m" + util.safeProp(field.name); gen
-            ("case %i: {", field.id);
+            ref   = "m" + util.safeProp(field.name);
 
         // Map fields
         if (field.map) { gen
+            ("case %i:{", field.id * 8 + 2)
                 ("if(%s===util.emptyObject)", ref)
                     ("%s={}", ref)
                 ("var c2 = r.uint32()+r.pos");
@@ -55,9 +55,9 @@ function decoder(mtype) {
             gen
                 ("while(r.pos<c2){")
                     ("var tag2=r.uint32()")
-                    ("switch(tag2>>>3){")
-                        ("case 1: k=r.%s(); break", field.keyType)
-                        ("case 2:");
+                    ("switch(tag2){")
+                        ("case %i: k=r.%s(); break", 8 + types.mapKey[field.keyType], field.keyType)
+                        ("case %i:", 16 + (types.basic[type] === undefined ? 2 : types.basic[type]));
 
             if (types.basic[type] === undefined) gen
                             ("value=types[%i].decode(r,r.uint32(),undefined,n+1)", i); // can't be groups
@@ -84,7 +84,13 @@ function decoder(mtype) {
 
         // Repeated fields
         } else if (field.repeated) { gen
+            ("case %i:", field.id * 8 + (types.basic[type] === undefined ? field.delimited ? 3 : 2 : types.basic[type]));
 
+            if (types.packed[type] !== undefined) gen
+            ("case %i:", field.id * 8 + 2);
+
+            gen
+            ("{")
                 ("if(!(%s&&%s.length))", ref, ref)
                     ("%s=[]", ref);
 
@@ -97,17 +103,26 @@ function decoder(mtype) {
                 ("}else");
 
             // Non-packed
-            if (types.basic[type] === undefined) gen(field.delimited
-                    ? "%s.push(types[%i].decode(r,undefined,((t&~7)|4),n+1))"
-                    : "%s.push(types[%i].decode(r,r.uint32(),undefined,n+1))", ref, i);
+            if (types.basic[type] === undefined) {
+                if (field.delimited) gen
+                    ("%s.push(types[%i].decode(r,undefined,%i,n+1))", ref, i, field.id * 8 + 4);
+                else gen
+                    ("%s.push(types[%i].decode(r,r.uint32(),undefined,n+1))", ref, i);
+            }
             else gen
                     ("%s.push(r.%s())", ref, type);
 
         // Non-repeated
-        } else if (types.basic[type] === undefined) gen(field.delimited
-                ? "%s=types[%i].decode(r,undefined,((t&~7)|4),n+1)"
-                : "%s=types[%i].decode(r,r.uint32(),undefined,n+1)", ref, i);
+        } else if (types.basic[type] === undefined) {
+            gen
+            ("case %i:{", field.id * 8 + (field.delimited ? 3 : 2));
+            if (field.delimited) gen
+                ("%s=types[%i].decode(r,undefined,%i,n+1)", ref, i, field.id * 8 + 4);
+            else gen
+                ("%s=types[%i].decode(r,r.uint32(),undefined,n+1)", ref, i);
+        }
         else gen
+            ("case %i:{", field.id * 8 + types.basic[type])
                 ("%s=r.%s()", ref, type);
         if (field.partOf) gen
                 ("m%s=%j", util.safeProp(field.partOf.name), field.name);

--- a/src/decoder.js
+++ b/src/decoder.js
@@ -40,7 +40,7 @@ function decoder(mtype) {
             ("case %i:{", field.id * 8 + 2)
                 ("if(%s===util.emptyObject)", ref)
                     ("%s={}", ref)
-                ("var c2 = r.uint32()+r.pos");
+                ("var c2=r.uint32()+r.pos");
 
             if (types.defaults[field.keyType] !== undefined) gen
                 ("k=%j", types.defaults[field.keyType]);
@@ -56,7 +56,7 @@ function decoder(mtype) {
                 ("while(r.pos<c2){")
                     ("var tag2=r.uint32()")
                     ("switch(tag2){")
-                        ("case %i: k=r.%s(); break", 8 + types.mapKey[field.keyType], field.keyType)
+                        ("case %i:k=r.%s();break", 8 + types.mapKey[field.keyType], field.keyType)
                         ("case %i:", 16 + (types.basic[type] === undefined ? 2 : types.basic[type]));
 
             if (types.basic[type] === undefined) gen

--- a/tests/api_type.js
+++ b/tests/api_type.js
@@ -186,6 +186,34 @@ tape.test("decode nesting", function(test) {
     test.end();
 });
 
+tape.test("decode known fields by wire type", function(test) {
+    var root = protobuf.Root.fromJSON({
+        nested: {
+            Message: {
+                fields: {
+                    value: { type: "int32", id: 1 }
+                }
+            }
+        }
+    });
+    var Message = root.lookupType("Message");
+    var field1WireType6 = [ 1 << 3 | 6, 0 ];
+    var field1WireType7 = [ 1 << 3 | 7, 0 ];
+    var field1Fixed64 = [ 1 << 3 | 1, 1, 2, 3, 4, 5, 6, 7, 8 ];
+
+    test.throws(function() {
+        Message.decode(protobuf.util.newBuffer(field1WireType6));
+    }, /invalid wire type 6/, "should reject invalid wire types for known fields");
+
+    test.throws(function() {
+        Message.decode(protobuf.util.newBuffer(field1WireType7));
+    }, /invalid wire type 7/, "should reject invalid wire types for known fields");
+
+    var message = Message.decode(protobuf.util.newBuffer(field1Fixed64));
+    test.notOk(Object.prototype.hasOwnProperty.call(message, "value"), "should skip valid but unexpected wire types");
+    test.end();
+});
+
 tape.test("object conversion nesting", function(test) {
     function nestedObject(depth) {
         var object = { value: 42 };

--- a/tests/data/comments.js
+++ b/tests/data/comments.js
@@ -131,16 +131,16 @@ $root.Test1 = (function() {
             var tag = reader.uint32();
             if (tag === error)
                 break;
-            switch (tag >>> 3) {
-            case 1: {
+            switch (tag) {
+            case 10: {
                     message.field1 = reader.string();
                     break;
                 }
-            case 2: {
+            case 16: {
                     message.field2 = reader.uint32();
                     break;
                 }
-            case 3: {
+            case 24: {
                     message.field3 = reader.bool();
                     break;
                 }
@@ -362,7 +362,7 @@ $root.Test2 = (function() {
             var tag = reader.uint32();
             if (tag === error)
                 break;
-            switch (tag >>> 3) {
+            switch (tag) {
             default:
                 reader.skipType(tag & 7, long);
                 break;

--- a/tests/data/convert.js
+++ b/tests/data/convert.js
@@ -210,22 +210,23 @@ $root.Message = (function() {
             var tag = reader.uint32();
             if (tag === error)
                 break;
-            switch (tag >>> 3) {
-            case 1: {
+            switch (tag) {
+            case 10: {
                     message.stringVal = reader.string();
                     break;
                 }
-            case 2: {
+            case 18: {
                     if (!(message.stringRepeated && message.stringRepeated.length))
                         message.stringRepeated = [];
                     message.stringRepeated.push(reader.string());
                     break;
                 }
-            case 3: {
+            case 24: {
                     message.uint64Val = reader.uint64();
                     break;
                 }
-            case 4: {
+            case 32:
+            case 34: {
                     if (!(message.uint64Repeated && message.uint64Repeated.length))
                         message.uint64Repeated = [];
                     if ((tag & 7) === 2) {
@@ -236,21 +237,22 @@ $root.Message = (function() {
                         message.uint64Repeated.push(reader.uint64());
                     break;
                 }
-            case 5: {
+            case 42: {
                     message.bytesVal = reader.bytes();
                     break;
                 }
-            case 6: {
+            case 50: {
                     if (!(message.bytesRepeated && message.bytesRepeated.length))
                         message.bytesRepeated = [];
                     message.bytesRepeated.push(reader.bytes());
                     break;
                 }
-            case 7: {
+            case 56: {
                     message.enumVal = reader.int32();
                     break;
                 }
-            case 8: {
+            case 64:
+            case 66: {
                     if (!(message.enumRepeated && message.enumRepeated.length))
                         message.enumRepeated = [];
                     if ((tag & 7) === 2) {
@@ -261,7 +263,7 @@ $root.Message = (function() {
                         message.enumRepeated.push(reader.int32());
                     break;
                 }
-            case 9: {
+            case 74: {
                     if (message.int64Map === $util.emptyObject)
                         message.int64Map = {};
                     var end2 = reader.uint32() + reader.pos;
@@ -269,11 +271,11 @@ $root.Message = (function() {
                     value = 0;
                     while (reader.pos < end2) {
                         var tag2 = reader.uint32();
-                        switch (tag2 >>> 3) {
-                        case 1:
+                        switch (tag2) {
+                        case 10:
                             key = reader.string();
                             break;
-                        case 2:
+                        case 16:
                             value = reader.int64();
                             break;
                         default:

--- a/tests/data/mapbox/vector_tile.js
+++ b/tests/data/mapbox/vector_tile.js
@@ -117,8 +117,8 @@ $root.vector_tile = (function() {
                 var tag = reader.uint32();
                 if (tag === error)
                     break;
-                switch (tag >>> 3) {
-                case 3: {
+                switch (tag) {
+                case 26: {
                         if (!(message.layers && message.layers.length))
                             message.layers = [];
                         message.layers.push($root.vector_tile.Tile.Layer.decode(reader, reader.uint32(), undefined, long + 1));
@@ -434,32 +434,32 @@ $root.vector_tile = (function() {
                     var tag = reader.uint32();
                     if (tag === error)
                         break;
-                    switch (tag >>> 3) {
-                    case 1: {
+                    switch (tag) {
+                    case 10: {
                             message.stringValue = reader.string();
                             break;
                         }
-                    case 2: {
+                    case 21: {
                             message.floatValue = reader.float();
                             break;
                         }
-                    case 3: {
+                    case 25: {
                             message.doubleValue = reader.double();
                             break;
                         }
-                    case 4: {
+                    case 32: {
                             message.intValue = reader.int64();
                             break;
                         }
-                    case 5: {
+                    case 40: {
                             message.uintValue = reader.uint64();
                             break;
                         }
-                    case 6: {
+                    case 48: {
                             message.sintValue = reader.sint64();
                             break;
                         }
-                    case 7: {
+                    case 56: {
                             message.boolValue = reader.bool();
                             break;
                         }
@@ -809,12 +809,13 @@ $root.vector_tile = (function() {
                     var tag = reader.uint32();
                     if (tag === error)
                         break;
-                    switch (tag >>> 3) {
-                    case 1: {
+                    switch (tag) {
+                    case 8: {
                             message.id = reader.uint64();
                             break;
                         }
-                    case 2: {
+                    case 16:
+                    case 18: {
                             if (!(message.tags && message.tags.length))
                                 message.tags = [];
                             if ((tag & 7) === 2) {
@@ -825,11 +826,12 @@ $root.vector_tile = (function() {
                                 message.tags.push(reader.uint32());
                             break;
                         }
-                    case 3: {
+                    case 24: {
                             message.type = reader.int32();
                             break;
                         }
-                    case 4: {
+                    case 32:
+                    case 34: {
                             if (!(message.geometry && message.geometry.length))
                                 message.geometry = [];
                             if ((tag & 7) === 2) {
@@ -1205,34 +1207,34 @@ $root.vector_tile = (function() {
                     var tag = reader.uint32();
                     if (tag === error)
                         break;
-                    switch (tag >>> 3) {
-                    case 15: {
+                    switch (tag) {
+                    case 120: {
                             message.version = reader.uint32();
                             break;
                         }
-                    case 1: {
+                    case 10: {
                             message.name = reader.string();
                             break;
                         }
-                    case 2: {
+                    case 18: {
                             if (!(message.features && message.features.length))
                                 message.features = [];
                             message.features.push($root.vector_tile.Tile.Feature.decode(reader, reader.uint32(), undefined, long + 1));
                             break;
                         }
-                    case 3: {
+                    case 26: {
                             if (!(message.keys && message.keys.length))
                                 message.keys = [];
                             message.keys.push(reader.string());
                             break;
                         }
-                    case 4: {
+                    case 34: {
                             if (!(message.values && message.values.length))
                                 message.values = [];
                             message.values.push($root.vector_tile.Tile.Value.decode(reader, reader.uint32(), undefined, long + 1));
                             break;
                         }
-                    case 5: {
+                    case 40: {
                             message.extent = reader.uint32();
                             break;
                         }

--- a/tests/data/package.js
+++ b/tests/data/package.js
@@ -294,54 +294,54 @@ $root.Package = (function() {
             var tag = reader.uint32();
             if (tag === error)
                 break;
-            switch (tag >>> 3) {
-            case 1: {
+            switch (tag) {
+            case 10: {
                     message.name = reader.string();
                     break;
                 }
-            case 2: {
+            case 18: {
                     message.version = reader.string();
                     break;
                 }
-            case 19: {
+            case 154: {
                     message.versionScheme = reader.string();
                     break;
                 }
-            case 3: {
+            case 26: {
                     message.description = reader.string();
                     break;
                 }
-            case 4: {
+            case 34: {
                     message.author = reader.string();
                     break;
                 }
-            case 5: {
+            case 42: {
                     message.license = reader.string();
                     break;
                 }
-            case 6: {
+            case 50: {
                     message.repository = $root.Package.Repository.decode(reader, reader.uint32(), undefined, long + 1);
                     break;
                 }
-            case 7: {
+            case 58: {
                     message.bugs = reader.string();
                     break;
                 }
-            case 8: {
+            case 66: {
                     message.homepage = reader.string();
                     break;
                 }
-            case 9: {
+            case 74: {
                     if (!(message.keywords && message.keywords.length))
                         message.keywords = [];
                     message.keywords.push(reader.string());
                     break;
                 }
-            case 10: {
+            case 82: {
                     message.main = reader.string();
                     break;
                 }
-            case 11: {
+            case 90: {
                     if (message.bin === $util.emptyObject)
                         message.bin = {};
                     var end2 = reader.uint32() + reader.pos;
@@ -349,11 +349,11 @@ $root.Package = (function() {
                     value = "";
                     while (reader.pos < end2) {
                         var tag2 = reader.uint32();
-                        switch (tag2 >>> 3) {
-                        case 1:
+                        switch (tag2) {
+                        case 10:
                             key = reader.string();
                             break;
-                        case 2:
+                        case 18:
                             value = reader.string();
                             break;
                         default:
@@ -366,7 +366,7 @@ $root.Package = (function() {
                     message.bin[key] = value;
                     break;
                 }
-            case 12: {
+            case 98: {
                     if (message.scripts === $util.emptyObject)
                         message.scripts = {};
                     var end2 = reader.uint32() + reader.pos;
@@ -374,11 +374,11 @@ $root.Package = (function() {
                     value = "";
                     while (reader.pos < end2) {
                         var tag2 = reader.uint32();
-                        switch (tag2 >>> 3) {
-                        case 1:
+                        switch (tag2) {
+                        case 10:
                             key = reader.string();
                             break;
-                        case 2:
+                        case 18:
                             value = reader.string();
                             break;
                         default:
@@ -391,7 +391,7 @@ $root.Package = (function() {
                     message.scripts[key] = value;
                     break;
                 }
-            case 13: {
+            case 106: {
                     if (message.dependencies === $util.emptyObject)
                         message.dependencies = {};
                     var end2 = reader.uint32() + reader.pos;
@@ -399,11 +399,11 @@ $root.Package = (function() {
                     value = "";
                     while (reader.pos < end2) {
                         var tag2 = reader.uint32();
-                        switch (tag2 >>> 3) {
-                        case 1:
+                        switch (tag2) {
+                        case 10:
                             key = reader.string();
                             break;
-                        case 2:
+                        case 18:
                             value = reader.string();
                             break;
                         default:
@@ -416,7 +416,7 @@ $root.Package = (function() {
                     message.dependencies[key] = value;
                     break;
                 }
-            case 15: {
+            case 122: {
                     if (message.devDependencies === $util.emptyObject)
                         message.devDependencies = {};
                     var end2 = reader.uint32() + reader.pos;
@@ -424,11 +424,11 @@ $root.Package = (function() {
                     value = "";
                     while (reader.pos < end2) {
                         var tag2 = reader.uint32();
-                        switch (tag2 >>> 3) {
-                        case 1:
+                        switch (tag2) {
+                        case 10:
                             key = reader.string();
                             break;
-                        case 2:
+                        case 18:
                             value = reader.string();
                             break;
                         default:
@@ -441,11 +441,11 @@ $root.Package = (function() {
                     message.devDependencies[key] = value;
                     break;
                 }
-            case 17: {
+            case 138: {
                     message.types = reader.string();
                     break;
                 }
-            case 18: {
+            case 146: {
                     if (!(message.cliDependencies && message.cliDependencies.length))
                         message.cliDependencies = [];
                     message.cliDependencies.push(reader.string());
@@ -910,12 +910,12 @@ $root.Package = (function() {
                 var tag = reader.uint32();
                 if (tag === error)
                     break;
-                switch (tag >>> 3) {
-                case 1: {
+                switch (tag) {
+                case 10: {
                         message.type = reader.string();
                         break;
                     }
-                case 2: {
+                case 18: {
                         message.url = reader.string();
                         break;
                     }

--- a/tests/data/rpc-es6.js
+++ b/tests/data/rpc-es6.js
@@ -172,8 +172,8 @@ export const MyRequest = $root.MyRequest = (() => {
             let tag = reader.uint32();
             if (tag === error)
                 break;
-            switch (tag >>> 3) {
-            case 1: {
+            switch (tag) {
+            case 10: {
                     message.path = reader.string();
                     break;
                 }
@@ -389,8 +389,8 @@ export const MyResponse = $root.MyResponse = (() => {
             let tag = reader.uint32();
             if (tag === error)
                 break;
-            switch (tag >>> 3) {
-            case 2: {
+            switch (tag) {
+            case 16: {
                     message.status = reader.int32();
                     break;
                 }

--- a/tests/data/rpc-reserved.js
+++ b/tests/data/rpc-reserved.js
@@ -174,8 +174,8 @@ $root.MyRequest = (function() {
             var tag = reader.uint32();
             if (tag === error)
                 break;
-            switch (tag >>> 3) {
-            case 1: {
+            switch (tag) {
+            case 10: {
                     message.path = reader.string();
                     break;
                 }
@@ -391,8 +391,8 @@ $root.MyResponse = (function() {
             var tag = reader.uint32();
             if (tag === error)
                 break;
-            switch (tag >>> 3) {
-            case 2: {
+            switch (tag) {
+            case 16: {
                     message.status = reader.int32();
                     break;
                 }

--- a/tests/data/rpc.js
+++ b/tests/data/rpc.js
@@ -174,8 +174,8 @@ $root.MyRequest = (function() {
             var tag = reader.uint32();
             if (tag === error)
                 break;
-            switch (tag >>> 3) {
-            case 1: {
+            switch (tag) {
+            case 10: {
                     message.path = reader.string();
                     break;
                 }
@@ -391,8 +391,8 @@ $root.MyResponse = (function() {
             var tag = reader.uint32();
             if (tag === error)
                 break;
-            switch (tag >>> 3) {
-            case 2: {
+            switch (tag) {
+            case 16: {
                     message.status = reader.int32();
                     break;
                 }

--- a/tests/data/test.js
+++ b/tests/data/test.js
@@ -113,7 +113,7 @@ $root.jspb = (function() {
                     var tag = reader.uint32();
                     if (tag === error)
                         break;
-                    switch (tag >>> 3) {
+                    switch (tag) {
                     default:
                         reader.skipType(tag & 7, long);
                         break;
@@ -327,8 +327,8 @@ $root.jspb = (function() {
                     var tag = reader.uint32();
                     if (tag === error)
                         break;
-                    switch (tag >>> 3) {
-                    case 1: {
+                    switch (tag) {
+                    case 8: {
                             message.outerEnum = reader.int32();
                             break;
                         }
@@ -586,18 +586,18 @@ $root.jspb = (function() {
                     var tag = reader.uint32();
                     if (tag === error)
                         break;
-                    switch (tag >>> 3) {
-                    case 1: {
+                    switch (tag) {
+                    case 10: {
                             message.aString = reader.string();
                             break;
                         }
-                    case 2: {
+                    case 18: {
                             if (!(message.aRepeatedString && message.aRepeatedString.length))
                                 message.aRepeatedString = [];
                             message.aRepeatedString.push(reader.string());
                             break;
                         }
-                    case 3: {
+                    case 24: {
                             message.aBoolean = reader.bool();
                             break;
                         }
@@ -856,12 +856,12 @@ $root.jspb = (function() {
                     var tag = reader.uint32();
                     if (tag === error)
                         break;
-                    switch (tag >>> 3) {
-                    case 1: {
+                    switch (tag) {
+                    case 10: {
                             message.aString = reader.string();
                             break;
                         }
-                    case 2: {
+                    case 18: {
                             if (!(message.aRepeatedString && message.aRepeatedString.length))
                                 message.aRepeatedString = [];
                             message.aRepeatedString.push(reader.string());
@@ -1130,20 +1130,20 @@ $root.jspb = (function() {
                     var tag = reader.uint32();
                     if (tag === error)
                         break;
-                    switch (tag >>> 3) {
-                    case 1: {
+                    switch (tag) {
+                    case 10: {
                             message.normal = reader.string();
                             break;
                         }
-                    case 2: {
+                    case 18: {
                             message["default"] = reader.string();
                             break;
                         }
-                    case 3: {
+                    case 26: {
                             message["function"] = reader.string();
                             break;
                         }
-                    case 4: {
+                    case 34: {
                             message["var"] = reader.string();
                             break;
                         }
@@ -1435,26 +1435,26 @@ $root.jspb = (function() {
                     var tag = reader.uint32();
                     if (tag === error)
                         break;
-                    switch (tag >>> 3) {
-                    case 1: {
+                    switch (tag) {
+                    case 10: {
                             message.aString = reader.string();
                             break;
                         }
-                    case 2: {
+                    case 16: {
                             message.aBool = reader.bool();
                             break;
                         }
-                    case 3: {
+                    case 26: {
                             message.aNestedMessage = $root.jspb.test.OptionalFields.Nested.decode(reader, reader.uint32(), undefined, long + 1);
                             break;
                         }
-                    case 4: {
+                    case 34: {
                             if (!(message.aRepeatedMessage && message.aRepeatedMessage.length))
                                 message.aRepeatedMessage = [];
                             message.aRepeatedMessage.push($root.jspb.test.OptionalFields.Nested.decode(reader, reader.uint32(), undefined, long + 1));
                             break;
                         }
-                    case 5: {
+                    case 42: {
                             if (!(message.aRepeatedString && message.aRepeatedString.length))
                                 message.aRepeatedString = [];
                             message.aRepeatedString.push(reader.string());
@@ -1739,8 +1739,8 @@ $root.jspb = (function() {
                         var tag = reader.uint32();
                         if (tag === error)
                             break;
-                        switch (tag >>> 3) {
-                        case 1: {
+                        switch (tag) {
+                        case 8: {
                                 message.anInt = reader.int32();
                                 break;
                             }
@@ -2051,44 +2051,44 @@ $root.jspb = (function() {
                     var tag = reader.uint32();
                     if (tag === error)
                         break;
-                    switch (tag >>> 3) {
-                    case 1: {
+                    switch (tag) {
+                    case 10: {
                             message.str1 = reader.string();
                             break;
                         }
-                    case 2: {
+                    case 18: {
                             message.str2 = reader.string();
                             break;
                         }
-                    case 3: {
+                    case 26: {
                             message.str3 = reader.string();
                             break;
                         }
-                    case 100: {
+                    case 802: {
                             message[".jspb.test.IsExtension.extField"] = $root.jspb.test.IsExtension.decode(reader, reader.uint32(), undefined, long + 1);
                             break;
                         }
-                    case 101: {
+                    case 810: {
                             message[".jspb.test.IndirectExtension.simple"] = $root.jspb.test.Simple1.decode(reader, reader.uint32(), undefined, long + 1);
                             break;
                         }
-                    case 102: {
+                    case 818: {
                             message[".jspb.test.IndirectExtension.str"] = reader.string();
                             break;
                         }
-                    case 103: {
+                    case 826: {
                             if (!(message[".jspb.test.IndirectExtension.repeatedStr"] && message[".jspb.test.IndirectExtension.repeatedStr"].length))
                                 message[".jspb.test.IndirectExtension.repeatedStr"] = [];
                             message[".jspb.test.IndirectExtension.repeatedStr"].push(reader.string());
                             break;
                         }
-                    case 104: {
+                    case 834: {
                             if (!(message[".jspb.test.IndirectExtension.repeatedSimple"] && message[".jspb.test.IndirectExtension.repeatedSimple"].length))
                                 message[".jspb.test.IndirectExtension.repeatedSimple"] = [];
                             message[".jspb.test.IndirectExtension.repeatedSimple"].push($root.jspb.test.Simple1.decode(reader, reader.uint32(), undefined, long + 1));
                             break;
                         }
-                    case 105: {
+                    case 842: {
                             message[".jspb.test.simple1"] = $root.jspb.test.Simple1.decode(reader, reader.uint32(), undefined, long + 1);
                             break;
                         }
@@ -2461,26 +2461,26 @@ $root.jspb = (function() {
                     var tag = reader.uint32();
                     if (tag === error)
                         break;
-                    switch (tag >>> 3) {
-                    case 1: {
+                    switch (tag) {
+                    case 10: {
                             message.aString = reader.string();
                             break;
                         }
-                    case 9: {
+                    case 72: {
                             message.anOutOfOrderBool = reader.bool();
                             break;
                         }
-                    case 4: {
+                    case 34: {
                             message.aNestedMessage = $root.jspb.test.Complex.Nested.decode(reader, reader.uint32(), undefined, long + 1);
                             break;
                         }
-                    case 5: {
+                    case 42: {
                             if (!(message.aRepeatedMessage && message.aRepeatedMessage.length))
                                 message.aRepeatedMessage = [];
                             message.aRepeatedMessage.push($root.jspb.test.Complex.Nested.decode(reader, reader.uint32(), undefined, long + 1));
                             break;
                         }
-                    case 7: {
+                    case 58: {
                             if (!(message.aRepeatedString && message.aRepeatedString.length))
                                 message.aRepeatedString = [];
                             message.aRepeatedString.push(reader.string());
@@ -2765,8 +2765,8 @@ $root.jspb = (function() {
                         var tag = reader.uint32();
                         if (tag === error)
                             break;
-                        switch (tag >>> 3) {
-                        case 2: {
+                        switch (tag) {
+                        case 16: {
                                 message.anInt = reader.int32();
                                 break;
                             }
@@ -2975,7 +2975,7 @@ $root.jspb = (function() {
                     var tag = reader.uint32();
                     if (tag === error)
                         break;
-                    switch (tag >>> 3) {
+                    switch (tag) {
                     default:
                         reader.skipType(tag & 7, long);
                         break;
@@ -3172,8 +3172,8 @@ $root.jspb = (function() {
                         var tag = reader.uint32();
                         if (tag === error)
                             break;
-                        switch (tag >>> 3) {
-                        case 1: {
+                        switch (tag) {
+                        case 8: {
                                 message.innerComplexField = reader.int32();
                                 break;
                             }
@@ -3392,8 +3392,8 @@ $root.jspb = (function() {
                     var tag = reader.uint32();
                     if (tag === error)
                         break;
-                    switch (tag >>> 3) {
-                    case 1: {
+                    switch (tag) {
+                    case 10: {
                             message.ext1 = reader.string();
                             break;
                         }
@@ -3598,7 +3598,7 @@ $root.jspb = (function() {
                     var tag = reader.uint32();
                     if (tag === error)
                         break;
-                    switch (tag >>> 3) {
+                    switch (tag) {
                     default:
                         reader.skipType(tag & 7, long);
                         break;
@@ -3853,28 +3853,28 @@ $root.jspb = (function() {
                     var tag = reader.uint32();
                     if (tag === error)
                         break;
-                    switch (tag >>> 3) {
-                    case 1: {
+                    switch (tag) {
+                    case 10: {
                             message.stringField = reader.string();
                             break;
                         }
-                    case 2: {
+                    case 16: {
                             message.boolField = reader.bool();
                             break;
                         }
-                    case 3: {
+                    case 24: {
                             message.intField = reader.int64();
                             break;
                         }
-                    case 4: {
+                    case 32: {
                             message.enumField = reader.int32();
                             break;
                         }
-                    case 6: {
+                    case 50: {
                             message.emptyField = reader.string();
                             break;
                         }
-                    case 8: {
+                    case 66: {
                             message.bytesField = reader.bytes();
                             break;
                         }
@@ -4270,16 +4270,17 @@ $root.jspb = (function() {
                     var tag = reader.uint32();
                     if (tag === error)
                         break;
-                    switch (tag >>> 3) {
-                    case 1: {
+                    switch (tag) {
+                    case 13: {
                             message.optionalFloatField = reader.float();
                             break;
                         }
-                    case 2: {
+                    case 21: {
                             message.requiredFloatField = reader.float();
                             break;
                         }
-                    case 3: {
+                    case 29:
+                    case 26: {
                             if (!(message.repeatedFloatField && message.repeatedFloatField.length))
                                 message.repeatedFloatField = [];
                             if ((tag & 7) === 2) {
@@ -4290,19 +4291,20 @@ $root.jspb = (function() {
                                 message.repeatedFloatField.push(reader.float());
                             break;
                         }
-                    case 4: {
+                    case 37: {
                             message.defaultFloatField = reader.float();
                             break;
                         }
-                    case 5: {
+                    case 41: {
                             message.optionalDoubleField = reader.double();
                             break;
                         }
-                    case 6: {
+                    case 49: {
                             message.requiredDoubleField = reader.double();
                             break;
                         }
-                    case 7: {
+                    case 57:
+                    case 58: {
                             if (!(message.repeatedDoubleField && message.repeatedDoubleField.length))
                                 message.repeatedDoubleField = [];
                             if ((tag & 7) === 2) {
@@ -4313,7 +4315,7 @@ $root.jspb = (function() {
                                 message.repeatedDoubleField.push(reader.double());
                             break;
                         }
-                    case 8: {
+                    case 65: {
                             message.defaultDoubleField = reader.double();
                             break;
                         }
@@ -4671,30 +4673,30 @@ $root.jspb = (function() {
                     var tag = reader.uint32();
                     if (tag === error)
                         break;
-                    switch (tag >>> 3) {
-                    case 1: {
+                    switch (tag) {
+                    case 10: {
                             message.str = reader.string();
                             break;
                         }
-                    case 3: {
+                    case 26: {
                             message.simple1 = $root.jspb.test.Simple1.decode(reader, reader.uint32(), undefined, long + 1);
                             break;
                         }
-                    case 5: {
+                    case 42: {
                             if (!(message.simple2 && message.simple2.length))
                                 message.simple2 = [];
                             message.simple2.push($root.jspb.test.Simple1.decode(reader, reader.uint32(), undefined, long + 1));
                             break;
                         }
-                    case 6: {
+                    case 50: {
                             message.bytesField = reader.bytes();
                             break;
                         }
-                    case 7: {
+                    case 58: {
                             message.unused = reader.string();
                             break;
                         }
-                    case 100: {
+                    case 802: {
                             message[".jspb.test.CloneExtension.extField"] = $root.jspb.test.CloneExtension.decode(reader, reader.uint32(), undefined, long + 1);
                             break;
                         }
@@ -4988,8 +4990,8 @@ $root.jspb = (function() {
                     var tag = reader.uint32();
                     if (tag === error)
                         break;
-                    switch (tag >>> 3) {
-                    case 2: {
+                    switch (tag) {
+                    case 18: {
                             message.ext = reader.string();
                             break;
                         }
@@ -5282,38 +5284,38 @@ $root.jspb = (function() {
                     var tag = reader.uint32();
                     if (tag === error)
                         break;
-                    switch (tag >>> 3) {
-                    case 1: {
+                    switch (tag) {
+                    case 11: {
                             if (!(message.repeatedGroup && message.repeatedGroup.length))
                                 message.repeatedGroup = [];
-                            message.repeatedGroup.push($root.jspb.test.TestGroup.RepeatedGroup.decode(reader, undefined, tag & ~7 | 4, long + 1));
+                            message.repeatedGroup.push($root.jspb.test.TestGroup.RepeatedGroup.decode(reader, undefined, 12, long + 1));
                             break;
                         }
-                    case 2: {
-                            message.requiredGroup = $root.jspb.test.TestGroup.RequiredGroup.decode(reader, undefined, tag & ~7 | 4, long + 1);
+                    case 19: {
+                            message.requiredGroup = $root.jspb.test.TestGroup.RequiredGroup.decode(reader, undefined, 20, long + 1);
                             break;
                         }
-                    case 3: {
-                            message.optionalGroup = $root.jspb.test.TestGroup.OptionalGroup.decode(reader, undefined, tag & ~7 | 4, long + 1);
+                    case 27: {
+                            message.optionalGroup = $root.jspb.test.TestGroup.OptionalGroup.decode(reader, undefined, 28, long + 1);
                             break;
                         }
-                    case 4: {
-                            message.messageInGroup = $root.jspb.test.TestGroup.MessageInGroup.decode(reader, undefined, tag & ~7 | 4, long + 1);
+                    case 35: {
+                            message.messageInGroup = $root.jspb.test.TestGroup.MessageInGroup.decode(reader, undefined, 36, long + 1);
                             break;
                         }
-                    case 5: {
-                            message.enumInGroup = $root.jspb.test.TestGroup.EnumInGroup.decode(reader, undefined, tag & ~7 | 4, long + 1);
+                    case 43: {
+                            message.enumInGroup = $root.jspb.test.TestGroup.EnumInGroup.decode(reader, undefined, 44, long + 1);
                             break;
                         }
-                    case 6: {
+                    case 50: {
                             message.id = reader.string();
                             break;
                         }
-                    case 7: {
+                    case 58: {
                             message.requiredSimple = $root.jspb.test.Simple2.decode(reader, reader.uint32(), undefined, long + 1);
                             break;
                         }
-                    case 8: {
+                    case 66: {
                             message.optionalSimple = $root.jspb.test.Simple2.decode(reader, reader.uint32(), undefined, long + 1);
                             break;
                         }
@@ -5647,12 +5649,13 @@ $root.jspb = (function() {
                         var tag = reader.uint32();
                         if (tag === error)
                             break;
-                        switch (tag >>> 3) {
-                        case 1: {
+                        switch (tag) {
+                        case 10: {
                                 message.id = reader.string();
                                 break;
                             }
-                        case 2: {
+                        case 16:
+                        case 18: {
                                 if (!(message.someBool && message.someBool.length))
                                     message.someBool = [];
                                 if ((tag & 7) === 2) {
@@ -5896,8 +5899,8 @@ $root.jspb = (function() {
                         var tag = reader.uint32();
                         if (tag === error)
                             break;
-                        switch (tag >>> 3) {
-                        case 1: {
+                        switch (tag) {
+                        case 10: {
                                 message.id = reader.string();
                                 break;
                             }
@@ -6113,8 +6116,8 @@ $root.jspb = (function() {
                         var tag = reader.uint32();
                         if (tag === error)
                             break;
-                        switch (tag >>> 3) {
-                        case 1: {
+                        switch (tag) {
+                        case 10: {
                                 message.id = reader.string();
                                 break;
                             }
@@ -6330,8 +6333,8 @@ $root.jspb = (function() {
                         var tag = reader.uint32();
                         if (tag === error)
                             break;
-                        switch (tag >>> 3) {
-                        case 1: {
+                        switch (tag) {
+                        case 10: {
                                 message.id = $root.jspb.test.TestGroup.MessageInGroup.NestedMessage.decode(reader, reader.uint32(), undefined, long + 1);
                                 break;
                             }
@@ -6551,8 +6554,8 @@ $root.jspb = (function() {
                             var tag = reader.uint32();
                             if (tag === error)
                                 break;
-                            switch (tag >>> 3) {
-                            case 1: {
+                            switch (tag) {
+                            case 10: {
                                     message.id = reader.string();
                                     break;
                                 }
@@ -6770,8 +6773,8 @@ $root.jspb = (function() {
                         var tag = reader.uint32();
                         if (tag === error)
                             break;
-                        switch (tag >>> 3) {
-                        case 1: {
+                        switch (tag) {
+                        case 8: {
                                 message.id = reader.int32();
                                 break;
                             }
@@ -7024,8 +7027,8 @@ $root.jspb = (function() {
                     var tag = reader.uint32();
                     if (tag === error)
                         break;
-                    switch (tag >>> 3) {
-                    case 1: {
+                    switch (tag) {
+                    case 10: {
                             message.group = $root.jspb.test.TestGroup.RepeatedGroup.decode(reader, reader.uint32(), undefined, long + 1);
                             break;
                         }
@@ -7257,12 +7260,12 @@ $root.jspb = (function() {
                     var tag = reader.uint32();
                     if (tag === error)
                         break;
-                    switch (tag >>> 3) {
-                    case 1: {
+                    switch (tag) {
+                    case 8: {
                             message.extension = reader.int32();
                             break;
                         }
-                    case 10: {
+                    case 80: {
                             message[".jspb.test.TestReservedNamesExtension.foo"] = reader.int32();
                             break;
                         }
@@ -7476,7 +7479,7 @@ $root.jspb = (function() {
                     var tag = reader.uint32();
                     if (tag === error)
                         break;
-                    switch (tag >>> 3) {
+                    switch (tag) {
                     default:
                         reader.skipType(tag & 7, long);
                         break;
@@ -7824,53 +7827,53 @@ $root.jspb = (function() {
                     var tag = reader.uint32();
                     if (tag === error)
                         break;
-                    switch (tag >>> 3) {
-                    case 3: {
+                    switch (tag) {
+                    case 26: {
                             message.pone = reader.string();
                             message.partialOneof = "pone";
                             break;
                         }
-                    case 5: {
+                    case 42: {
                             message.pthree = reader.string();
                             message.partialOneof = "pthree";
                             break;
                         }
-                    case 6: {
+                    case 50: {
                             message.rone = $root.jspb.test.TestMessageWithOneof.decode(reader, reader.uint32(), undefined, long + 1);
                             message.recursiveOneof = "rone";
                             break;
                         }
-                    case 7: {
+                    case 58: {
                             message.rtwo = reader.string();
                             message.recursiveOneof = "rtwo";
                             break;
                         }
-                    case 8: {
+                    case 64: {
                             message.normalField = reader.bool();
                             break;
                         }
-                    case 9: {
+                    case 74: {
                             if (!(message.repeatedField && message.repeatedField.length))
                                 message.repeatedField = [];
                             message.repeatedField.push(reader.string());
                             break;
                         }
-                    case 10: {
+                    case 80: {
                             message.aone = reader.int32();
                             message.defaultOneofA = "aone";
                             break;
                         }
-                    case 11: {
+                    case 88: {
                             message.atwo = reader.int32();
                             message.defaultOneofA = "atwo";
                             break;
                         }
-                    case 12: {
+                    case 96: {
                             message.bone = reader.int32();
                             message.defaultOneofB = "bone";
                             break;
                         }
-                    case 13: {
+                    case 104: {
                             message.btwo = reader.int32();
                             message.defaultOneofB = "btwo";
                             break;
@@ -8230,12 +8233,12 @@ $root.jspb = (function() {
                     var tag = reader.uint32();
                     if (tag === error)
                         break;
-                    switch (tag >>> 3) {
-                    case 1: {
+                    switch (tag) {
+                    case 8: {
                             message.value = reader.int32();
                             break;
                         }
-                    case 2: {
+                    case 18: {
                             message.data = reader.bytes();
                             break;
                         }
@@ -8616,8 +8619,8 @@ $root.jspb = (function() {
                     var tag = reader.uint32();
                     if (tag === error)
                         break;
-                    switch (tag >>> 3) {
-                    case 1: {
+                    switch (tag) {
+                    case 10: {
                             if (message.mapStringString === $util.emptyObject)
                                 message.mapStringString = {};
                             var end2 = reader.uint32() + reader.pos;
@@ -8625,11 +8628,11 @@ $root.jspb = (function() {
                             value = "";
                             while (reader.pos < end2) {
                                 var tag2 = reader.uint32();
-                                switch (tag2 >>> 3) {
-                                case 1:
+                                switch (tag2) {
+                                case 10:
                                     key = reader.string();
                                     break;
-                                case 2:
+                                case 18:
                                     value = reader.string();
                                     break;
                                 default:
@@ -8642,7 +8645,7 @@ $root.jspb = (function() {
                             message.mapStringString[key] = value;
                             break;
                         }
-                    case 2: {
+                    case 18: {
                             if (message.mapStringInt32 === $util.emptyObject)
                                 message.mapStringInt32 = {};
                             var end2 = reader.uint32() + reader.pos;
@@ -8650,11 +8653,11 @@ $root.jspb = (function() {
                             value = 0;
                             while (reader.pos < end2) {
                                 var tag2 = reader.uint32();
-                                switch (tag2 >>> 3) {
-                                case 1:
+                                switch (tag2) {
+                                case 10:
                                     key = reader.string();
                                     break;
-                                case 2:
+                                case 16:
                                     value = reader.int32();
                                     break;
                                 default:
@@ -8667,7 +8670,7 @@ $root.jspb = (function() {
                             message.mapStringInt32[key] = value;
                             break;
                         }
-                    case 3: {
+                    case 26: {
                             if (message.mapStringInt64 === $util.emptyObject)
                                 message.mapStringInt64 = {};
                             var end2 = reader.uint32() + reader.pos;
@@ -8675,11 +8678,11 @@ $root.jspb = (function() {
                             value = 0;
                             while (reader.pos < end2) {
                                 var tag2 = reader.uint32();
-                                switch (tag2 >>> 3) {
-                                case 1:
+                                switch (tag2) {
+                                case 10:
                                     key = reader.string();
                                     break;
-                                case 2:
+                                case 16:
                                     value = reader.int64();
                                     break;
                                 default:
@@ -8692,7 +8695,7 @@ $root.jspb = (function() {
                             message.mapStringInt64[key] = value;
                             break;
                         }
-                    case 4: {
+                    case 34: {
                             if (message.mapStringBool === $util.emptyObject)
                                 message.mapStringBool = {};
                             var end2 = reader.uint32() + reader.pos;
@@ -8700,11 +8703,11 @@ $root.jspb = (function() {
                             value = false;
                             while (reader.pos < end2) {
                                 var tag2 = reader.uint32();
-                                switch (tag2 >>> 3) {
-                                case 1:
+                                switch (tag2) {
+                                case 10:
                                     key = reader.string();
                                     break;
-                                case 2:
+                                case 16:
                                     value = reader.bool();
                                     break;
                                 default:
@@ -8717,7 +8720,7 @@ $root.jspb = (function() {
                             message.mapStringBool[key] = value;
                             break;
                         }
-                    case 5: {
+                    case 42: {
                             if (message.mapStringDouble === $util.emptyObject)
                                 message.mapStringDouble = {};
                             var end2 = reader.uint32() + reader.pos;
@@ -8725,11 +8728,11 @@ $root.jspb = (function() {
                             value = 0;
                             while (reader.pos < end2) {
                                 var tag2 = reader.uint32();
-                                switch (tag2 >>> 3) {
-                                case 1:
+                                switch (tag2) {
+                                case 10:
                                     key = reader.string();
                                     break;
-                                case 2:
+                                case 17:
                                     value = reader.double();
                                     break;
                                 default:
@@ -8742,7 +8745,7 @@ $root.jspb = (function() {
                             message.mapStringDouble[key] = value;
                             break;
                         }
-                    case 6: {
+                    case 50: {
                             if (message.mapStringEnum === $util.emptyObject)
                                 message.mapStringEnum = {};
                             var end2 = reader.uint32() + reader.pos;
@@ -8750,11 +8753,11 @@ $root.jspb = (function() {
                             value = 0;
                             while (reader.pos < end2) {
                                 var tag2 = reader.uint32();
-                                switch (tag2 >>> 3) {
-                                case 1:
+                                switch (tag2) {
+                                case 10:
                                     key = reader.string();
                                     break;
-                                case 2:
+                                case 16:
                                     value = reader.int32();
                                     break;
                                 default:
@@ -8767,7 +8770,7 @@ $root.jspb = (function() {
                             message.mapStringEnum[key] = value;
                             break;
                         }
-                    case 7: {
+                    case 58: {
                             if (message.mapStringMsg === $util.emptyObject)
                                 message.mapStringMsg = {};
                             var end2 = reader.uint32() + reader.pos;
@@ -8775,11 +8778,11 @@ $root.jspb = (function() {
                             value = null;
                             while (reader.pos < end2) {
                                 var tag2 = reader.uint32();
-                                switch (tag2 >>> 3) {
-                                case 1:
+                                switch (tag2) {
+                                case 10:
                                     key = reader.string();
                                     break;
-                                case 2:
+                                case 18:
                                     value = $root.jspb.test.MapValueMessageNoBinary.decode(reader, reader.uint32(), undefined, long + 1);
                                     break;
                                 default:
@@ -8792,7 +8795,7 @@ $root.jspb = (function() {
                             message.mapStringMsg[key] = value;
                             break;
                         }
-                    case 8: {
+                    case 66: {
                             if (message.mapInt32String === $util.emptyObject)
                                 message.mapInt32String = {};
                             var end2 = reader.uint32() + reader.pos;
@@ -8800,11 +8803,11 @@ $root.jspb = (function() {
                             value = "";
                             while (reader.pos < end2) {
                                 var tag2 = reader.uint32();
-                                switch (tag2 >>> 3) {
-                                case 1:
+                                switch (tag2) {
+                                case 8:
                                     key = reader.int32();
                                     break;
-                                case 2:
+                                case 18:
                                     value = reader.string();
                                     break;
                                 default:
@@ -8815,7 +8818,7 @@ $root.jspb = (function() {
                             message.mapInt32String[key] = value;
                             break;
                         }
-                    case 9: {
+                    case 74: {
                             if (message.mapInt64String === $util.emptyObject)
                                 message.mapInt64String = {};
                             var end2 = reader.uint32() + reader.pos;
@@ -8823,11 +8826,11 @@ $root.jspb = (function() {
                             value = "";
                             while (reader.pos < end2) {
                                 var tag2 = reader.uint32();
-                                switch (tag2 >>> 3) {
-                                case 1:
+                                switch (tag2) {
+                                case 8:
                                     key = reader.int64();
                                     break;
-                                case 2:
+                                case 18:
                                     value = reader.string();
                                     break;
                                 default:
@@ -8838,7 +8841,7 @@ $root.jspb = (function() {
                             message.mapInt64String[typeof key === "object" ? $util.longToHash(key) : key] = value;
                             break;
                         }
-                    case 10: {
+                    case 82: {
                             if (message.mapBoolString === $util.emptyObject)
                                 message.mapBoolString = {};
                             var end2 = reader.uint32() + reader.pos;
@@ -8846,11 +8849,11 @@ $root.jspb = (function() {
                             value = "";
                             while (reader.pos < end2) {
                                 var tag2 = reader.uint32();
-                                switch (tag2 >>> 3) {
-                                case 1:
+                                switch (tag2) {
+                                case 8:
                                     key = reader.bool();
                                     break;
-                                case 2:
+                                case 18:
                                     value = reader.string();
                                     break;
                                 default:
@@ -8861,11 +8864,11 @@ $root.jspb = (function() {
                             message.mapBoolString[key] = value;
                             break;
                         }
-                    case 11: {
+                    case 90: {
                             message.testMapFields = $root.jspb.test.TestMapFieldsNoBinary.decode(reader, reader.uint32(), undefined, long + 1);
                             break;
                         }
-                    case 12: {
+                    case 98: {
                             if (message.mapStringTestmapfields === $util.emptyObject)
                                 message.mapStringTestmapfields = {};
                             var end2 = reader.uint32() + reader.pos;
@@ -8873,11 +8876,11 @@ $root.jspb = (function() {
                             value = null;
                             while (reader.pos < end2) {
                                 var tag2 = reader.uint32();
-                                switch (tag2 >>> 3) {
-                                case 1:
+                                switch (tag2) {
+                                case 10:
                                     key = reader.string();
                                     break;
-                                case 2:
+                                case 18:
                                     value = $root.jspb.test.TestMapFieldsNoBinary.decode(reader, reader.uint32(), undefined, long + 1);
                                     break;
                                 default:
@@ -9476,8 +9479,8 @@ $root.jspb = (function() {
                     var tag = reader.uint32();
                     if (tag === error)
                         break;
-                    switch (tag >>> 3) {
-                    case 1: {
+                    switch (tag) {
+                    case 8: {
                             message.foo = reader.int32();
                             break;
                         }
@@ -9682,7 +9685,7 @@ $root.jspb = (function() {
                     var tag = reader.uint32();
                     if (tag === error)
                         break;
-                    switch (tag >>> 3) {
+                    switch (tag) {
                     default:
                         reader.skipType(tag & 7, long);
                         break;
@@ -9868,7 +9871,7 @@ $root.jspb = (function() {
                         var tag = reader.uint32();
                         if (tag === error)
                             break;
-                        switch (tag >>> 3) {
+                        switch (tag) {
                         default:
                             reader.skipType(tag & 7, long);
                             break;
@@ -10065,8 +10068,8 @@ $root.jspb = (function() {
                             var tag = reader.uint32();
                             if (tag === error)
                                 break;
-                            switch (tag >>> 3) {
-                            case 1: {
+                            switch (tag) {
+                            case 8: {
                                     message.count = reader.int32();
                                     break;
                                 }
@@ -10314,8 +10317,8 @@ $root.google = (function() {
                     var tag = reader.uint32();
                     if (tag === error)
                         break;
-                    switch (tag >>> 3) {
-                    case 1: {
+                    switch (tag) {
+                    case 10: {
                             if (!(message.file && message.file.length))
                                 message.file = [];
                             message.file.push($root.google.protobuf.FileDescriptorProto.decode(reader, reader.uint32(), undefined, long + 1));
@@ -10743,22 +10746,23 @@ $root.google = (function() {
                     var tag = reader.uint32();
                     if (tag === error)
                         break;
-                    switch (tag >>> 3) {
-                    case 1: {
+                    switch (tag) {
+                    case 10: {
                             message.name = reader.string();
                             break;
                         }
-                    case 2: {
+                    case 18: {
                             message["package"] = reader.string();
                             break;
                         }
-                    case 3: {
+                    case 26: {
                             if (!(message.dependency && message.dependency.length))
                                 message.dependency = [];
                             message.dependency.push(reader.string());
                             break;
                         }
-                    case 10: {
+                    case 80:
+                    case 82: {
                             if (!(message.publicDependency && message.publicDependency.length))
                                 message.publicDependency = [];
                             if ((tag & 7) === 2) {
@@ -10769,7 +10773,8 @@ $root.google = (function() {
                                 message.publicDependency.push(reader.int32());
                             break;
                         }
-                    case 11: {
+                    case 88:
+                    case 90: {
                             if (!(message.weakDependency && message.weakDependency.length))
                                 message.weakDependency = [];
                             if ((tag & 7) === 2) {
@@ -10780,49 +10785,49 @@ $root.google = (function() {
                                 message.weakDependency.push(reader.int32());
                             break;
                         }
-                    case 15: {
+                    case 122: {
                             if (!(message.optionDependency && message.optionDependency.length))
                                 message.optionDependency = [];
                             message.optionDependency.push(reader.string());
                             break;
                         }
-                    case 4: {
+                    case 34: {
                             if (!(message.messageType && message.messageType.length))
                                 message.messageType = [];
                             message.messageType.push($root.google.protobuf.DescriptorProto.decode(reader, reader.uint32(), undefined, long + 1));
                             break;
                         }
-                    case 5: {
+                    case 42: {
                             if (!(message.enumType && message.enumType.length))
                                 message.enumType = [];
                             message.enumType.push($root.google.protobuf.EnumDescriptorProto.decode(reader, reader.uint32(), undefined, long + 1));
                             break;
                         }
-                    case 6: {
+                    case 50: {
                             if (!(message.service && message.service.length))
                                 message.service = [];
                             message.service.push($root.google.protobuf.ServiceDescriptorProto.decode(reader, reader.uint32(), undefined, long + 1));
                             break;
                         }
-                    case 7: {
+                    case 58: {
                             if (!(message.extension && message.extension.length))
                                 message.extension = [];
                             message.extension.push($root.google.protobuf.FieldDescriptorProto.decode(reader, reader.uint32(), undefined, long + 1));
                             break;
                         }
-                    case 8: {
+                    case 66: {
                             message.options = $root.google.protobuf.FileOptions.decode(reader, reader.uint32(), undefined, long + 1);
                             break;
                         }
-                    case 9: {
+                    case 74: {
                             message.sourceCodeInfo = $root.google.protobuf.SourceCodeInfo.decode(reader, reader.uint32(), undefined, long + 1);
                             break;
                         }
-                    case 12: {
+                    case 98: {
                             message.syntax = reader.string();
                             break;
                         }
-                    case 14: {
+                    case 112: {
                             message.edition = reader.int32();
                             break;
                         }
@@ -11466,64 +11471,64 @@ $root.google = (function() {
                     var tag = reader.uint32();
                     if (tag === error)
                         break;
-                    switch (tag >>> 3) {
-                    case 1: {
+                    switch (tag) {
+                    case 10: {
                             message.name = reader.string();
                             break;
                         }
-                    case 2: {
+                    case 18: {
                             if (!(message.field && message.field.length))
                                 message.field = [];
                             message.field.push($root.google.protobuf.FieldDescriptorProto.decode(reader, reader.uint32(), undefined, long + 1));
                             break;
                         }
-                    case 6: {
+                    case 50: {
                             if (!(message.extension && message.extension.length))
                                 message.extension = [];
                             message.extension.push($root.google.protobuf.FieldDescriptorProto.decode(reader, reader.uint32(), undefined, long + 1));
                             break;
                         }
-                    case 3: {
+                    case 26: {
                             if (!(message.nestedType && message.nestedType.length))
                                 message.nestedType = [];
                             message.nestedType.push($root.google.protobuf.DescriptorProto.decode(reader, reader.uint32(), undefined, long + 1));
                             break;
                         }
-                    case 4: {
+                    case 34: {
                             if (!(message.enumType && message.enumType.length))
                                 message.enumType = [];
                             message.enumType.push($root.google.protobuf.EnumDescriptorProto.decode(reader, reader.uint32(), undefined, long + 1));
                             break;
                         }
-                    case 5: {
+                    case 42: {
                             if (!(message.extensionRange && message.extensionRange.length))
                                 message.extensionRange = [];
                             message.extensionRange.push($root.google.protobuf.DescriptorProto.ExtensionRange.decode(reader, reader.uint32(), undefined, long + 1));
                             break;
                         }
-                    case 8: {
+                    case 66: {
                             if (!(message.oneofDecl && message.oneofDecl.length))
                                 message.oneofDecl = [];
                             message.oneofDecl.push($root.google.protobuf.OneofDescriptorProto.decode(reader, reader.uint32(), undefined, long + 1));
                             break;
                         }
-                    case 7: {
+                    case 58: {
                             message.options = $root.google.protobuf.MessageOptions.decode(reader, reader.uint32(), undefined, long + 1);
                             break;
                         }
-                    case 9: {
+                    case 74: {
                             if (!(message.reservedRange && message.reservedRange.length))
                                 message.reservedRange = [];
                             message.reservedRange.push($root.google.protobuf.DescriptorProto.ReservedRange.decode(reader, reader.uint32(), undefined, long + 1));
                             break;
                         }
-                    case 10: {
+                    case 82: {
                             if (!(message.reservedName && message.reservedName.length))
                                 message.reservedName = [];
                             message.reservedName.push(reader.string());
                             break;
                         }
-                    case 11: {
+                    case 88: {
                             message.visibility = reader.int32();
                             break;
                         }
@@ -12001,16 +12006,16 @@ $root.google = (function() {
                         var tag = reader.uint32();
                         if (tag === error)
                             break;
-                        switch (tag >>> 3) {
-                        case 1: {
+                        switch (tag) {
+                        case 8: {
                                 message.start = reader.int32();
                                 break;
                             }
-                        case 2: {
+                        case 16: {
                                 message.end = reader.int32();
                                 break;
                             }
-                        case 3: {
+                        case 26: {
                                 message.options = $root.google.protobuf.ExtensionRangeOptions.decode(reader, reader.uint32(), undefined, long + 1);
                                 break;
                             }
@@ -12259,12 +12264,12 @@ $root.google = (function() {
                         var tag = reader.uint32();
                         if (tag === error)
                             break;
-                        switch (tag >>> 3) {
-                        case 1: {
+                        switch (tag) {
+                        case 8: {
                                 message.start = reader.int32();
                                 break;
                             }
-                        case 2: {
+                        case 16: {
                                 message.end = reader.int32();
                                 break;
                             }
@@ -12529,24 +12534,24 @@ $root.google = (function() {
                     var tag = reader.uint32();
                     if (tag === error)
                         break;
-                    switch (tag >>> 3) {
-                    case 999: {
+                    switch (tag) {
+                    case 7994: {
                             if (!(message.uninterpretedOption && message.uninterpretedOption.length))
                                 message.uninterpretedOption = [];
                             message.uninterpretedOption.push($root.google.protobuf.UninterpretedOption.decode(reader, reader.uint32(), undefined, long + 1));
                             break;
                         }
-                    case 2: {
+                    case 18: {
                             if (!(message.declaration && message.declaration.length))
                                 message.declaration = [];
                             message.declaration.push($root.google.protobuf.ExtensionRangeOptions.Declaration.decode(reader, reader.uint32(), undefined, long + 1));
                             break;
                         }
-                    case 50: {
+                    case 402: {
                             message.features = $root.google.protobuf.FeatureSet.decode(reader, reader.uint32(), undefined, long + 1);
                             break;
                         }
-                    case 3: {
+                    case 24: {
                             message.verification = reader.int32();
                             break;
                         }
@@ -12888,24 +12893,24 @@ $root.google = (function() {
                         var tag = reader.uint32();
                         if (tag === error)
                             break;
-                        switch (tag >>> 3) {
-                        case 1: {
+                        switch (tag) {
+                        case 8: {
                                 message.number = reader.int32();
                                 break;
                             }
-                        case 2: {
+                        case 18: {
                                 message.fullName = reader.string();
                                 break;
                             }
-                        case 3: {
+                        case 26: {
                                 message.type = reader.string();
                                 break;
                             }
-                        case 5: {
+                        case 40: {
                                 message.reserved = reader.bool();
                                 break;
                             }
-                        case 6: {
+                        case 48: {
                                 message.repeated = reader.bool();
                                 break;
                             }
@@ -13281,48 +13286,48 @@ $root.google = (function() {
                     var tag = reader.uint32();
                     if (tag === error)
                         break;
-                    switch (tag >>> 3) {
-                    case 1: {
+                    switch (tag) {
+                    case 10: {
                             message.name = reader.string();
                             break;
                         }
-                    case 3: {
+                    case 24: {
                             message.number = reader.int32();
                             break;
                         }
-                    case 4: {
+                    case 32: {
                             message.label = reader.int32();
                             break;
                         }
-                    case 5: {
+                    case 40: {
                             message.type = reader.int32();
                             break;
                         }
-                    case 6: {
+                    case 50: {
                             message.typeName = reader.string();
                             break;
                         }
-                    case 2: {
+                    case 18: {
                             message.extendee = reader.string();
                             break;
                         }
-                    case 7: {
+                    case 58: {
                             message.defaultValue = reader.string();
                             break;
                         }
-                    case 9: {
+                    case 72: {
                             message.oneofIndex = reader.int32();
                             break;
                         }
-                    case 10: {
+                    case 82: {
                             message.jsonName = reader.string();
                             break;
                         }
-                    case 8: {
+                    case 66: {
                             message.options = $root.google.protobuf.FieldOptions.decode(reader, reader.uint32(), undefined, long + 1);
                             break;
                         }
-                    case 17: {
+                    case 136: {
                             message.proto3Optional = reader.bool();
                             break;
                         }
@@ -13820,12 +13825,12 @@ $root.google = (function() {
                     var tag = reader.uint32();
                     if (tag === error)
                         break;
-                    switch (tag >>> 3) {
-                    case 1: {
+                    switch (tag) {
+                    case 10: {
                             message.name = reader.string();
                             break;
                         }
-                    case 2: {
+                    case 18: {
                             message.options = $root.google.protobuf.OneofOptions.decode(reader, reader.uint32(), undefined, long + 1);
                             break;
                         }
@@ -14116,34 +14121,34 @@ $root.google = (function() {
                     var tag = reader.uint32();
                     if (tag === error)
                         break;
-                    switch (tag >>> 3) {
-                    case 1: {
+                    switch (tag) {
+                    case 10: {
                             message.name = reader.string();
                             break;
                         }
-                    case 2: {
+                    case 18: {
                             if (!(message.value && message.value.length))
                                 message.value = [];
                             message.value.push($root.google.protobuf.EnumValueDescriptorProto.decode(reader, reader.uint32(), undefined, long + 1));
                             break;
                         }
-                    case 3: {
+                    case 26: {
                             message.options = $root.google.protobuf.EnumOptions.decode(reader, reader.uint32(), undefined, long + 1);
                             break;
                         }
-                    case 4: {
+                    case 34: {
                             if (!(message.reservedRange && message.reservedRange.length))
                                 message.reservedRange = [];
                             message.reservedRange.push($root.google.protobuf.EnumDescriptorProto.EnumReservedRange.decode(reader, reader.uint32(), undefined, long + 1));
                             break;
                         }
-                    case 5: {
+                    case 42: {
                             if (!(message.reservedName && message.reservedName.length))
                                 message.reservedName = [];
                             message.reservedName.push(reader.string());
                             break;
                         }
-                    case 6: {
+                    case 48: {
                             message.visibility = reader.int32();
                             break;
                         }
@@ -14485,12 +14490,12 @@ $root.google = (function() {
                         var tag = reader.uint32();
                         if (tag === error)
                             break;
-                        switch (tag >>> 3) {
-                        case 1: {
+                        switch (tag) {
+                        case 8: {
                                 message.start = reader.int32();
                                 break;
                             }
-                        case 2: {
+                        case 16: {
                                 message.end = reader.int32();
                                 break;
                             }
@@ -14740,16 +14745,16 @@ $root.google = (function() {
                     var tag = reader.uint32();
                     if (tag === error)
                         break;
-                    switch (tag >>> 3) {
-                    case 1: {
+                    switch (tag) {
+                    case 10: {
                             message.name = reader.string();
                             break;
                         }
-                    case 2: {
+                    case 16: {
                             message.number = reader.int32();
                             break;
                         }
-                    case 3: {
+                    case 26: {
                             message.options = $root.google.protobuf.EnumValueOptions.decode(reader, reader.uint32(), undefined, long + 1);
                             break;
                         }
@@ -15011,18 +15016,18 @@ $root.google = (function() {
                     var tag = reader.uint32();
                     if (tag === error)
                         break;
-                    switch (tag >>> 3) {
-                    case 1: {
+                    switch (tag) {
+                    case 10: {
                             message.name = reader.string();
                             break;
                         }
-                    case 2: {
+                    case 18: {
                             if (!(message.method && message.method.length))
                                 message.method = [];
                             message.method.push($root.google.protobuf.MethodDescriptorProto.decode(reader, reader.uint32(), undefined, long + 1));
                             break;
                         }
-                    case 3: {
+                    case 26: {
                             message.options = $root.google.protobuf.ServiceOptions.decode(reader, reader.uint32(), undefined, long + 1);
                             break;
                         }
@@ -15333,28 +15338,28 @@ $root.google = (function() {
                     var tag = reader.uint32();
                     if (tag === error)
                         break;
-                    switch (tag >>> 3) {
-                    case 1: {
+                    switch (tag) {
+                    case 10: {
                             message.name = reader.string();
                             break;
                         }
-                    case 2: {
+                    case 18: {
                             message.inputType = reader.string();
                             break;
                         }
-                    case 3: {
+                    case 26: {
                             message.outputType = reader.string();
                             break;
                         }
-                    case 4: {
+                    case 34: {
                             message.options = $root.google.protobuf.MethodOptions.decode(reader, reader.uint32(), undefined, long + 1);
                             break;
                         }
-                    case 5: {
+                    case 40: {
                             message.clientStreaming = reader.bool();
                             break;
                         }
-                    case 6: {
+                    case 48: {
                             message.serverStreaming = reader.bool();
                             break;
                         }
@@ -15838,88 +15843,88 @@ $root.google = (function() {
                     var tag = reader.uint32();
                     if (tag === error)
                         break;
-                    switch (tag >>> 3) {
-                    case 1: {
+                    switch (tag) {
+                    case 10: {
                             message.javaPackage = reader.string();
                             break;
                         }
-                    case 8: {
+                    case 66: {
                             message.javaOuterClassname = reader.string();
                             break;
                         }
-                    case 10: {
+                    case 80: {
                             message.javaMultipleFiles = reader.bool();
                             break;
                         }
-                    case 20: {
+                    case 160: {
                             message.javaGenerateEqualsAndHash = reader.bool();
                             break;
                         }
-                    case 27: {
+                    case 216: {
                             message.javaStringCheckUtf8 = reader.bool();
                             break;
                         }
-                    case 9: {
+                    case 72: {
                             message.optimizeFor = reader.int32();
                             break;
                         }
-                    case 11: {
+                    case 90: {
                             message.goPackage = reader.string();
                             break;
                         }
-                    case 16: {
+                    case 128: {
                             message.ccGenericServices = reader.bool();
                             break;
                         }
-                    case 17: {
+                    case 136: {
                             message.javaGenericServices = reader.bool();
                             break;
                         }
-                    case 18: {
+                    case 144: {
                             message.pyGenericServices = reader.bool();
                             break;
                         }
-                    case 23: {
+                    case 184: {
                             message.deprecated = reader.bool();
                             break;
                         }
-                    case 31: {
+                    case 248: {
                             message.ccEnableArenas = reader.bool();
                             break;
                         }
-                    case 36: {
+                    case 290: {
                             message.objcClassPrefix = reader.string();
                             break;
                         }
-                    case 37: {
+                    case 298: {
                             message.csharpNamespace = reader.string();
                             break;
                         }
-                    case 39: {
+                    case 314: {
                             message.swiftPrefix = reader.string();
                             break;
                         }
-                    case 40: {
+                    case 322: {
                             message.phpClassPrefix = reader.string();
                             break;
                         }
-                    case 41: {
+                    case 330: {
                             message.phpNamespace = reader.string();
                             break;
                         }
-                    case 44: {
+                    case 354: {
                             message.phpMetadataNamespace = reader.string();
                             break;
                         }
-                    case 45: {
+                    case 362: {
                             message.rubyPackage = reader.string();
                             break;
                         }
-                    case 50: {
+                    case 402: {
                             message.features = $root.google.protobuf.FeatureSet.decode(reader, reader.uint32(), undefined, long + 1);
                             break;
                         }
-                    case 999: {
+                    case 7994: {
                             if (!(message.uninterpretedOption && message.uninterpretedOption.length))
                                 message.uninterpretedOption = [];
                             message.uninterpretedOption.push($root.google.protobuf.UninterpretedOption.decode(reader, reader.uint32(), undefined, long + 1));
@@ -16429,32 +16434,32 @@ $root.google = (function() {
                     var tag = reader.uint32();
                     if (tag === error)
                         break;
-                    switch (tag >>> 3) {
-                    case 1: {
+                    switch (tag) {
+                    case 8: {
                             message.messageSetWireFormat = reader.bool();
                             break;
                         }
-                    case 2: {
+                    case 16: {
                             message.noStandardDescriptorAccessor = reader.bool();
                             break;
                         }
-                    case 3: {
+                    case 24: {
                             message.deprecated = reader.bool();
                             break;
                         }
-                    case 7: {
+                    case 56: {
                             message.mapEntry = reader.bool();
                             break;
                         }
-                    case 11: {
+                    case 88: {
                             message.deprecatedLegacyJsonFieldConflicts = reader.bool();
                             break;
                         }
-                    case 12: {
+                    case 98: {
                             message.features = $root.google.protobuf.FeatureSet.decode(reader, reader.uint32(), undefined, long + 1);
                             break;
                         }
-                    case 999: {
+                    case 7994: {
                             if (!(message.uninterpretedOption && message.uninterpretedOption.length))
                                 message.uninterpretedOption = [];
                             message.uninterpretedOption.push($root.google.protobuf.UninterpretedOption.decode(reader, reader.uint32(), undefined, long + 1));
@@ -16893,44 +16898,45 @@ $root.google = (function() {
                     var tag = reader.uint32();
                     if (tag === error)
                         break;
-                    switch (tag >>> 3) {
-                    case 1: {
+                    switch (tag) {
+                    case 8: {
                             message.ctype = reader.int32();
                             break;
                         }
-                    case 2: {
+                    case 16: {
                             message.packed = reader.bool();
                             break;
                         }
-                    case 6: {
+                    case 48: {
                             message.jstype = reader.int32();
                             break;
                         }
-                    case 5: {
+                    case 40: {
                             message.lazy = reader.bool();
                             break;
                         }
-                    case 15: {
+                    case 120: {
                             message.unverifiedLazy = reader.bool();
                             break;
                         }
-                    case 3: {
+                    case 24: {
                             message.deprecated = reader.bool();
                             break;
                         }
-                    case 10: {
+                    case 80: {
                             message.weak = reader.bool();
                             break;
                         }
-                    case 16: {
+                    case 128: {
                             message.debugRedact = reader.bool();
                             break;
                         }
-                    case 17: {
+                    case 136: {
                             message.retention = reader.int32();
                             break;
                         }
-                    case 19: {
+                    case 152:
+                    case 154: {
                             if (!(message.targets && message.targets.length))
                                 message.targets = [];
                             if ((tag & 7) === 2) {
@@ -16941,21 +16947,21 @@ $root.google = (function() {
                                 message.targets.push(reader.int32());
                             break;
                         }
-                    case 20: {
+                    case 162: {
                             if (!(message.editionDefaults && message.editionDefaults.length))
                                 message.editionDefaults = [];
                             message.editionDefaults.push($root.google.protobuf.FieldOptions.EditionDefault.decode(reader, reader.uint32(), undefined, long + 1));
                             break;
                         }
-                    case 21: {
+                    case 170: {
                             message.features = $root.google.protobuf.FeatureSet.decode(reader, reader.uint32(), undefined, long + 1);
                             break;
                         }
-                    case 22: {
+                    case 178: {
                             message.featureSupport = $root.google.protobuf.FieldOptions.FeatureSupport.decode(reader, reader.uint32(), undefined, long + 1);
                             break;
                         }
-                    case 999: {
+                    case 7994: {
                             if (!(message.uninterpretedOption && message.uninterpretedOption.length))
                                 message.uninterpretedOption = [];
                             message.uninterpretedOption.push($root.google.protobuf.UninterpretedOption.decode(reader, reader.uint32(), undefined, long + 1));
@@ -17553,12 +17559,12 @@ $root.google = (function() {
                         var tag = reader.uint32();
                         if (tag === error)
                             break;
-                        switch (tag >>> 3) {
-                        case 3: {
+                        switch (tag) {
+                        case 24: {
                                 message.edition = reader.int32();
                                 break;
                             }
-                        case 2: {
+                        case 18: {
                                 message.value = reader.string();
                                 break;
                             }
@@ -17885,20 +17891,20 @@ $root.google = (function() {
                         var tag = reader.uint32();
                         if (tag === error)
                             break;
-                        switch (tag >>> 3) {
-                        case 1: {
+                        switch (tag) {
+                        case 8: {
                                 message.editionIntroduced = reader.int32();
                                 break;
                             }
-                        case 2: {
+                        case 16: {
                                 message.editionDeprecated = reader.int32();
                                 break;
                             }
-                        case 3: {
+                        case 26: {
                                 message.deprecationWarning = reader.string();
                                 break;
                             }
-                        case 4: {
+                        case 32: {
                                 message.editionRemoved = reader.int32();
                                 break;
                             }
@@ -18362,12 +18368,12 @@ $root.google = (function() {
                     var tag = reader.uint32();
                     if (tag === error)
                         break;
-                    switch (tag >>> 3) {
-                    case 1: {
+                    switch (tag) {
+                    case 10: {
                             message.features = $root.google.protobuf.FeatureSet.decode(reader, reader.uint32(), undefined, long + 1);
                             break;
                         }
-                    case 999: {
+                    case 7994: {
                             if (!(message.uninterpretedOption && message.uninterpretedOption.length))
                                 message.uninterpretedOption = [];
                             message.uninterpretedOption.push($root.google.protobuf.UninterpretedOption.decode(reader, reader.uint32(), undefined, long + 1));
@@ -18673,30 +18679,30 @@ $root.google = (function() {
                     var tag = reader.uint32();
                     if (tag === error)
                         break;
-                    switch (tag >>> 3) {
-                    case 2: {
+                    switch (tag) {
+                    case 16: {
                             message.allowAlias = reader.bool();
                             break;
                         }
-                    case 3: {
+                    case 24: {
                             message.deprecated = reader.bool();
                             break;
                         }
-                    case 6: {
+                    case 48: {
                             message.deprecatedLegacyJsonFieldConflicts = reader.bool();
                             break;
                         }
-                    case 7: {
+                    case 58: {
                             message.features = $root.google.protobuf.FeatureSet.decode(reader, reader.uint32(), undefined, long + 1);
                             break;
                         }
-                    case 999: {
+                    case 7994: {
                             if (!(message.uninterpretedOption && message.uninterpretedOption.length))
                                 message.uninterpretedOption = [];
                             message.uninterpretedOption.push($root.google.protobuf.UninterpretedOption.decode(reader, reader.uint32(), undefined, long + 1));
                             break;
                         }
-                    case 42113038: {
+                    case 336904306: {
                             message[".jspb.test.IsExtension.simpleOption"] = reader.string();
                             break;
                         }
@@ -19022,24 +19028,24 @@ $root.google = (function() {
                     var tag = reader.uint32();
                     if (tag === error)
                         break;
-                    switch (tag >>> 3) {
-                    case 1: {
+                    switch (tag) {
+                    case 8: {
                             message.deprecated = reader.bool();
                             break;
                         }
-                    case 2: {
+                    case 18: {
                             message.features = $root.google.protobuf.FeatureSet.decode(reader, reader.uint32(), undefined, long + 1);
                             break;
                         }
-                    case 3: {
+                    case 24: {
                             message.debugRedact = reader.bool();
                             break;
                         }
-                    case 4: {
+                    case 34: {
                             message.featureSupport = $root.google.protobuf.FieldOptions.FeatureSupport.decode(reader, reader.uint32(), undefined, long + 1);
                             break;
                         }
-                    case 999: {
+                    case 7994: {
                             if (!(message.uninterpretedOption && message.uninterpretedOption.length))
                                 message.uninterpretedOption = [];
                             message.uninterpretedOption.push($root.google.protobuf.UninterpretedOption.decode(reader, reader.uint32(), undefined, long + 1));
@@ -19342,16 +19348,16 @@ $root.google = (function() {
                     var tag = reader.uint32();
                     if (tag === error)
                         break;
-                    switch (tag >>> 3) {
-                    case 34: {
+                    switch (tag) {
+                    case 274: {
                             message.features = $root.google.protobuf.FeatureSet.decode(reader, reader.uint32(), undefined, long + 1);
                             break;
                         }
-                    case 33: {
+                    case 264: {
                             message.deprecated = reader.bool();
                             break;
                         }
-                    case 999: {
+                    case 7994: {
                             if (!(message.uninterpretedOption && message.uninterpretedOption.length))
                                 message.uninterpretedOption = [];
                             message.uninterpretedOption.push($root.google.protobuf.UninterpretedOption.decode(reader, reader.uint32(), undefined, long + 1));
@@ -19644,20 +19650,20 @@ $root.google = (function() {
                     var tag = reader.uint32();
                     if (tag === error)
                         break;
-                    switch (tag >>> 3) {
-                    case 33: {
+                    switch (tag) {
+                    case 264: {
                             message.deprecated = reader.bool();
                             break;
                         }
-                    case 34: {
+                    case 272: {
                             message.idempotencyLevel = reader.int32();
                             break;
                         }
-                    case 35: {
+                    case 282: {
                             message.features = $root.google.protobuf.FeatureSet.decode(reader, reader.uint32(), undefined, long + 1);
                             break;
                         }
-                    case 999: {
+                    case 7994: {
                             if (!(message.uninterpretedOption && message.uninterpretedOption.length))
                                 message.uninterpretedOption = [];
                             message.uninterpretedOption.push($root.google.protobuf.UninterpretedOption.decode(reader, reader.uint32(), undefined, long + 1));
@@ -20031,34 +20037,34 @@ $root.google = (function() {
                     var tag = reader.uint32();
                     if (tag === error)
                         break;
-                    switch (tag >>> 3) {
-                    case 2: {
+                    switch (tag) {
+                    case 18: {
                             if (!(message.name && message.name.length))
                                 message.name = [];
                             message.name.push($root.google.protobuf.UninterpretedOption.NamePart.decode(reader, reader.uint32(), undefined, long + 1));
                             break;
                         }
-                    case 3: {
+                    case 26: {
                             message.identifierValue = reader.string();
                             break;
                         }
-                    case 4: {
+                    case 32: {
                             message.positiveIntValue = reader.uint64();
                             break;
                         }
-                    case 5: {
+                    case 40: {
                             message.negativeIntValue = reader.int64();
                             break;
                         }
-                    case 6: {
+                    case 49: {
                             message.doubleValue = reader.double();
                             break;
                         }
-                    case 7: {
+                    case 58: {
                             message.stringValue = reader.bytes();
                             break;
                         }
-                    case 8: {
+                    case 66: {
                             message.aggregateValue = reader.string();
                             break;
                         }
@@ -20384,12 +20390,12 @@ $root.google = (function() {
                         var tag = reader.uint32();
                         if (tag === error)
                             break;
-                        switch (tag >>> 3) {
-                        case 1: {
+                        switch (tag) {
+                        case 10: {
                                 message.namePart = reader.string();
                                 break;
                             }
-                        case 2: {
+                        case 16: {
                                 message.isExtension = reader.bool();
                                 break;
                             }
@@ -20696,36 +20702,36 @@ $root.google = (function() {
                     var tag = reader.uint32();
                     if (tag === error)
                         break;
-                    switch (tag >>> 3) {
-                    case 1: {
+                    switch (tag) {
+                    case 8: {
                             message.fieldPresence = reader.int32();
                             break;
                         }
-                    case 2: {
+                    case 16: {
                             message.enumType = reader.int32();
                             break;
                         }
-                    case 3: {
+                    case 24: {
                             message.repeatedFieldEncoding = reader.int32();
                             break;
                         }
-                    case 4: {
+                    case 32: {
                             message.utf8Validation = reader.int32();
                             break;
                         }
-                    case 5: {
+                    case 40: {
                             message.messageEncoding = reader.int32();
                             break;
                         }
-                    case 6: {
+                    case 48: {
                             message.jsonFormat = reader.int32();
                             break;
                         }
-                    case 7: {
+                    case 56: {
                             message.enforceNamingStyle = reader.int32();
                             break;
                         }
-                    case 8: {
+                    case 64: {
                             message.defaultSymbolVisibility = reader.int32();
                             break;
                         }
@@ -21305,7 +21311,7 @@ $root.google = (function() {
                         var tag = reader.uint32();
                         if (tag === error)
                             break;
-                        switch (tag >>> 3) {
+                        switch (tag) {
                         default:
                             reader.skipType(tag & 7, long);
                             break;
@@ -21552,18 +21558,18 @@ $root.google = (function() {
                     var tag = reader.uint32();
                     if (tag === error)
                         break;
-                    switch (tag >>> 3) {
-                    case 1: {
+                    switch (tag) {
+                    case 10: {
                             if (!(message.defaults && message.defaults.length))
                                 message.defaults = [];
                             message.defaults.push($root.google.protobuf.FeatureSetDefaults.FeatureSetEditionDefault.decode(reader, reader.uint32(), undefined, long + 1));
                             break;
                         }
-                    case 4: {
+                    case 32: {
                             message.minimumEdition = reader.int32();
                             break;
                         }
-                    case 5: {
+                    case 40: {
                             message.maximumEdition = reader.int32();
                             break;
                         }
@@ -21971,16 +21977,16 @@ $root.google = (function() {
                         var tag = reader.uint32();
                         if (tag === error)
                             break;
-                        switch (tag >>> 3) {
-                        case 3: {
+                        switch (tag) {
+                        case 24: {
                                 message.edition = reader.int32();
                                 break;
                             }
-                        case 4: {
+                        case 34: {
                                 message.overridableFeatures = $root.google.protobuf.FeatureSet.decode(reader, reader.uint32(), undefined, long + 1);
                                 break;
                             }
-                        case 5: {
+                        case 42: {
                                 message.fixedFeatures = $root.google.protobuf.FeatureSet.decode(reader, reader.uint32(), undefined, long + 1);
                                 break;
                             }
@@ -22297,8 +22303,8 @@ $root.google = (function() {
                     var tag = reader.uint32();
                     if (tag === error)
                         break;
-                    switch (tag >>> 3) {
-                    case 1: {
+                    switch (tag) {
+                    case 10: {
                             if (!(message.location && message.location.length))
                                 message.location = [];
                             message.location.push($root.google.protobuf.SourceCodeInfo.Location.decode(reader, reader.uint32(), undefined, long + 1));
@@ -22586,8 +22592,9 @@ $root.google = (function() {
                         var tag = reader.uint32();
                         if (tag === error)
                             break;
-                        switch (tag >>> 3) {
-                        case 1: {
+                        switch (tag) {
+                        case 8:
+                        case 10: {
                                 if (!(message.path && message.path.length))
                                     message.path = [];
                                 if ((tag & 7) === 2) {
@@ -22598,7 +22605,8 @@ $root.google = (function() {
                                     message.path.push(reader.int32());
                                 break;
                             }
-                        case 2: {
+                        case 16:
+                        case 18: {
                                 if (!(message.span && message.span.length))
                                     message.span = [];
                                 if ((tag & 7) === 2) {
@@ -22609,15 +22617,15 @@ $root.google = (function() {
                                     message.span.push(reader.int32());
                                 break;
                             }
-                        case 3: {
+                        case 26: {
                                 message.leadingComments = reader.string();
                                 break;
                             }
-                        case 4: {
+                        case 34: {
                                 message.trailingComments = reader.string();
                                 break;
                             }
-                        case 6: {
+                        case 50: {
                                 if (!(message.leadingDetachedComments && message.leadingDetachedComments.length))
                                     message.leadingDetachedComments = [];
                                 message.leadingDetachedComments.push(reader.string());
@@ -22911,8 +22919,8 @@ $root.google = (function() {
                     var tag = reader.uint32();
                     if (tag === error)
                         break;
-                    switch (tag >>> 3) {
-                    case 1: {
+                    switch (tag) {
+                    case 10: {
                             if (!(message.annotation && message.annotation.length))
                                 message.annotation = [];
                             message.annotation.push($root.google.protobuf.GeneratedCodeInfo.Annotation.decode(reader, reader.uint32(), undefined, long + 1));
@@ -23193,8 +23201,9 @@ $root.google = (function() {
                         var tag = reader.uint32();
                         if (tag === error)
                             break;
-                        switch (tag >>> 3) {
-                        case 1: {
+                        switch (tag) {
+                        case 8:
+                        case 10: {
                                 if (!(message.path && message.path.length))
                                     message.path = [];
                                 if ((tag & 7) === 2) {
@@ -23205,19 +23214,19 @@ $root.google = (function() {
                                     message.path.push(reader.int32());
                                 break;
                             }
-                        case 2: {
+                        case 18: {
                                 message.sourceFile = reader.string();
                                 break;
                             }
-                        case 3: {
+                        case 24: {
                                 message.begin = reader.int32();
                                 break;
                             }
-                        case 4: {
+                        case 32: {
                                 message.end = reader.int32();
                                 break;
                             }
-                        case 5: {
+                        case 40: {
                                 message.semantic = reader.int32();
                                 break;
                             }

--- a/tests/data/type_url.js
+++ b/tests/data/type_url.js
@@ -106,8 +106,8 @@ $root.TypeUrlTest = (function() {
             var tag = reader.uint32();
             if (tag === error)
                 break;
-            switch (tag >>> 3) {
-            case 1: {
+            switch (tag) {
+            case 10: {
                     message.nested = $root.TypeUrlTest.Nested.decode(reader, reader.uint32(), undefined, long + 1);
                     break;
                 }
@@ -325,8 +325,8 @@ $root.TypeUrlTest = (function() {
                 var tag = reader.uint32();
                 if (tag === error)
                     break;
-                switch (tag >>> 3) {
-                case 1: {
+                switch (tag) {
+                case 10: {
                         message.a = reader.string();
                         break;
                     }


### PR DESCRIPTION
Updates generated decoders to dispatch fields by full wire tag instead of just field number, so known fields with an unexpected but valid wire type fall through to the default skip case, while invalid wire types such as 6 and 7 now fail consistently instead of being decoded as if the field had the expected wire type.

Also regenerates affected fixtures.