### PR TITLE
fix: Read non-minimal 32-bit varints correctly

### DIFF
--- a/src/reader.js
+++ b/src/reader.js
@@ -92,12 +92,15 @@ Reader.prototype.uint32 = (function read_uint32_setup() {
         value = (value | (this.buf[this.pos] & 127) << 21) >>> 0; if (this.buf[this.pos++] < 128) return value;
         value = (value | (this.buf[this.pos] &  15) << 28) >>> 0; if (this.buf[this.pos++] < 128) return value;
 
-        /* istanbul ignore if */
-        if ((this.pos += 5) > this.len) {
-            this.pos = this.len;
-            throw indexOutOfRange(this, 10);
+        for (var i = 0; i < 5; ++i) {
+            /* istanbul ignore if */
+            if (this.pos >= this.len)
+                throw indexOutOfRange(this);
+            if (this.buf[this.pos++] < 128)
+                return value;
         }
-        return value;
+        /* istanbul ignore next */
+        throw Error("invalid varint encoding");
     };
 })();
 

--- a/tests/api_writer-reader.js
+++ b/tests/api_writer-reader.js
@@ -39,6 +39,9 @@ tape.test("writer & reader", function(test) {
     test.ok(expect("uint32", -1 >>> 0, [ 255, 255, 255, 255, 15 ]), "should write -1 as an unsigned varint of length 5");
     test.ok(expect("int32", -1, [ 255, 255, 255, 255, 255, 255, 255, 255, 255, 1 ]), "should write -1 as a signed varint of length 10");
     test.ok(expect("sint32", -1, [ 1 ]), "should write -1 as a signed zig-zag encoded varint of length 1");
+    var reader = Reader.create([ 128, 128, 128, 128, 128, 0, 1 ]);
+    test.equal(reader.uint32(), 0, "should read non-minimal uint32 varints");
+    test.equal(reader.uint32(), 1, "should stop after the non-minimal uint32 varint");
 
     // fixed32, sfixed32
 


### PR DESCRIPTION
Updates `Reader#uint32` to consume non-minimal 32-bit varints until their actual terminator instead of skipping a fixed number of remaining bytes after the fifth byte.

Fixes valid protobuf inputs where `int32`, `uint32`, or enum values are encoded as longer varints. May address some `invalid wire type` / `index out of range` decode failures.