### PR TITLE
fix: Validate field and group tags while decoding

### DIFF
--- a/bench/data/static_pbjs.js
+++ b/bench/data/static_pbjs.js
@@ -41,12 +41,14 @@ $root.Test = (function() {
         if (_depth === undefined)
             _depth = 0;
         if (_depth > $Reader.recursionLimit)
-            throw Error("maximum nesting depth exceeded");
+            throw Error("max depth exceeded");
         var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.Test();
         while (reader.pos < end) {
             var tag = reader.uint32();
-            if (tag === _end)
+            if (tag === _end) {
+                _end = undefined;
                 break;
+            }
             switch (tag) {
             case 10: {
                     message.string = reader.string();
@@ -65,10 +67,12 @@ $root.Test = (function() {
                     break;
                 }
             default:
-                reader.skipType(tag & 7, _depth);
+                reader.skipType(tag & 7, _depth, tag >>> 3);
                 break;
             }
         }
+        if (_end !== undefined)
+            throw Error("missing end group");
         return message;
     };
 
@@ -103,12 +107,14 @@ $root.Test = (function() {
             if (_depth === undefined)
                 _depth = 0;
             if (_depth > $Reader.recursionLimit)
-                throw Error("maximum nesting depth exceeded");
+                throw Error("max depth exceeded");
             var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.Test.Inner();
             while (reader.pos < end) {
                 var tag = reader.uint32();
-                if (tag === _end)
+                if (tag === _end) {
+                    _end = undefined;
                     break;
+                }
                 switch (tag) {
                 case 8: {
                         message.int32 = reader.int32();
@@ -123,10 +129,12 @@ $root.Test = (function() {
                         break;
                     }
                 default:
-                    reader.skipType(tag & 7, _depth);
+                    reader.skipType(tag & 7, _depth, tag >>> 3);
                     break;
                 }
             }
+            if (_end !== undefined)
+                throw Error("missing end group");
             return message;
         };
 
@@ -161,12 +169,14 @@ $root.Test = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $Reader.recursionLimit)
-                    throw Error("maximum nesting depth exceeded");
+                    throw Error("max depth exceeded");
                 var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.Test.Inner.InnerInner();
                 while (reader.pos < end) {
                     var tag = reader.uint32();
-                    if (tag === _end)
+                    if (tag === _end) {
+                        _end = undefined;
                         break;
+                    }
                     switch (tag) {
                     case 8: {
                             message.long = reader.int64();
@@ -181,10 +191,12 @@ $root.Test = (function() {
                             break;
                         }
                     default:
-                        reader.skipType(tag & 7, _depth);
+                        reader.skipType(tag & 7, _depth, tag >>> 3);
                         break;
                     }
                 }
+                if (_end !== undefined)
+                    throw Error("missing end group");
                 return message;
             };
 
@@ -240,12 +252,14 @@ $root.Outer = (function() {
         if (_depth === undefined)
             _depth = 0;
         if (_depth > $Reader.recursionLimit)
-            throw Error("maximum nesting depth exceeded");
+            throw Error("max depth exceeded");
         var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.Outer();
         while (reader.pos < end) {
             var tag = reader.uint32();
-            if (tag === _end)
+            if (tag === _end) {
+                _end = undefined;
                 break;
+            }
             switch (tag) {
             case 8:
             case 10: {
@@ -264,10 +278,12 @@ $root.Outer = (function() {
                     break;
                 }
             default:
-                reader.skipType(tag & 7, _depth);
+                reader.skipType(tag & 7, _depth, tag >>> 3);
                 break;
             }
         }
+        if (_end !== undefined)
+            throw Error("missing end group");
         return message;
     };
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1278,9 +1278,10 @@ export class Reader {
      * Skips the next element of the specified wire type.
      * @param wireType Wire type received
      * @param [depth] Depth of recursion to control nested calls; 0 if omitted
+     * @param [fieldNumber] Field number for validating group end tags
      * @returns `this`
      */
-    public skipType(wireType: number, depth?: number): Reader;
+    public skipType(wireType: number, depth?: number, fieldNumber?: number): Reader;
 }
 
 /** Wire format reader using node buffers. */

--- a/src/converter.js
+++ b/src/converter.js
@@ -111,7 +111,7 @@ converter.fromObject = function fromObject(mtype) {
         ("return d")
     ("if(q===undefined)q=0")
     ("if(q>util.recursionLimit)")
-        ("throw Error(\"maximum nesting depth exceeded\")");
+        ("throw Error(\"max depth exceeded\")");
     if (!fields.length) return gen
     ("return new this.ctor");
     gen

--- a/src/decoder.js
+++ b/src/decoder.js
@@ -21,12 +21,14 @@ function decoder(mtype) {
         ("r=Reader.create(r)")
     ("if(q===undefined)q=0")
     ("if(q>Reader.recursionLimit)")
-        ("throw Error(\"maximum nesting depth exceeded\")")
+        ("throw Error(\"max depth exceeded\")")
     ("var c=l===undefined?r.len:r.pos+l,m=g||new this.ctor" + (mtype.fieldsArray.filter(function(field) { return field.map; }).length ? ",k,value" : ""))
     ("while(r.pos<c){")
         ("var t=r.uint32()")
-        ("if(t===z)")
+        ("if(t===z){")
+            ("z=undefined")
             ("break")
+        ("}")
         ("switch(t){");
 
     var i = 0;
@@ -67,7 +69,7 @@ function decoder(mtype) {
             gen
                             ("break")
                         ("default:")
-                            ("r.skipType(tag2&7,q)")
+                            ("r.skipType(tag2&7,q,tag2>>>3)")
                             ("break")
                     ("}")
                 ("}");
@@ -132,11 +134,15 @@ function decoder(mtype) {
         // Unknown fields
     } gen
             ("default:")
-                ("r.skipType(t&7,q)")
+                ("r.skipType(t&7,q,t>>>3)")
                 ("break")
 
         ("}")
     ("}");
+
+    gen
+    ("if(z!==undefined)")
+        ("throw Error(\"missing end group\")");
 
     // Field presence
     for (i = 0; i < mtype._fieldsArray.length; ++i) {

--- a/src/reader.js
+++ b/src/reader.js
@@ -378,12 +378,15 @@ Reader.recursionLimit = util.recursionLimit;
  * Skips the next element of the specified wire type.
  * @param {number} wireType Wire type received
  * @param {number} [depth] Depth of recursion to control nested calls; 0 if omitted
+ * @param {number} [fieldNumber] Field number for validating group end tags
  * @returns {Reader} `this`
  */
-Reader.prototype.skipType = function(wireType, depth) {
+Reader.prototype.skipType = function(wireType, depth, fieldNumber) {
     if (depth === undefined) depth = 0;
     if (depth > Reader.recursionLimit)
-        throw Error("maximum nesting depth exceeded");
+        throw Error("max depth exceeded");
+    if (fieldNumber === 0)
+        throw Error("illegal tag: field number 0");
     switch (wireType) {
         case 0:
             this.skip();
@@ -395,8 +398,18 @@ Reader.prototype.skipType = function(wireType, depth) {
             this.skip(this.uint32());
             break;
         case 3:
-            while ((wireType = this.uint32() & 7) !== 4) {
-                this.skipType(wireType, depth + 1);
+            while (true) {
+                var tag = this.uint32();
+                var nestedField = tag >>> 3;
+                wireType = tag & 7;
+                if (!nestedField)
+                    throw Error("illegal tag: field number 0");
+                if (wireType === 4) {
+                    if (fieldNumber !== undefined && nestedField !== fieldNumber)
+                        throw Error("invalid end group tag");
+                    break;
+                }
+                this.skipType(wireType, depth + 1, nestedField);
             }
             break;
         case 5:

--- a/src/verifier.js
+++ b/src/verifier.js
@@ -127,7 +127,7 @@ function verifier(mtype) {
         ("return%j", "object expected")
     ("if(q===undefined)q=0")
     ("if(q>util.recursionLimit)")
-        ("return%j", "maximum nesting depth exceeded");
+        ("return%j", "max depth exceeded");
     var oneofs = mtype.oneofsArray,
         seenFirstField = {};
     if (oneofs.length) gen

--- a/tests/api_type.js
+++ b/tests/api_type.js
@@ -178,7 +178,7 @@ tape.test("decode nesting", function(test) {
         test.equal(Node.decode(nestedPayload(2)).child.child.value, 42, "should decode below the limit");
         test.throws(function() {
             Node.decode(nestedPayload(4));
-        }, /maximum nesting depth exceeded/, "should reject excessive nesting");
+        }, /max depth exceeded/, "should reject excessive nesting");
     } finally {
         protobuf.Reader.recursionLimit = recursionLimit;
     }
@@ -197,9 +197,16 @@ tape.test("decode known fields by wire type", function(test) {
         }
     });
     var Message = root.lookupType("Message");
+    var field0Varint = [ 0, 0 ];
     var field1WireType6 = [ 1 << 3 | 6, 0 ];
     var field1WireType7 = [ 1 << 3 | 7, 0 ];
     var field1Fixed64 = [ 1 << 3 | 1, 1, 2, 3, 4, 5, 6, 7, 8 ];
+    var field1Group = [ 1 << 3 | 3, 1 << 3 | 4 ];
+    var field1GroupField2End = [ 1 << 3 | 3, 2 << 3 | 4 ];
+
+    test.throws(function() {
+        Message.decode(protobuf.util.newBuffer(field0Varint));
+    }, /illegal tag: field number 0/, "should reject field number 0");
 
     test.throws(function() {
         Message.decode(protobuf.util.newBuffer(field1WireType6));
@@ -211,6 +218,13 @@ tape.test("decode known fields by wire type", function(test) {
 
     var message = Message.decode(protobuf.util.newBuffer(field1Fixed64));
     test.notOk(Object.prototype.hasOwnProperty.call(message, "value"), "should skip valid but unexpected wire types");
+
+    message = Message.decode(protobuf.util.newBuffer(field1Group));
+    test.notOk(Object.prototype.hasOwnProperty.call(message, "value"), "should skip valid but unexpected groups");
+
+    test.throws(function() {
+        Message.decode(protobuf.util.newBuffer(field1GroupField2End));
+    }, /invalid end group tag/, "should reject mismatched unknown group tags");
     test.end();
 });
 
@@ -238,11 +252,11 @@ tape.test("object conversion nesting", function(test) {
     protobuf.util.recursionLimit = 3;
     try {
         test.equal(Node.verify(nestedObject(2)), null, "should verify below the limit");
-        test.match(Node.verify(nestedObject(4)), /maximum nesting depth exceeded/, "should reject excessive nesting while verifying");
+        test.match(Node.verify(nestedObject(4)), /max depth exceeded/, "should reject excessive nesting while verifying");
         test.equal(Node.fromObject(nestedObject(2)).child.child.value, 42, "should convert below the limit");
         test.throws(function() {
             Node.fromObject(nestedObject(4));
-        }, /maximum nesting depth exceeded/, "should reject excessive nesting while converting");
+        }, /max depth exceeded/, "should reject excessive nesting while converting");
     } finally {
         protobuf.util.recursionLimit = recursionLimit;
     }

--- a/tests/api_writer-reader.js
+++ b/tests/api_writer-reader.js
@@ -113,8 +113,8 @@ tape.test("writer & reader", function(test) {
             .uint32(1)
             .double(0.1)
             .string("123")
-            .uint32(1 << 3 | 1).double(0.1).uint32(4)
-            .uint32(4)
+            .uint32(1 << 3 | 1).double(0.1).uint32(1 << 3 | 4)
+            .uint32(1 << 3 | 4)
             .float(0.125)
             .finish()
         );
@@ -147,7 +147,7 @@ tape.test("writer & reader", function(test) {
       // 0x7B (field 15, wire type 3 = start group)
       const payload = Buffer.alloc(50000, 0x7B);
       MyMessage.decode(payload);
-    }, /maximum nesting depth exceeded/, "limits recursion in reader");
+    }, /max depth exceeded/, "limits recursion in reader");
 
     test.end();
 });

--- a/tests/comp_groups.js
+++ b/tests/comp_groups.js
@@ -67,6 +67,14 @@ tape.test("legacy groups", function(test) {
         test.end();
     };})(Test, msg));
 
+    test.test(test.name + " - should reject unmatched start group", (function(Test) { return function(test) {
+        var buf = protobuf.util.newBuffer([1 << 3 | 3]);
+        test.throws(function() {
+            Test.decode(buf);
+        }, /missing end group/, "should reject groups without an end tag");
+        test.end();
+    };})(Test));
+
     // Same but repeated
     root = protobuf.parse(protoRepeated).root;
     Test = root.resolveAll().lookup("Test");

--- a/tests/data/comments.js
+++ b/tests/data/comments.js
@@ -125,12 +125,14 @@ $root.Test1 = (function() {
         if (_depth === undefined)
             _depth = 0;
         if (_depth > $Reader.recursionLimit)
-            throw Error("maximum nesting depth exceeded");
+            throw Error("max depth exceeded");
         var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.Test1();
         while (reader.pos < end) {
             var tag = reader.uint32();
-            if (tag === _end)
+            if (tag === _end) {
+                _end = undefined;
                 break;
+            }
             switch (tag) {
             case 10: {
                     message.field1 = reader.string();
@@ -145,10 +147,12 @@ $root.Test1 = (function() {
                     break;
                 }
             default:
-                reader.skipType(tag & 7, _depth);
+                reader.skipType(tag & 7, _depth, tag >>> 3);
                 break;
             }
         }
+        if (_end !== undefined)
+            throw Error("missing end group");
         return message;
     };
 
@@ -182,7 +186,7 @@ $root.Test1 = (function() {
         if (_depth === undefined)
             _depth = 0;
         if (_depth > $util.recursionLimit)
-            return "maximum nesting depth exceeded";
+            return "max depth exceeded";
         if (message.field1 != null && message.hasOwnProperty("field1"))
             if (!$util.isString(message.field1))
                 return "field1: string expected";
@@ -209,7 +213,7 @@ $root.Test1 = (function() {
         if (_depth === undefined)
             _depth = 0;
         if (_depth > $util.recursionLimit)
-            throw Error("maximum nesting depth exceeded");
+            throw Error("max depth exceeded");
         var message = new $root.Test1();
         if (object.field1 != null)
             message.field1 = String(object.field1);
@@ -356,18 +360,22 @@ $root.Test2 = (function() {
         if (_depth === undefined)
             _depth = 0;
         if (_depth > $Reader.recursionLimit)
-            throw Error("maximum nesting depth exceeded");
+            throw Error("max depth exceeded");
         var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.Test2();
         while (reader.pos < end) {
             var tag = reader.uint32();
-            if (tag === _end)
+            if (tag === _end) {
+                _end = undefined;
                 break;
+            }
             switch (tag) {
             default:
-                reader.skipType(tag & 7, _depth);
+                reader.skipType(tag & 7, _depth, tag >>> 3);
                 break;
             }
         }
+        if (_end !== undefined)
+            throw Error("missing end group");
         return message;
     };
 
@@ -401,7 +409,7 @@ $root.Test2 = (function() {
         if (_depth === undefined)
             _depth = 0;
         if (_depth > $util.recursionLimit)
-            return "maximum nesting depth exceeded";
+            return "max depth exceeded";
         return null;
     };
 
@@ -419,7 +427,7 @@ $root.Test2 = (function() {
         if (_depth === undefined)
             _depth = 0;
         if (_depth > $util.recursionLimit)
-            throw Error("maximum nesting depth exceeded");
+            throw Error("max depth exceeded");
         return new $root.Test2();
     };
 

--- a/tests/data/convert.js
+++ b/tests/data/convert.js
@@ -204,12 +204,14 @@ $root.Message = (function() {
         if (_depth === undefined)
             _depth = 0;
         if (_depth > $Reader.recursionLimit)
-            throw Error("maximum nesting depth exceeded");
+            throw Error("max depth exceeded");
         var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.Message(), key, value;
         while (reader.pos < end) {
             var tag = reader.uint32();
-            if (tag === _end)
+            if (tag === _end) {
+                _end = undefined;
                 break;
+            }
             switch (tag) {
             case 10: {
                     message.stringVal = reader.string();
@@ -279,7 +281,7 @@ $root.Message = (function() {
                             value = reader.int64();
                             break;
                         default:
-                            reader.skipType(tag2 & 7, _depth);
+                            reader.skipType(tag2 & 7, _depth, tag2 >>> 3);
                             break;
                         }
                     }
@@ -289,10 +291,12 @@ $root.Message = (function() {
                     break;
                 }
             default:
-                reader.skipType(tag & 7, _depth);
+                reader.skipType(tag & 7, _depth, tag >>> 3);
                 break;
             }
         }
+        if (_end !== undefined)
+            throw Error("missing end group");
         return message;
     };
 
@@ -326,7 +330,7 @@ $root.Message = (function() {
         if (_depth === undefined)
             _depth = 0;
         if (_depth > $util.recursionLimit)
-            return "maximum nesting depth exceeded";
+            return "max depth exceeded";
         if (message.stringVal != null && message.hasOwnProperty("stringVal"))
             if (!$util.isString(message.stringVal))
                 return "stringVal: string expected";
@@ -402,7 +406,7 @@ $root.Message = (function() {
         if (_depth === undefined)
             _depth = 0;
         if (_depth > $util.recursionLimit)
-            throw Error("maximum nesting depth exceeded");
+            throw Error("max depth exceeded");
         var message = new $root.Message();
         if (object.stringVal != null)
             message.stringVal = String(object.stringVal);

--- a/tests/data/mapbox/vector_tile.js
+++ b/tests/data/mapbox/vector_tile.js
@@ -111,12 +111,14 @@ $root.vector_tile = (function() {
             if (_depth === undefined)
                 _depth = 0;
             if (_depth > $Reader.recursionLimit)
-                throw Error("maximum nesting depth exceeded");
+                throw Error("max depth exceeded");
             var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.vector_tile.Tile();
             while (reader.pos < end) {
                 var tag = reader.uint32();
-                if (tag === _end)
+                if (tag === _end) {
+                    _end = undefined;
                     break;
+                }
                 switch (tag) {
                 case 26: {
                         if (!(message.layers && message.layers.length))
@@ -125,10 +127,12 @@ $root.vector_tile = (function() {
                         break;
                     }
                 default:
-                    reader.skipType(tag & 7, _depth);
+                    reader.skipType(tag & 7, _depth, tag >>> 3);
                     break;
                 }
             }
+            if (_end !== undefined)
+                throw Error("missing end group");
             return message;
         };
 
@@ -162,7 +166,7 @@ $root.vector_tile = (function() {
             if (_depth === undefined)
                 _depth = 0;
             if (_depth > $util.recursionLimit)
-                return "maximum nesting depth exceeded";
+                return "max depth exceeded";
             if (message.layers != null && message.hasOwnProperty("layers")) {
                 if (!Array.isArray(message.layers))
                     return "layers: array expected";
@@ -189,7 +193,7 @@ $root.vector_tile = (function() {
             if (_depth === undefined)
                 _depth = 0;
             if (_depth > $util.recursionLimit)
-                throw Error("maximum nesting depth exceeded");
+                throw Error("max depth exceeded");
             var message = new $root.vector_tile.Tile();
             if (object.layers) {
                 if (!Array.isArray(object.layers))
@@ -428,12 +432,14 @@ $root.vector_tile = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $Reader.recursionLimit)
-                    throw Error("maximum nesting depth exceeded");
+                    throw Error("max depth exceeded");
                 var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.vector_tile.Tile.Value();
                 while (reader.pos < end) {
                     var tag = reader.uint32();
-                    if (tag === _end)
+                    if (tag === _end) {
+                        _end = undefined;
                         break;
+                    }
                     switch (tag) {
                     case 10: {
                             message.stringValue = reader.string();
@@ -464,10 +470,12 @@ $root.vector_tile = (function() {
                             break;
                         }
                     default:
-                        reader.skipType(tag & 7, _depth);
+                        reader.skipType(tag & 7, _depth, tag >>> 3);
                         break;
                     }
                 }
+                if (_end !== undefined)
+                    throw Error("missing end group");
                 return message;
             };
 
@@ -501,7 +509,7 @@ $root.vector_tile = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $util.recursionLimit)
-                    return "maximum nesting depth exceeded";
+                    return "max depth exceeded";
                 if (message.stringValue != null && message.hasOwnProperty("stringValue"))
                     if (!$util.isString(message.stringValue))
                         return "stringValue: string expected";
@@ -540,7 +548,7 @@ $root.vector_tile = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $util.recursionLimit)
-                    throw Error("maximum nesting depth exceeded");
+                    throw Error("max depth exceeded");
                 var message = new $root.vector_tile.Tile.Value();
                 if (object.stringValue != null)
                     message.stringValue = String(object.stringValue);
@@ -803,12 +811,14 @@ $root.vector_tile = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $Reader.recursionLimit)
-                    throw Error("maximum nesting depth exceeded");
+                    throw Error("max depth exceeded");
                 var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.vector_tile.Tile.Feature();
                 while (reader.pos < end) {
                     var tag = reader.uint32();
-                    if (tag === _end)
+                    if (tag === _end) {
+                        _end = undefined;
                         break;
+                    }
                     switch (tag) {
                     case 8: {
                             message.id = reader.uint64();
@@ -843,10 +853,12 @@ $root.vector_tile = (function() {
                             break;
                         }
                     default:
-                        reader.skipType(tag & 7, _depth);
+                        reader.skipType(tag & 7, _depth, tag >>> 3);
                         break;
                     }
                 }
+                if (_end !== undefined)
+                    throw Error("missing end group");
                 return message;
             };
 
@@ -880,7 +892,7 @@ $root.vector_tile = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $util.recursionLimit)
-                    return "maximum nesting depth exceeded";
+                    return "max depth exceeded";
                 if (message.id != null && message.hasOwnProperty("id"))
                     if (!$util.isInteger(message.id) && !(message.id && $util.isInteger(message.id.low) && $util.isInteger(message.id.high)))
                         return "id: integer|Long expected";
@@ -925,7 +937,7 @@ $root.vector_tile = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $util.recursionLimit)
-                    throw Error("maximum nesting depth exceeded");
+                    throw Error("max depth exceeded");
                 var message = new $root.vector_tile.Tile.Feature();
                 if (object.id != null)
                     if ($util.Long)
@@ -1201,12 +1213,14 @@ $root.vector_tile = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $Reader.recursionLimit)
-                    throw Error("maximum nesting depth exceeded");
+                    throw Error("max depth exceeded");
                 var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.vector_tile.Tile.Layer();
                 while (reader.pos < end) {
                     var tag = reader.uint32();
-                    if (tag === _end)
+                    if (tag === _end) {
+                        _end = undefined;
                         break;
+                    }
                     switch (tag) {
                     case 120: {
                             message.version = reader.uint32();
@@ -1239,10 +1253,12 @@ $root.vector_tile = (function() {
                             break;
                         }
                     default:
-                        reader.skipType(tag & 7, _depth);
+                        reader.skipType(tag & 7, _depth, tag >>> 3);
                         break;
                     }
                 }
+                if (_end !== undefined)
+                    throw Error("missing end group");
                 if (!message.hasOwnProperty("version"))
                     throw $util.ProtocolError("missing required 'version'", { instance: message });
                 if (!message.hasOwnProperty("name"))
@@ -1280,7 +1296,7 @@ $root.vector_tile = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $util.recursionLimit)
-                    return "maximum nesting depth exceeded";
+                    return "max depth exceeded";
                 if (!$util.isInteger(message.version))
                     return "version: integer expected";
                 if (!$util.isString(message.name))
@@ -1330,7 +1346,7 @@ $root.vector_tile = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $util.recursionLimit)
-                    throw Error("maximum nesting depth exceeded");
+                    throw Error("max depth exceeded");
                 var message = new $root.vector_tile.Tile.Layer();
                 if (object.version != null)
                     message.version = object.version >>> 0;

--- a/tests/data/package.js
+++ b/tests/data/package.js
@@ -288,12 +288,14 @@ $root.Package = (function() {
         if (_depth === undefined)
             _depth = 0;
         if (_depth > $Reader.recursionLimit)
-            throw Error("maximum nesting depth exceeded");
+            throw Error("max depth exceeded");
         var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.Package(), key, value;
         while (reader.pos < end) {
             var tag = reader.uint32();
-            if (tag === _end)
+            if (tag === _end) {
+                _end = undefined;
                 break;
+            }
             switch (tag) {
             case 10: {
                     message.name = reader.string();
@@ -357,7 +359,7 @@ $root.Package = (function() {
                             value = reader.string();
                             break;
                         default:
-                            reader.skipType(tag2 & 7, _depth);
+                            reader.skipType(tag2 & 7, _depth, tag2 >>> 3);
                             break;
                         }
                     }
@@ -382,7 +384,7 @@ $root.Package = (function() {
                             value = reader.string();
                             break;
                         default:
-                            reader.skipType(tag2 & 7, _depth);
+                            reader.skipType(tag2 & 7, _depth, tag2 >>> 3);
                             break;
                         }
                     }
@@ -407,7 +409,7 @@ $root.Package = (function() {
                             value = reader.string();
                             break;
                         default:
-                            reader.skipType(tag2 & 7, _depth);
+                            reader.skipType(tag2 & 7, _depth, tag2 >>> 3);
                             break;
                         }
                     }
@@ -432,7 +434,7 @@ $root.Package = (function() {
                             value = reader.string();
                             break;
                         default:
-                            reader.skipType(tag2 & 7, _depth);
+                            reader.skipType(tag2 & 7, _depth, tag2 >>> 3);
                             break;
                         }
                     }
@@ -452,10 +454,12 @@ $root.Package = (function() {
                     break;
                 }
             default:
-                reader.skipType(tag & 7, _depth);
+                reader.skipType(tag & 7, _depth, tag >>> 3);
                 break;
             }
         }
+        if (_end !== undefined)
+            throw Error("missing end group");
         return message;
     };
 
@@ -489,7 +493,7 @@ $root.Package = (function() {
         if (_depth === undefined)
             _depth = 0;
         if (_depth > $util.recursionLimit)
-            return "maximum nesting depth exceeded";
+            return "max depth exceeded";
         if (message.name != null && message.hasOwnProperty("name"))
             if (!$util.isString(message.name))
                 return "name: string expected";
@@ -588,7 +592,7 @@ $root.Package = (function() {
         if (_depth === undefined)
             _depth = 0;
         if (_depth > $util.recursionLimit)
-            throw Error("maximum nesting depth exceeded");
+            throw Error("max depth exceeded");
         var message = new $root.Package();
         if (object.name != null)
             message.name = String(object.name);
@@ -904,12 +908,14 @@ $root.Package = (function() {
             if (_depth === undefined)
                 _depth = 0;
             if (_depth > $Reader.recursionLimit)
-                throw Error("maximum nesting depth exceeded");
+                throw Error("max depth exceeded");
             var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.Package.Repository();
             while (reader.pos < end) {
                 var tag = reader.uint32();
-                if (tag === _end)
+                if (tag === _end) {
+                    _end = undefined;
                     break;
+                }
                 switch (tag) {
                 case 10: {
                         message.type = reader.string();
@@ -920,10 +926,12 @@ $root.Package = (function() {
                         break;
                     }
                 default:
-                    reader.skipType(tag & 7, _depth);
+                    reader.skipType(tag & 7, _depth, tag >>> 3);
                     break;
                 }
             }
+            if (_end !== undefined)
+                throw Error("missing end group");
             return message;
         };
 
@@ -957,7 +965,7 @@ $root.Package = (function() {
             if (_depth === undefined)
                 _depth = 0;
             if (_depth > $util.recursionLimit)
-                return "maximum nesting depth exceeded";
+                return "max depth exceeded";
             if (message.type != null && message.hasOwnProperty("type"))
                 if (!$util.isString(message.type))
                     return "type: string expected";
@@ -981,7 +989,7 @@ $root.Package = (function() {
             if (_depth === undefined)
                 _depth = 0;
             if (_depth > $util.recursionLimit)
-                throw Error("maximum nesting depth exceeded");
+                throw Error("max depth exceeded");
             var message = new $root.Package.Repository();
             if (object.type != null)
                 message.type = String(object.type);

--- a/tests/data/rpc-es6.js
+++ b/tests/data/rpc-es6.js
@@ -166,22 +166,26 @@ export const MyRequest = $root.MyRequest = (() => {
         if (_depth === undefined)
             _depth = 0;
         if (_depth > $Reader.recursionLimit)
-            throw Error("maximum nesting depth exceeded");
+            throw Error("max depth exceeded");
         let end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.MyRequest();
         while (reader.pos < end) {
             let tag = reader.uint32();
-            if (tag === _end)
+            if (tag === _end) {
+                _end = undefined;
                 break;
+            }
             switch (tag) {
             case 10: {
                     message.path = reader.string();
                     break;
                 }
             default:
-                reader.skipType(tag & 7, _depth);
+                reader.skipType(tag & 7, _depth, tag >>> 3);
                 break;
             }
         }
+        if (_end !== undefined)
+            throw Error("missing end group");
         return message;
     };
 
@@ -215,7 +219,7 @@ export const MyRequest = $root.MyRequest = (() => {
         if (_depth === undefined)
             _depth = 0;
         if (_depth > $util.recursionLimit)
-            return "maximum nesting depth exceeded";
+            return "max depth exceeded";
         if (message.path != null && message.hasOwnProperty("path"))
             if (!$util.isString(message.path))
                 return "path: string expected";
@@ -236,7 +240,7 @@ export const MyRequest = $root.MyRequest = (() => {
         if (_depth === undefined)
             _depth = 0;
         if (_depth > $util.recursionLimit)
-            throw Error("maximum nesting depth exceeded");
+            throw Error("max depth exceeded");
         let message = new $root.MyRequest();
         if (object.path != null)
             message.path = String(object.path);
@@ -383,22 +387,26 @@ export const MyResponse = $root.MyResponse = (() => {
         if (_depth === undefined)
             _depth = 0;
         if (_depth > $Reader.recursionLimit)
-            throw Error("maximum nesting depth exceeded");
+            throw Error("max depth exceeded");
         let end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.MyResponse();
         while (reader.pos < end) {
             let tag = reader.uint32();
-            if (tag === _end)
+            if (tag === _end) {
+                _end = undefined;
                 break;
+            }
             switch (tag) {
             case 16: {
                     message.status = reader.int32();
                     break;
                 }
             default:
-                reader.skipType(tag & 7, _depth);
+                reader.skipType(tag & 7, _depth, tag >>> 3);
                 break;
             }
         }
+        if (_end !== undefined)
+            throw Error("missing end group");
         return message;
     };
 
@@ -432,7 +440,7 @@ export const MyResponse = $root.MyResponse = (() => {
         if (_depth === undefined)
             _depth = 0;
         if (_depth > $util.recursionLimit)
-            return "maximum nesting depth exceeded";
+            return "max depth exceeded";
         if (message.status != null && message.hasOwnProperty("status"))
             if (!$util.isInteger(message.status))
                 return "status: integer expected";
@@ -453,7 +461,7 @@ export const MyResponse = $root.MyResponse = (() => {
         if (_depth === undefined)
             _depth = 0;
         if (_depth > $util.recursionLimit)
-            throw Error("maximum nesting depth exceeded");
+            throw Error("max depth exceeded");
         let message = new $root.MyResponse();
         if (object.status != null)
             message.status = object.status | 0;

--- a/tests/data/rpc-reserved.js
+++ b/tests/data/rpc-reserved.js
@@ -168,22 +168,26 @@ $root.MyRequest = (function() {
         if (_depth === undefined)
             _depth = 0;
         if (_depth > $Reader.recursionLimit)
-            throw Error("maximum nesting depth exceeded");
+            throw Error("max depth exceeded");
         var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.MyRequest();
         while (reader.pos < end) {
             var tag = reader.uint32();
-            if (tag === _end)
+            if (tag === _end) {
+                _end = undefined;
                 break;
+            }
             switch (tag) {
             case 10: {
                     message.path = reader.string();
                     break;
                 }
             default:
-                reader.skipType(tag & 7, _depth);
+                reader.skipType(tag & 7, _depth, tag >>> 3);
                 break;
             }
         }
+        if (_end !== undefined)
+            throw Error("missing end group");
         return message;
     };
 
@@ -217,7 +221,7 @@ $root.MyRequest = (function() {
         if (_depth === undefined)
             _depth = 0;
         if (_depth > $util.recursionLimit)
-            return "maximum nesting depth exceeded";
+            return "max depth exceeded";
         if (message.path != null && message.hasOwnProperty("path"))
             if (!$util.isString(message.path))
                 return "path: string expected";
@@ -238,7 +242,7 @@ $root.MyRequest = (function() {
         if (_depth === undefined)
             _depth = 0;
         if (_depth > $util.recursionLimit)
-            throw Error("maximum nesting depth exceeded");
+            throw Error("max depth exceeded");
         var message = new $root.MyRequest();
         if (object.path != null)
             message.path = String(object.path);
@@ -385,22 +389,26 @@ $root.MyResponse = (function() {
         if (_depth === undefined)
             _depth = 0;
         if (_depth > $Reader.recursionLimit)
-            throw Error("maximum nesting depth exceeded");
+            throw Error("max depth exceeded");
         var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.MyResponse();
         while (reader.pos < end) {
             var tag = reader.uint32();
-            if (tag === _end)
+            if (tag === _end) {
+                _end = undefined;
                 break;
+            }
             switch (tag) {
             case 16: {
                     message.status = reader.int32();
                     break;
                 }
             default:
-                reader.skipType(tag & 7, _depth);
+                reader.skipType(tag & 7, _depth, tag >>> 3);
                 break;
             }
         }
+        if (_end !== undefined)
+            throw Error("missing end group");
         return message;
     };
 
@@ -434,7 +442,7 @@ $root.MyResponse = (function() {
         if (_depth === undefined)
             _depth = 0;
         if (_depth > $util.recursionLimit)
-            return "maximum nesting depth exceeded";
+            return "max depth exceeded";
         if (message.status != null && message.hasOwnProperty("status"))
             if (!$util.isInteger(message.status))
                 return "status: integer expected";
@@ -455,7 +463,7 @@ $root.MyResponse = (function() {
         if (_depth === undefined)
             _depth = 0;
         if (_depth > $util.recursionLimit)
-            throw Error("maximum nesting depth exceeded");
+            throw Error("max depth exceeded");
         var message = new $root.MyResponse();
         if (object.status != null)
             message.status = object.status | 0;

--- a/tests/data/rpc.js
+++ b/tests/data/rpc.js
@@ -168,22 +168,26 @@ $root.MyRequest = (function() {
         if (_depth === undefined)
             _depth = 0;
         if (_depth > $Reader.recursionLimit)
-            throw Error("maximum nesting depth exceeded");
+            throw Error("max depth exceeded");
         var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.MyRequest();
         while (reader.pos < end) {
             var tag = reader.uint32();
-            if (tag === _end)
+            if (tag === _end) {
+                _end = undefined;
                 break;
+            }
             switch (tag) {
             case 10: {
                     message.path = reader.string();
                     break;
                 }
             default:
-                reader.skipType(tag & 7, _depth);
+                reader.skipType(tag & 7, _depth, tag >>> 3);
                 break;
             }
         }
+        if (_end !== undefined)
+            throw Error("missing end group");
         return message;
     };
 
@@ -217,7 +221,7 @@ $root.MyRequest = (function() {
         if (_depth === undefined)
             _depth = 0;
         if (_depth > $util.recursionLimit)
-            return "maximum nesting depth exceeded";
+            return "max depth exceeded";
         if (message.path != null && message.hasOwnProperty("path"))
             if (!$util.isString(message.path))
                 return "path: string expected";
@@ -238,7 +242,7 @@ $root.MyRequest = (function() {
         if (_depth === undefined)
             _depth = 0;
         if (_depth > $util.recursionLimit)
-            throw Error("maximum nesting depth exceeded");
+            throw Error("max depth exceeded");
         var message = new $root.MyRequest();
         if (object.path != null)
             message.path = String(object.path);
@@ -385,22 +389,26 @@ $root.MyResponse = (function() {
         if (_depth === undefined)
             _depth = 0;
         if (_depth > $Reader.recursionLimit)
-            throw Error("maximum nesting depth exceeded");
+            throw Error("max depth exceeded");
         var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.MyResponse();
         while (reader.pos < end) {
             var tag = reader.uint32();
-            if (tag === _end)
+            if (tag === _end) {
+                _end = undefined;
                 break;
+            }
             switch (tag) {
             case 16: {
                     message.status = reader.int32();
                     break;
                 }
             default:
-                reader.skipType(tag & 7, _depth);
+                reader.skipType(tag & 7, _depth, tag >>> 3);
                 break;
             }
         }
+        if (_end !== undefined)
+            throw Error("missing end group");
         return message;
     };
 
@@ -434,7 +442,7 @@ $root.MyResponse = (function() {
         if (_depth === undefined)
             _depth = 0;
         if (_depth > $util.recursionLimit)
-            return "maximum nesting depth exceeded";
+            return "max depth exceeded";
         if (message.status != null && message.hasOwnProperty("status"))
             if (!$util.isInteger(message.status))
                 return "status: integer expected";
@@ -455,7 +463,7 @@ $root.MyResponse = (function() {
         if (_depth === undefined)
             _depth = 0;
         if (_depth > $util.recursionLimit)
-            throw Error("maximum nesting depth exceeded");
+            throw Error("max depth exceeded");
         var message = new $root.MyResponse();
         if (object.status != null)
             message.status = object.status | 0;

--- a/tests/data/test.js
+++ b/tests/data/test.js
@@ -107,18 +107,22 @@ $root.jspb = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $Reader.recursionLimit)
-                    throw Error("maximum nesting depth exceeded");
+                    throw Error("max depth exceeded");
                 var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.jspb.test.Empty();
                 while (reader.pos < end) {
                     var tag = reader.uint32();
-                    if (tag === _end)
+                    if (tag === _end) {
+                        _end = undefined;
                         break;
+                    }
                     switch (tag) {
                     default:
-                        reader.skipType(tag & 7, _depth);
+                        reader.skipType(tag & 7, _depth, tag >>> 3);
                         break;
                     }
                 }
+                if (_end !== undefined)
+                    throw Error("missing end group");
                 return message;
             };
 
@@ -152,7 +156,7 @@ $root.jspb = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $util.recursionLimit)
-                    return "maximum nesting depth exceeded";
+                    return "max depth exceeded";
                 return null;
             };
 
@@ -170,7 +174,7 @@ $root.jspb = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $util.recursionLimit)
-                    throw Error("maximum nesting depth exceeded");
+                    throw Error("max depth exceeded");
                 return new $root.jspb.test.Empty();
             };
 
@@ -321,22 +325,26 @@ $root.jspb = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $Reader.recursionLimit)
-                    throw Error("maximum nesting depth exceeded");
+                    throw Error("max depth exceeded");
                 var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.jspb.test.EnumContainer();
                 while (reader.pos < end) {
                     var tag = reader.uint32();
-                    if (tag === _end)
+                    if (tag === _end) {
+                        _end = undefined;
                         break;
+                    }
                     switch (tag) {
                     case 8: {
                             message.outerEnum = reader.int32();
                             break;
                         }
                     default:
-                        reader.skipType(tag & 7, _depth);
+                        reader.skipType(tag & 7, _depth, tag >>> 3);
                         break;
                     }
                 }
+                if (_end !== undefined)
+                    throw Error("missing end group");
                 return message;
             };
 
@@ -370,7 +378,7 @@ $root.jspb = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $util.recursionLimit)
-                    return "maximum nesting depth exceeded";
+                    return "max depth exceeded";
                 if (message.outerEnum != null && message.hasOwnProperty("outerEnum"))
                     switch (message.outerEnum) {
                     default:
@@ -396,7 +404,7 @@ $root.jspb = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $util.recursionLimit)
-                    throw Error("maximum nesting depth exceeded");
+                    throw Error("max depth exceeded");
                 var message = new $root.jspb.test.EnumContainer();
                 switch (object.outerEnum) {
                 default:
@@ -580,12 +588,14 @@ $root.jspb = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $Reader.recursionLimit)
-                    throw Error("maximum nesting depth exceeded");
+                    throw Error("max depth exceeded");
                 var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.jspb.test.Simple1();
                 while (reader.pos < end) {
                     var tag = reader.uint32();
-                    if (tag === _end)
+                    if (tag === _end) {
+                        _end = undefined;
                         break;
+                    }
                     switch (tag) {
                     case 10: {
                             message.aString = reader.string();
@@ -602,10 +612,12 @@ $root.jspb = (function() {
                             break;
                         }
                     default:
-                        reader.skipType(tag & 7, _depth);
+                        reader.skipType(tag & 7, _depth, tag >>> 3);
                         break;
                     }
                 }
+                if (_end !== undefined)
+                    throw Error("missing end group");
                 if (!message.hasOwnProperty("aString"))
                     throw $util.ProtocolError("missing required 'aString'", { instance: message });
                 return message;
@@ -641,7 +653,7 @@ $root.jspb = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $util.recursionLimit)
-                    return "maximum nesting depth exceeded";
+                    return "max depth exceeded";
                 if (!$util.isString(message.aString))
                     return "aString: string expected";
                 if (message.aRepeatedString != null && message.hasOwnProperty("aRepeatedString")) {
@@ -671,7 +683,7 @@ $root.jspb = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $util.recursionLimit)
-                    throw Error("maximum nesting depth exceeded");
+                    throw Error("max depth exceeded");
                 var message = new $root.jspb.test.Simple1();
                 if (object.aString != null)
                     message.aString = String(object.aString);
@@ -850,12 +862,14 @@ $root.jspb = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $Reader.recursionLimit)
-                    throw Error("maximum nesting depth exceeded");
+                    throw Error("max depth exceeded");
                 var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.jspb.test.Simple2();
                 while (reader.pos < end) {
                     var tag = reader.uint32();
-                    if (tag === _end)
+                    if (tag === _end) {
+                        _end = undefined;
                         break;
+                    }
                     switch (tag) {
                     case 10: {
                             message.aString = reader.string();
@@ -868,10 +882,12 @@ $root.jspb = (function() {
                             break;
                         }
                     default:
-                        reader.skipType(tag & 7, _depth);
+                        reader.skipType(tag & 7, _depth, tag >>> 3);
                         break;
                     }
                 }
+                if (_end !== undefined)
+                    throw Error("missing end group");
                 if (!message.hasOwnProperty("aString"))
                     throw $util.ProtocolError("missing required 'aString'", { instance: message });
                 return message;
@@ -907,7 +923,7 @@ $root.jspb = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $util.recursionLimit)
-                    return "maximum nesting depth exceeded";
+                    return "max depth exceeded";
                 if (!$util.isString(message.aString))
                     return "aString: string expected";
                 if (message.aRepeatedString != null && message.hasOwnProperty("aRepeatedString")) {
@@ -934,7 +950,7 @@ $root.jspb = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $util.recursionLimit)
-                    throw Error("maximum nesting depth exceeded");
+                    throw Error("max depth exceeded");
                 var message = new $root.jspb.test.Simple2();
                 if (object.aString != null)
                     message.aString = String(object.aString);
@@ -1124,12 +1140,14 @@ $root.jspb = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $Reader.recursionLimit)
-                    throw Error("maximum nesting depth exceeded");
+                    throw Error("max depth exceeded");
                 var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.jspb.test.SpecialCases();
                 while (reader.pos < end) {
                     var tag = reader.uint32();
-                    if (tag === _end)
+                    if (tag === _end) {
+                        _end = undefined;
                         break;
+                    }
                     switch (tag) {
                     case 10: {
                             message.normal = reader.string();
@@ -1148,10 +1166,12 @@ $root.jspb = (function() {
                             break;
                         }
                     default:
-                        reader.skipType(tag & 7, _depth);
+                        reader.skipType(tag & 7, _depth, tag >>> 3);
                         break;
                     }
                 }
+                if (_end !== undefined)
+                    throw Error("missing end group");
                 if (!message.hasOwnProperty("normal"))
                     throw $util.ProtocolError("missing required 'normal'", { instance: message });
                 if (!message.hasOwnProperty("default"))
@@ -1193,7 +1213,7 @@ $root.jspb = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $util.recursionLimit)
-                    return "maximum nesting depth exceeded";
+                    return "max depth exceeded";
                 if (!$util.isString(message.normal))
                     return "normal: string expected";
                 if (!$util.isString(message["default"]))
@@ -1219,7 +1239,7 @@ $root.jspb = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $util.recursionLimit)
-                    throw Error("maximum nesting depth exceeded");
+                    throw Error("max depth exceeded");
                 var message = new $root.jspb.test.SpecialCases();
                 if (object.normal != null)
                     message.normal = String(object.normal);
@@ -1429,12 +1449,14 @@ $root.jspb = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $Reader.recursionLimit)
-                    throw Error("maximum nesting depth exceeded");
+                    throw Error("max depth exceeded");
                 var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.jspb.test.OptionalFields();
                 while (reader.pos < end) {
                     var tag = reader.uint32();
-                    if (tag === _end)
+                    if (tag === _end) {
+                        _end = undefined;
                         break;
+                    }
                     switch (tag) {
                     case 10: {
                             message.aString = reader.string();
@@ -1461,10 +1483,12 @@ $root.jspb = (function() {
                             break;
                         }
                     default:
-                        reader.skipType(tag & 7, _depth);
+                        reader.skipType(tag & 7, _depth, tag >>> 3);
                         break;
                     }
                 }
+                if (_end !== undefined)
+                    throw Error("missing end group");
                 if (!message.hasOwnProperty("aBool"))
                     throw $util.ProtocolError("missing required 'aBool'", { instance: message });
                 return message;
@@ -1500,7 +1524,7 @@ $root.jspb = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $util.recursionLimit)
-                    return "maximum nesting depth exceeded";
+                    return "max depth exceeded";
                 if (message.aString != null && message.hasOwnProperty("aString"))
                     if (!$util.isString(message.aString))
                         return "aString: string expected";
@@ -1544,7 +1568,7 @@ $root.jspb = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $util.recursionLimit)
-                    throw Error("maximum nesting depth exceeded");
+                    throw Error("max depth exceeded");
                 var message = new $root.jspb.test.OptionalFields();
                 if (object.aString != null)
                     message.aString = String(object.aString);
@@ -1733,22 +1757,26 @@ $root.jspb = (function() {
                     if (_depth === undefined)
                         _depth = 0;
                     if (_depth > $Reader.recursionLimit)
-                        throw Error("maximum nesting depth exceeded");
+                        throw Error("max depth exceeded");
                     var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.jspb.test.OptionalFields.Nested();
                     while (reader.pos < end) {
                         var tag = reader.uint32();
-                        if (tag === _end)
+                        if (tag === _end) {
+                            _end = undefined;
                             break;
+                        }
                         switch (tag) {
                         case 8: {
                                 message.anInt = reader.int32();
                                 break;
                             }
                         default:
-                            reader.skipType(tag & 7, _depth);
+                            reader.skipType(tag & 7, _depth, tag >>> 3);
                             break;
                         }
                     }
+                    if (_end !== undefined)
+                        throw Error("missing end group");
                     return message;
                 };
 
@@ -1782,7 +1810,7 @@ $root.jspb = (function() {
                     if (_depth === undefined)
                         _depth = 0;
                     if (_depth > $util.recursionLimit)
-                        return "maximum nesting depth exceeded";
+                        return "max depth exceeded";
                     if (message.anInt != null && message.hasOwnProperty("anInt"))
                         if (!$util.isInteger(message.anInt))
                             return "anInt: integer expected";
@@ -1803,7 +1831,7 @@ $root.jspb = (function() {
                     if (_depth === undefined)
                         _depth = 0;
                     if (_depth > $util.recursionLimit)
-                        throw Error("maximum nesting depth exceeded");
+                        throw Error("max depth exceeded");
                     var message = new $root.jspb.test.OptionalFields.Nested();
                     if (object.anInt != null)
                         message.anInt = object.anInt | 0;
@@ -2010,12 +2038,14 @@ $root.jspb = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $Reader.recursionLimit)
-                    throw Error("maximum nesting depth exceeded");
+                    throw Error("max depth exceeded");
                 var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.jspb.test.HasExtensions();
                 while (reader.pos < end) {
                     var tag = reader.uint32();
-                    if (tag === _end)
+                    if (tag === _end) {
+                        _end = undefined;
                         break;
+                    }
                     switch (tag) {
                     case 10: {
                             message.str1 = reader.string();
@@ -2058,10 +2088,12 @@ $root.jspb = (function() {
                             break;
                         }
                     default:
-                        reader.skipType(tag & 7, _depth);
+                        reader.skipType(tag & 7, _depth, tag >>> 3);
                         break;
                     }
                 }
+                if (_end !== undefined)
+                    throw Error("missing end group");
                 return message;
             };
 
@@ -2095,7 +2127,7 @@ $root.jspb = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $util.recursionLimit)
-                    return "maximum nesting depth exceeded";
+                    return "max depth exceeded";
                 if (message.str1 != null && message.hasOwnProperty("str1"))
                     if (!$util.isString(message.str1))
                         return "str1: string expected";
@@ -2156,7 +2188,7 @@ $root.jspb = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $util.recursionLimit)
-                    throw Error("maximum nesting depth exceeded");
+                    throw Error("max depth exceeded");
                 var message = new $root.jspb.test.HasExtensions();
                 if (object.str1 != null)
                     message.str1 = String(object.str1);
@@ -2420,12 +2452,14 @@ $root.jspb = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $Reader.recursionLimit)
-                    throw Error("maximum nesting depth exceeded");
+                    throw Error("max depth exceeded");
                 var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.jspb.test.Complex();
                 while (reader.pos < end) {
                     var tag = reader.uint32();
-                    if (tag === _end)
+                    if (tag === _end) {
+                        _end = undefined;
                         break;
+                    }
                     switch (tag) {
                     case 10: {
                             message.aString = reader.string();
@@ -2452,10 +2486,12 @@ $root.jspb = (function() {
                             break;
                         }
                     default:
-                        reader.skipType(tag & 7, _depth);
+                        reader.skipType(tag & 7, _depth, tag >>> 3);
                         break;
                     }
                 }
+                if (_end !== undefined)
+                    throw Error("missing end group");
                 if (!message.hasOwnProperty("aString"))
                     throw $util.ProtocolError("missing required 'aString'", { instance: message });
                 if (!message.hasOwnProperty("anOutOfOrderBool"))
@@ -2493,7 +2529,7 @@ $root.jspb = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $util.recursionLimit)
-                    return "maximum nesting depth exceeded";
+                    return "max depth exceeded";
                 if (!$util.isString(message.aString))
                     return "aString: string expected";
                 if (typeof message.anOutOfOrderBool !== "boolean")
@@ -2536,7 +2572,7 @@ $root.jspb = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $util.recursionLimit)
-                    throw Error("maximum nesting depth exceeded");
+                    throw Error("max depth exceeded");
                 var message = new $root.jspb.test.Complex();
                 if (object.aString != null)
                     message.aString = String(object.aString);
@@ -2724,22 +2760,26 @@ $root.jspb = (function() {
                     if (_depth === undefined)
                         _depth = 0;
                     if (_depth > $Reader.recursionLimit)
-                        throw Error("maximum nesting depth exceeded");
+                        throw Error("max depth exceeded");
                     var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.jspb.test.Complex.Nested();
                     while (reader.pos < end) {
                         var tag = reader.uint32();
-                        if (tag === _end)
+                        if (tag === _end) {
+                            _end = undefined;
                             break;
+                        }
                         switch (tag) {
                         case 16: {
                                 message.anInt = reader.int32();
                                 break;
                             }
                         default:
-                            reader.skipType(tag & 7, _depth);
+                            reader.skipType(tag & 7, _depth, tag >>> 3);
                             break;
                         }
                     }
+                    if (_end !== undefined)
+                        throw Error("missing end group");
                     if (!message.hasOwnProperty("anInt"))
                         throw $util.ProtocolError("missing required 'anInt'", { instance: message });
                     return message;
@@ -2775,7 +2815,7 @@ $root.jspb = (function() {
                     if (_depth === undefined)
                         _depth = 0;
                     if (_depth > $util.recursionLimit)
-                        return "maximum nesting depth exceeded";
+                        return "max depth exceeded";
                     if (!$util.isInteger(message.anInt))
                         return "anInt: integer expected";
                     return null;
@@ -2795,7 +2835,7 @@ $root.jspb = (function() {
                     if (_depth === undefined)
                         _depth = 0;
                     if (_depth > $util.recursionLimit)
-                        throw Error("maximum nesting depth exceeded");
+                        throw Error("max depth exceeded");
                     var message = new $root.jspb.test.Complex.Nested();
                     if (object.anInt != null)
                         message.anInt = object.anInt | 0;
@@ -2934,18 +2974,22 @@ $root.jspb = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $Reader.recursionLimit)
-                    throw Error("maximum nesting depth exceeded");
+                    throw Error("max depth exceeded");
                 var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.jspb.test.OuterMessage();
                 while (reader.pos < end) {
                     var tag = reader.uint32();
-                    if (tag === _end)
+                    if (tag === _end) {
+                        _end = undefined;
                         break;
+                    }
                     switch (tag) {
                     default:
-                        reader.skipType(tag & 7, _depth);
+                        reader.skipType(tag & 7, _depth, tag >>> 3);
                         break;
                     }
                 }
+                if (_end !== undefined)
+                    throw Error("missing end group");
                 return message;
             };
 
@@ -2979,7 +3023,7 @@ $root.jspb = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $util.recursionLimit)
-                    return "maximum nesting depth exceeded";
+                    return "max depth exceeded";
                 return null;
             };
 
@@ -2997,7 +3041,7 @@ $root.jspb = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $util.recursionLimit)
-                    throw Error("maximum nesting depth exceeded");
+                    throw Error("max depth exceeded");
                 return new $root.jspb.test.OuterMessage();
             };
 
@@ -3131,22 +3175,26 @@ $root.jspb = (function() {
                     if (_depth === undefined)
                         _depth = 0;
                     if (_depth > $Reader.recursionLimit)
-                        throw Error("maximum nesting depth exceeded");
+                        throw Error("max depth exceeded");
                     var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.jspb.test.OuterMessage.Complex();
                     while (reader.pos < end) {
                         var tag = reader.uint32();
-                        if (tag === _end)
+                        if (tag === _end) {
+                            _end = undefined;
                             break;
+                        }
                         switch (tag) {
                         case 8: {
                                 message.innerComplexField = reader.int32();
                                 break;
                             }
                         default:
-                            reader.skipType(tag & 7, _depth);
+                            reader.skipType(tag & 7, _depth, tag >>> 3);
                             break;
                         }
                     }
+                    if (_end !== undefined)
+                        throw Error("missing end group");
                     return message;
                 };
 
@@ -3180,7 +3228,7 @@ $root.jspb = (function() {
                     if (_depth === undefined)
                         _depth = 0;
                     if (_depth > $util.recursionLimit)
-                        return "maximum nesting depth exceeded";
+                        return "max depth exceeded";
                     if (message.innerComplexField != null && message.hasOwnProperty("innerComplexField"))
                         if (!$util.isInteger(message.innerComplexField))
                             return "innerComplexField: integer expected";
@@ -3201,7 +3249,7 @@ $root.jspb = (function() {
                     if (_depth === undefined)
                         _depth = 0;
                     if (_depth > $util.recursionLimit)
-                        throw Error("maximum nesting depth exceeded");
+                        throw Error("max depth exceeded");
                     var message = new $root.jspb.test.OuterMessage.Complex();
                     if (object.innerComplexField != null)
                         message.innerComplexField = object.innerComplexField | 0;
@@ -3351,22 +3399,26 @@ $root.jspb = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $Reader.recursionLimit)
-                    throw Error("maximum nesting depth exceeded");
+                    throw Error("max depth exceeded");
                 var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.jspb.test.IsExtension();
                 while (reader.pos < end) {
                     var tag = reader.uint32();
-                    if (tag === _end)
+                    if (tag === _end) {
+                        _end = undefined;
                         break;
+                    }
                     switch (tag) {
                     case 10: {
                             message.ext1 = reader.string();
                             break;
                         }
                     default:
-                        reader.skipType(tag & 7, _depth);
+                        reader.skipType(tag & 7, _depth, tag >>> 3);
                         break;
                     }
                 }
+                if (_end !== undefined)
+                    throw Error("missing end group");
                 return message;
             };
 
@@ -3400,7 +3452,7 @@ $root.jspb = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $util.recursionLimit)
-                    return "maximum nesting depth exceeded";
+                    return "max depth exceeded";
                 if (message.ext1 != null && message.hasOwnProperty("ext1"))
                     if (!$util.isString(message.ext1))
                         return "ext1: string expected";
@@ -3421,7 +3473,7 @@ $root.jspb = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $util.recursionLimit)
-                    throw Error("maximum nesting depth exceeded");
+                    throw Error("max depth exceeded");
                 var message = new $root.jspb.test.IsExtension();
                 if (object.ext1 != null)
                     message.ext1 = String(object.ext1);
@@ -3557,18 +3609,22 @@ $root.jspb = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $Reader.recursionLimit)
-                    throw Error("maximum nesting depth exceeded");
+                    throw Error("max depth exceeded");
                 var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.jspb.test.IndirectExtension();
                 while (reader.pos < end) {
                     var tag = reader.uint32();
-                    if (tag === _end)
+                    if (tag === _end) {
+                        _end = undefined;
                         break;
+                    }
                     switch (tag) {
                     default:
-                        reader.skipType(tag & 7, _depth);
+                        reader.skipType(tag & 7, _depth, tag >>> 3);
                         break;
                     }
                 }
+                if (_end !== undefined)
+                    throw Error("missing end group");
                 return message;
             };
 
@@ -3602,7 +3658,7 @@ $root.jspb = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $util.recursionLimit)
-                    return "maximum nesting depth exceeded";
+                    return "max depth exceeded";
                 return null;
             };
 
@@ -3620,7 +3676,7 @@ $root.jspb = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $util.recursionLimit)
-                    throw Error("maximum nesting depth exceeded");
+                    throw Error("max depth exceeded");
                 return new $root.jspb.test.IndirectExtension();
             };
 
@@ -3812,12 +3868,14 @@ $root.jspb = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $Reader.recursionLimit)
-                    throw Error("maximum nesting depth exceeded");
+                    throw Error("max depth exceeded");
                 var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.jspb.test.DefaultValues();
                 while (reader.pos < end) {
                     var tag = reader.uint32();
-                    if (tag === _end)
+                    if (tag === _end) {
+                        _end = undefined;
                         break;
+                    }
                     switch (tag) {
                     case 10: {
                             message.stringField = reader.string();
@@ -3844,10 +3902,12 @@ $root.jspb = (function() {
                             break;
                         }
                     default:
-                        reader.skipType(tag & 7, _depth);
+                        reader.skipType(tag & 7, _depth, tag >>> 3);
                         break;
                     }
                 }
+                if (_end !== undefined)
+                    throw Error("missing end group");
                 return message;
             };
 
@@ -3881,7 +3941,7 @@ $root.jspb = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $util.recursionLimit)
-                    return "maximum nesting depth exceeded";
+                    return "max depth exceeded";
                 if (message.stringField != null && message.hasOwnProperty("stringField"))
                     if (!$util.isString(message.stringField))
                         return "stringField: string expected";
@@ -3922,7 +3982,7 @@ $root.jspb = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $util.recursionLimit)
-                    throw Error("maximum nesting depth exceeded");
+                    throw Error("max depth exceeded");
                 var message = new $root.jspb.test.DefaultValues();
                 if (object.stringField != null)
                     message.stringField = String(object.stringField);
@@ -4229,12 +4289,14 @@ $root.jspb = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $Reader.recursionLimit)
-                    throw Error("maximum nesting depth exceeded");
+                    throw Error("max depth exceeded");
                 var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.jspb.test.FloatingPointFields();
                 while (reader.pos < end) {
                     var tag = reader.uint32();
-                    if (tag === _end)
+                    if (tag === _end) {
+                        _end = undefined;
                         break;
+                    }
                     switch (tag) {
                     case 13: {
                             message.optionalFloatField = reader.float();
@@ -4285,10 +4347,12 @@ $root.jspb = (function() {
                             break;
                         }
                     default:
-                        reader.skipType(tag & 7, _depth);
+                        reader.skipType(tag & 7, _depth, tag >>> 3);
                         break;
                     }
                 }
+                if (_end !== undefined)
+                    throw Error("missing end group");
                 if (!message.hasOwnProperty("requiredFloatField"))
                     throw $util.ProtocolError("missing required 'requiredFloatField'", { instance: message });
                 if (!message.hasOwnProperty("requiredDoubleField"))
@@ -4326,7 +4390,7 @@ $root.jspb = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $util.recursionLimit)
-                    return "maximum nesting depth exceeded";
+                    return "max depth exceeded";
                 if (message.optionalFloatField != null && message.hasOwnProperty("optionalFloatField"))
                     if (typeof message.optionalFloatField !== "number")
                         return "optionalFloatField: number expected";
@@ -4374,7 +4438,7 @@ $root.jspb = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $util.recursionLimit)
-                    throw Error("maximum nesting depth exceeded");
+                    throw Error("max depth exceeded");
                 var message = new $root.jspb.test.FloatingPointFields();
                 if (object.optionalFloatField != null)
                     message.optionalFloatField = Number(object.optionalFloatField);
@@ -4627,12 +4691,14 @@ $root.jspb = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $Reader.recursionLimit)
-                    throw Error("maximum nesting depth exceeded");
+                    throw Error("max depth exceeded");
                 var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.jspb.test.TestClone();
                 while (reader.pos < end) {
                     var tag = reader.uint32();
-                    if (tag === _end)
+                    if (tag === _end) {
+                        _end = undefined;
                         break;
+                    }
                     switch (tag) {
                     case 10: {
                             message.str = reader.string();
@@ -4661,10 +4727,12 @@ $root.jspb = (function() {
                             break;
                         }
                     default:
-                        reader.skipType(tag & 7, _depth);
+                        reader.skipType(tag & 7, _depth, tag >>> 3);
                         break;
                     }
                 }
+                if (_end !== undefined)
+                    throw Error("missing end group");
                 return message;
             };
 
@@ -4698,7 +4766,7 @@ $root.jspb = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $util.recursionLimit)
-                    return "maximum nesting depth exceeded";
+                    return "max depth exceeded";
                 if (message.str != null && message.hasOwnProperty("str"))
                     if (!$util.isString(message.str))
                         return "str: string expected";
@@ -4744,7 +4812,7 @@ $root.jspb = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $util.recursionLimit)
-                    throw Error("maximum nesting depth exceeded");
+                    throw Error("max depth exceeded");
                 var message = new $root.jspb.test.TestClone();
                 if (object.str != null)
                     message.str = String(object.str);
@@ -4944,22 +5012,26 @@ $root.jspb = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $Reader.recursionLimit)
-                    throw Error("maximum nesting depth exceeded");
+                    throw Error("max depth exceeded");
                 var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.jspb.test.CloneExtension();
                 while (reader.pos < end) {
                     var tag = reader.uint32();
-                    if (tag === _end)
+                    if (tag === _end) {
+                        _end = undefined;
                         break;
+                    }
                     switch (tag) {
                     case 18: {
                             message.ext = reader.string();
                             break;
                         }
                     default:
-                        reader.skipType(tag & 7, _depth);
+                        reader.skipType(tag & 7, _depth, tag >>> 3);
                         break;
                     }
                 }
+                if (_end !== undefined)
+                    throw Error("missing end group");
                 return message;
             };
 
@@ -4993,7 +5065,7 @@ $root.jspb = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $util.recursionLimit)
-                    return "maximum nesting depth exceeded";
+                    return "max depth exceeded";
                 if (message.ext != null && message.hasOwnProperty("ext"))
                     if (!$util.isString(message.ext))
                         return "ext: string expected";
@@ -5014,7 +5086,7 @@ $root.jspb = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $util.recursionLimit)
-                    throw Error("maximum nesting depth exceeded");
+                    throw Error("max depth exceeded");
                 var message = new $root.jspb.test.CloneExtension();
                 if (object.ext != null)
                     message.ext = String(object.ext);
@@ -5238,12 +5310,14 @@ $root.jspb = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $Reader.recursionLimit)
-                    throw Error("maximum nesting depth exceeded");
+                    throw Error("max depth exceeded");
                 var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.jspb.test.TestGroup();
                 while (reader.pos < end) {
                     var tag = reader.uint32();
-                    if (tag === _end)
+                    if (tag === _end) {
+                        _end = undefined;
                         break;
+                    }
                     switch (tag) {
                     case 11: {
                             if (!(message.repeatedGroup && message.repeatedGroup.length))
@@ -5280,10 +5354,12 @@ $root.jspb = (function() {
                             break;
                         }
                     default:
-                        reader.skipType(tag & 7, _depth);
+                        reader.skipType(tag & 7, _depth, tag >>> 3);
                         break;
                     }
                 }
+                if (_end !== undefined)
+                    throw Error("missing end group");
                 if (!message.hasOwnProperty("requiredGroup"))
                     throw $util.ProtocolError("missing required 'requiredGroup'", { instance: message });
                 if (!message.hasOwnProperty("requiredSimple"))
@@ -5321,7 +5397,7 @@ $root.jspb = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $util.recursionLimit)
-                    return "maximum nesting depth exceeded";
+                    return "max depth exceeded";
                 if (message.repeatedGroup != null && message.hasOwnProperty("repeatedGroup")) {
                     if (!Array.isArray(message.repeatedGroup))
                         return "repeatedGroup: array expected";
@@ -5381,7 +5457,7 @@ $root.jspb = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $util.recursionLimit)
-                    throw Error("maximum nesting depth exceeded");
+                    throw Error("max depth exceeded");
                 var message = new $root.jspb.test.TestGroup();
                 if (object.repeatedGroup) {
                     if (!Array.isArray(object.repeatedGroup))
@@ -5603,12 +5679,14 @@ $root.jspb = (function() {
                     if (_depth === undefined)
                         _depth = 0;
                     if (_depth > $Reader.recursionLimit)
-                        throw Error("maximum nesting depth exceeded");
+                        throw Error("max depth exceeded");
                     var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.jspb.test.TestGroup.RepeatedGroup();
                     while (reader.pos < end) {
                         var tag = reader.uint32();
-                        if (tag === _end)
+                        if (tag === _end) {
+                            _end = undefined;
                             break;
+                        }
                         switch (tag) {
                         case 10: {
                                 message.id = reader.string();
@@ -5627,10 +5705,12 @@ $root.jspb = (function() {
                                 break;
                             }
                         default:
-                            reader.skipType(tag & 7, _depth);
+                            reader.skipType(tag & 7, _depth, tag >>> 3);
                             break;
                         }
                     }
+                    if (_end !== undefined)
+                        throw Error("missing end group");
                     if (!message.hasOwnProperty("id"))
                         throw $util.ProtocolError("missing required 'id'", { instance: message });
                     return message;
@@ -5666,7 +5746,7 @@ $root.jspb = (function() {
                     if (_depth === undefined)
                         _depth = 0;
                     if (_depth > $util.recursionLimit)
-                        return "maximum nesting depth exceeded";
+                        return "max depth exceeded";
                     if (!$util.isString(message.id))
                         return "id: string expected";
                     if (message.someBool != null && message.hasOwnProperty("someBool")) {
@@ -5693,7 +5773,7 @@ $root.jspb = (function() {
                     if (_depth === undefined)
                         _depth = 0;
                     if (_depth > $util.recursionLimit)
-                        throw Error("maximum nesting depth exceeded");
+                        throw Error("max depth exceeded");
                     var message = new $root.jspb.test.TestGroup.RepeatedGroup();
                     if (object.id != null)
                         message.id = String(object.id);
@@ -5853,22 +5933,26 @@ $root.jspb = (function() {
                     if (_depth === undefined)
                         _depth = 0;
                     if (_depth > $Reader.recursionLimit)
-                        throw Error("maximum nesting depth exceeded");
+                        throw Error("max depth exceeded");
                     var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.jspb.test.TestGroup.RequiredGroup();
                     while (reader.pos < end) {
                         var tag = reader.uint32();
-                        if (tag === _end)
+                        if (tag === _end) {
+                            _end = undefined;
                             break;
+                        }
                         switch (tag) {
                         case 10: {
                                 message.id = reader.string();
                                 break;
                             }
                         default:
-                            reader.skipType(tag & 7, _depth);
+                            reader.skipType(tag & 7, _depth, tag >>> 3);
                             break;
                         }
                     }
+                    if (_end !== undefined)
+                        throw Error("missing end group");
                     if (!message.hasOwnProperty("id"))
                         throw $util.ProtocolError("missing required 'id'", { instance: message });
                     return message;
@@ -5904,7 +5988,7 @@ $root.jspb = (function() {
                     if (_depth === undefined)
                         _depth = 0;
                     if (_depth > $util.recursionLimit)
-                        return "maximum nesting depth exceeded";
+                        return "max depth exceeded";
                     if (!$util.isString(message.id))
                         return "id: string expected";
                     return null;
@@ -5924,7 +6008,7 @@ $root.jspb = (function() {
                     if (_depth === undefined)
                         _depth = 0;
                     if (_depth > $util.recursionLimit)
-                        throw Error("maximum nesting depth exceeded");
+                        throw Error("max depth exceeded");
                     var message = new $root.jspb.test.TestGroup.RequiredGroup();
                     if (object.id != null)
                         message.id = String(object.id);
@@ -6070,22 +6154,26 @@ $root.jspb = (function() {
                     if (_depth === undefined)
                         _depth = 0;
                     if (_depth > $Reader.recursionLimit)
-                        throw Error("maximum nesting depth exceeded");
+                        throw Error("max depth exceeded");
                     var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.jspb.test.TestGroup.OptionalGroup();
                     while (reader.pos < end) {
                         var tag = reader.uint32();
-                        if (tag === _end)
+                        if (tag === _end) {
+                            _end = undefined;
                             break;
+                        }
                         switch (tag) {
                         case 10: {
                                 message.id = reader.string();
                                 break;
                             }
                         default:
-                            reader.skipType(tag & 7, _depth);
+                            reader.skipType(tag & 7, _depth, tag >>> 3);
                             break;
                         }
                     }
+                    if (_end !== undefined)
+                        throw Error("missing end group");
                     if (!message.hasOwnProperty("id"))
                         throw $util.ProtocolError("missing required 'id'", { instance: message });
                     return message;
@@ -6121,7 +6209,7 @@ $root.jspb = (function() {
                     if (_depth === undefined)
                         _depth = 0;
                     if (_depth > $util.recursionLimit)
-                        return "maximum nesting depth exceeded";
+                        return "max depth exceeded";
                     if (!$util.isString(message.id))
                         return "id: string expected";
                     return null;
@@ -6141,7 +6229,7 @@ $root.jspb = (function() {
                     if (_depth === undefined)
                         _depth = 0;
                     if (_depth > $util.recursionLimit)
-                        throw Error("maximum nesting depth exceeded");
+                        throw Error("max depth exceeded");
                     var message = new $root.jspb.test.TestGroup.OptionalGroup();
                     if (object.id != null)
                         message.id = String(object.id);
@@ -6287,22 +6375,26 @@ $root.jspb = (function() {
                     if (_depth === undefined)
                         _depth = 0;
                     if (_depth > $Reader.recursionLimit)
-                        throw Error("maximum nesting depth exceeded");
+                        throw Error("max depth exceeded");
                     var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.jspb.test.TestGroup.MessageInGroup();
                     while (reader.pos < end) {
                         var tag = reader.uint32();
-                        if (tag === _end)
+                        if (tag === _end) {
+                            _end = undefined;
                             break;
+                        }
                         switch (tag) {
                         case 10: {
                                 message.id = $root.jspb.test.TestGroup.MessageInGroup.NestedMessage.decode(reader, reader.uint32(), undefined, _depth + 1, message.id);
                                 break;
                             }
                         default:
-                            reader.skipType(tag & 7, _depth);
+                            reader.skipType(tag & 7, _depth, tag >>> 3);
                             break;
                         }
                     }
+                    if (_end !== undefined)
+                        throw Error("missing end group");
                     if (!message.hasOwnProperty("id"))
                         throw $util.ProtocolError("missing required 'id'", { instance: message });
                     return message;
@@ -6338,7 +6430,7 @@ $root.jspb = (function() {
                     if (_depth === undefined)
                         _depth = 0;
                     if (_depth > $util.recursionLimit)
-                        return "maximum nesting depth exceeded";
+                        return "max depth exceeded";
                     {
                         var error = $root.jspb.test.TestGroup.MessageInGroup.NestedMessage.verify(message.id, _depth + 1);
                         if (error)
@@ -6361,7 +6453,7 @@ $root.jspb = (function() {
                     if (_depth === undefined)
                         _depth = 0;
                     if (_depth > $util.recursionLimit)
-                        throw Error("maximum nesting depth exceeded");
+                        throw Error("max depth exceeded");
                     var message = new $root.jspb.test.TestGroup.MessageInGroup();
                     if (object.id != null) {
                         if (typeof object.id !== "object")
@@ -6508,22 +6600,26 @@ $root.jspb = (function() {
                         if (_depth === undefined)
                             _depth = 0;
                         if (_depth > $Reader.recursionLimit)
-                            throw Error("maximum nesting depth exceeded");
+                            throw Error("max depth exceeded");
                         var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.jspb.test.TestGroup.MessageInGroup.NestedMessage();
                         while (reader.pos < end) {
                             var tag = reader.uint32();
-                            if (tag === _end)
+                            if (tag === _end) {
+                                _end = undefined;
                                 break;
+                            }
                             switch (tag) {
                             case 10: {
                                     message.id = reader.string();
                                     break;
                                 }
                             default:
-                                reader.skipType(tag & 7, _depth);
+                                reader.skipType(tag & 7, _depth, tag >>> 3);
                                 break;
                             }
                         }
+                        if (_end !== undefined)
+                            throw Error("missing end group");
                         return message;
                     };
 
@@ -6557,7 +6653,7 @@ $root.jspb = (function() {
                         if (_depth === undefined)
                             _depth = 0;
                         if (_depth > $util.recursionLimit)
-                            return "maximum nesting depth exceeded";
+                            return "max depth exceeded";
                         if (message.id != null && message.hasOwnProperty("id"))
                             if (!$util.isString(message.id))
                                 return "id: string expected";
@@ -6578,7 +6674,7 @@ $root.jspb = (function() {
                         if (_depth === undefined)
                             _depth = 0;
                         if (_depth > $util.recursionLimit)
-                            throw Error("maximum nesting depth exceeded");
+                            throw Error("max depth exceeded");
                         var message = new $root.jspb.test.TestGroup.MessageInGroup.NestedMessage();
                         if (object.id != null)
                             message.id = String(object.id);
@@ -6727,22 +6823,26 @@ $root.jspb = (function() {
                     if (_depth === undefined)
                         _depth = 0;
                     if (_depth > $Reader.recursionLimit)
-                        throw Error("maximum nesting depth exceeded");
+                        throw Error("max depth exceeded");
                     var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.jspb.test.TestGroup.EnumInGroup();
                     while (reader.pos < end) {
                         var tag = reader.uint32();
-                        if (tag === _end)
+                        if (tag === _end) {
+                            _end = undefined;
                             break;
+                        }
                         switch (tag) {
                         case 8: {
                                 message.id = reader.int32();
                                 break;
                             }
                         default:
-                            reader.skipType(tag & 7, _depth);
+                            reader.skipType(tag & 7, _depth, tag >>> 3);
                             break;
                         }
                     }
+                    if (_end !== undefined)
+                        throw Error("missing end group");
                     if (!message.hasOwnProperty("id"))
                         throw $util.ProtocolError("missing required 'id'", { instance: message });
                     return message;
@@ -6778,7 +6878,7 @@ $root.jspb = (function() {
                     if (_depth === undefined)
                         _depth = 0;
                     if (_depth > $util.recursionLimit)
-                        return "maximum nesting depth exceeded";
+                        return "max depth exceeded";
                     switch (message.id) {
                     default:
                         return "id: enum value expected";
@@ -6803,7 +6903,7 @@ $root.jspb = (function() {
                     if (_depth === undefined)
                         _depth = 0;
                     if (_depth > $util.recursionLimit)
-                        throw Error("maximum nesting depth exceeded");
+                        throw Error("max depth exceeded");
                     var message = new $root.jspb.test.TestGroup.EnumInGroup();
                     switch (object.id) {
                     default:
@@ -6981,22 +7081,26 @@ $root.jspb = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $Reader.recursionLimit)
-                    throw Error("maximum nesting depth exceeded");
+                    throw Error("max depth exceeded");
                 var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.jspb.test.TestGroup1();
                 while (reader.pos < end) {
                     var tag = reader.uint32();
-                    if (tag === _end)
+                    if (tag === _end) {
+                        _end = undefined;
                         break;
+                    }
                     switch (tag) {
                     case 10: {
                             message.group = $root.jspb.test.TestGroup.RepeatedGroup.decode(reader, reader.uint32(), undefined, _depth + 1, message.group);
                             break;
                         }
                     default:
-                        reader.skipType(tag & 7, _depth);
+                        reader.skipType(tag & 7, _depth, tag >>> 3);
                         break;
                     }
                 }
+                if (_end !== undefined)
+                    throw Error("missing end group");
                 return message;
             };
 
@@ -7030,7 +7134,7 @@ $root.jspb = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $util.recursionLimit)
-                    return "maximum nesting depth exceeded";
+                    return "max depth exceeded";
                 if (message.group != null && message.hasOwnProperty("group")) {
                     var error = $root.jspb.test.TestGroup.RepeatedGroup.verify(message.group, _depth + 1);
                     if (error)
@@ -7053,7 +7157,7 @@ $root.jspb = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $util.recursionLimit)
-                    throw Error("maximum nesting depth exceeded");
+                    throw Error("max depth exceeded");
                 var message = new $root.jspb.test.TestGroup1();
                 if (object.group != null) {
                     if (typeof object.group !== "object")
@@ -7209,12 +7313,14 @@ $root.jspb = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $Reader.recursionLimit)
-                    throw Error("maximum nesting depth exceeded");
+                    throw Error("max depth exceeded");
                 var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.jspb.test.TestReservedNames();
                 while (reader.pos < end) {
                     var tag = reader.uint32();
-                    if (tag === _end)
+                    if (tag === _end) {
+                        _end = undefined;
                         break;
+                    }
                     switch (tag) {
                     case 8: {
                             message.extension = reader.int32();
@@ -7225,10 +7331,12 @@ $root.jspb = (function() {
                             break;
                         }
                     default:
-                        reader.skipType(tag & 7, _depth);
+                        reader.skipType(tag & 7, _depth, tag >>> 3);
                         break;
                     }
                 }
+                if (_end !== undefined)
+                    throw Error("missing end group");
                 return message;
             };
 
@@ -7262,7 +7370,7 @@ $root.jspb = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $util.recursionLimit)
-                    return "maximum nesting depth exceeded";
+                    return "max depth exceeded";
                 if (message.extension != null && message.hasOwnProperty("extension"))
                     if (!$util.isInteger(message.extension))
                         return "extension: integer expected";
@@ -7286,7 +7394,7 @@ $root.jspb = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $util.recursionLimit)
-                    throw Error("maximum nesting depth exceeded");
+                    throw Error("max depth exceeded");
                 var message = new $root.jspb.test.TestReservedNames();
                 if (object.extension != null)
                     message.extension = object.extension | 0;
@@ -7428,18 +7536,22 @@ $root.jspb = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $Reader.recursionLimit)
-                    throw Error("maximum nesting depth exceeded");
+                    throw Error("max depth exceeded");
                 var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.jspb.test.TestReservedNamesExtension();
                 while (reader.pos < end) {
                     var tag = reader.uint32();
-                    if (tag === _end)
+                    if (tag === _end) {
+                        _end = undefined;
                         break;
+                    }
                     switch (tag) {
                     default:
-                        reader.skipType(tag & 7, _depth);
+                        reader.skipType(tag & 7, _depth, tag >>> 3);
                         break;
                     }
                 }
+                if (_end !== undefined)
+                    throw Error("missing end group");
                 return message;
             };
 
@@ -7473,7 +7585,7 @@ $root.jspb = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $util.recursionLimit)
-                    return "maximum nesting depth exceeded";
+                    return "max depth exceeded";
                 return null;
             };
 
@@ -7491,7 +7603,7 @@ $root.jspb = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $util.recursionLimit)
-                    throw Error("maximum nesting depth exceeded");
+                    throw Error("max depth exceeded");
                 return new $root.jspb.test.TestReservedNamesExtension();
             };
 
@@ -7776,12 +7888,14 @@ $root.jspb = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $Reader.recursionLimit)
-                    throw Error("maximum nesting depth exceeded");
+                    throw Error("max depth exceeded");
                 var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.jspb.test.TestMessageWithOneof();
                 while (reader.pos < end) {
                     var tag = reader.uint32();
-                    if (tag === _end)
+                    if (tag === _end) {
+                        _end = undefined;
                         break;
+                    }
                     switch (tag) {
                     case 26: {
                             message.pone = reader.string();
@@ -7834,10 +7948,12 @@ $root.jspb = (function() {
                             break;
                         }
                     default:
-                        reader.skipType(tag & 7, _depth);
+                        reader.skipType(tag & 7, _depth, tag >>> 3);
                         break;
                     }
                 }
+                if (_end !== undefined)
+                    throw Error("missing end group");
                 return message;
             };
 
@@ -7871,7 +7987,7 @@ $root.jspb = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $util.recursionLimit)
-                    return "maximum nesting depth exceeded";
+                    return "max depth exceeded";
                 var properties = {};
                 if (message.pone != null && message.hasOwnProperty("pone")) {
                     properties.partialOneof = 1;
@@ -7951,7 +8067,7 @@ $root.jspb = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $util.recursionLimit)
-                    throw Error("maximum nesting depth exceeded");
+                    throw Error("max depth exceeded");
                 var message = new $root.jspb.test.TestMessageWithOneof();
                 if (object.pone != null)
                     message.pone = String(object.pone);
@@ -8182,12 +8298,14 @@ $root.jspb = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $Reader.recursionLimit)
-                    throw Error("maximum nesting depth exceeded");
+                    throw Error("max depth exceeded");
                 var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.jspb.test.TestEndsWithBytes();
                 while (reader.pos < end) {
                     var tag = reader.uint32();
-                    if (tag === _end)
+                    if (tag === _end) {
+                        _end = undefined;
                         break;
+                    }
                     switch (tag) {
                     case 8: {
                             message.value = reader.int32();
@@ -8198,10 +8316,12 @@ $root.jspb = (function() {
                             break;
                         }
                     default:
-                        reader.skipType(tag & 7, _depth);
+                        reader.skipType(tag & 7, _depth, tag >>> 3);
                         break;
                     }
                 }
+                if (_end !== undefined)
+                    throw Error("missing end group");
                 return message;
             };
 
@@ -8235,7 +8355,7 @@ $root.jspb = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $util.recursionLimit)
-                    return "maximum nesting depth exceeded";
+                    return "max depth exceeded";
                 if (message.value != null && message.hasOwnProperty("value"))
                     if (!$util.isInteger(message.value))
                         return "value: integer expected";
@@ -8259,7 +8379,7 @@ $root.jspb = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $util.recursionLimit)
-                    throw Error("maximum nesting depth exceeded");
+                    throw Error("max depth exceeded");
                 var message = new $root.jspb.test.TestEndsWithBytes();
                 if (object.value != null)
                     message.value = object.value | 0;
@@ -8568,12 +8688,14 @@ $root.jspb = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $Reader.recursionLimit)
-                    throw Error("maximum nesting depth exceeded");
+                    throw Error("max depth exceeded");
                 var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.jspb.test.TestMapFieldsNoBinary(), key, value;
                 while (reader.pos < end) {
                     var tag = reader.uint32();
-                    if (tag === _end)
+                    if (tag === _end) {
+                        _end = undefined;
                         break;
+                    }
                     switch (tag) {
                     case 10: {
                             if (message.mapStringString === $util.emptyObject)
@@ -8591,7 +8713,7 @@ $root.jspb = (function() {
                                     value = reader.string();
                                     break;
                                 default:
-                                    reader.skipType(tag2 & 7, _depth);
+                                    reader.skipType(tag2 & 7, _depth, tag2 >>> 3);
                                     break;
                                 }
                             }
@@ -8616,7 +8738,7 @@ $root.jspb = (function() {
                                     value = reader.int32();
                                     break;
                                 default:
-                                    reader.skipType(tag2 & 7, _depth);
+                                    reader.skipType(tag2 & 7, _depth, tag2 >>> 3);
                                     break;
                                 }
                             }
@@ -8641,7 +8763,7 @@ $root.jspb = (function() {
                                     value = reader.int64();
                                     break;
                                 default:
-                                    reader.skipType(tag2 & 7, _depth);
+                                    reader.skipType(tag2 & 7, _depth, tag2 >>> 3);
                                     break;
                                 }
                             }
@@ -8666,7 +8788,7 @@ $root.jspb = (function() {
                                     value = reader.bool();
                                     break;
                                 default:
-                                    reader.skipType(tag2 & 7, _depth);
+                                    reader.skipType(tag2 & 7, _depth, tag2 >>> 3);
                                     break;
                                 }
                             }
@@ -8691,7 +8813,7 @@ $root.jspb = (function() {
                                     value = reader.double();
                                     break;
                                 default:
-                                    reader.skipType(tag2 & 7, _depth);
+                                    reader.skipType(tag2 & 7, _depth, tag2 >>> 3);
                                     break;
                                 }
                             }
@@ -8716,7 +8838,7 @@ $root.jspb = (function() {
                                     value = reader.int32();
                                     break;
                                 default:
-                                    reader.skipType(tag2 & 7, _depth);
+                                    reader.skipType(tag2 & 7, _depth, tag2 >>> 3);
                                     break;
                                 }
                             }
@@ -8741,7 +8863,7 @@ $root.jspb = (function() {
                                     value = $root.jspb.test.MapValueMessageNoBinary.decode(reader, reader.uint32(), undefined, _depth + 1);
                                     break;
                                 default:
-                                    reader.skipType(tag2 & 7, _depth);
+                                    reader.skipType(tag2 & 7, _depth, tag2 >>> 3);
                                     break;
                                 }
                             }
@@ -8766,7 +8888,7 @@ $root.jspb = (function() {
                                     value = reader.string();
                                     break;
                                 default:
-                                    reader.skipType(tag2 & 7, _depth);
+                                    reader.skipType(tag2 & 7, _depth, tag2 >>> 3);
                                     break;
                                 }
                             }
@@ -8789,7 +8911,7 @@ $root.jspb = (function() {
                                     value = reader.string();
                                     break;
                                 default:
-                                    reader.skipType(tag2 & 7, _depth);
+                                    reader.skipType(tag2 & 7, _depth, tag2 >>> 3);
                                     break;
                                 }
                             }
@@ -8812,7 +8934,7 @@ $root.jspb = (function() {
                                     value = reader.string();
                                     break;
                                 default:
-                                    reader.skipType(tag2 & 7, _depth);
+                                    reader.skipType(tag2 & 7, _depth, tag2 >>> 3);
                                     break;
                                 }
                             }
@@ -8839,7 +8961,7 @@ $root.jspb = (function() {
                                     value = $root.jspb.test.TestMapFieldsNoBinary.decode(reader, reader.uint32(), undefined, _depth + 1);
                                     break;
                                 default:
-                                    reader.skipType(tag2 & 7, _depth);
+                                    reader.skipType(tag2 & 7, _depth, tag2 >>> 3);
                                     break;
                                 }
                             }
@@ -8849,10 +8971,12 @@ $root.jspb = (function() {
                             break;
                         }
                     default:
-                        reader.skipType(tag & 7, _depth);
+                        reader.skipType(tag & 7, _depth, tag >>> 3);
                         break;
                     }
                 }
+                if (_end !== undefined)
+                    throw Error("missing end group");
                 return message;
             };
 
@@ -8886,7 +9010,7 @@ $root.jspb = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $util.recursionLimit)
-                    return "maximum nesting depth exceeded";
+                    return "max depth exceeded";
                 if (message.mapStringString != null && message.hasOwnProperty("mapStringString")) {
                     if (!$util.isObject(message.mapStringString))
                         return "mapStringString: object expected";
@@ -9016,7 +9140,7 @@ $root.jspb = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $util.recursionLimit)
-                    throw Error("maximum nesting depth exceeded");
+                    throw Error("max depth exceeded");
                 var message = new $root.jspb.test.TestMapFieldsNoBinary();
                 if (object.mapStringString) {
                     if (typeof object.mapStringString !== "object")
@@ -9428,22 +9552,26 @@ $root.jspb = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $Reader.recursionLimit)
-                    throw Error("maximum nesting depth exceeded");
+                    throw Error("max depth exceeded");
                 var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.jspb.test.MapValueMessageNoBinary();
                 while (reader.pos < end) {
                     var tag = reader.uint32();
-                    if (tag === _end)
+                    if (tag === _end) {
+                        _end = undefined;
                         break;
+                    }
                     switch (tag) {
                     case 8: {
                             message.foo = reader.int32();
                             break;
                         }
                     default:
-                        reader.skipType(tag & 7, _depth);
+                        reader.skipType(tag & 7, _depth, tag >>> 3);
                         break;
                     }
                 }
+                if (_end !== undefined)
+                    throw Error("missing end group");
                 return message;
             };
 
@@ -9477,7 +9605,7 @@ $root.jspb = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $util.recursionLimit)
-                    return "maximum nesting depth exceeded";
+                    return "max depth exceeded";
                 if (message.foo != null && message.hasOwnProperty("foo"))
                     if (!$util.isInteger(message.foo))
                         return "foo: integer expected";
@@ -9498,7 +9626,7 @@ $root.jspb = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $util.recursionLimit)
-                    throw Error("maximum nesting depth exceeded");
+                    throw Error("max depth exceeded");
                 var message = new $root.jspb.test.MapValueMessageNoBinary();
                 if (object.foo != null)
                     message.foo = object.foo | 0;
@@ -9634,18 +9762,22 @@ $root.jspb = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $Reader.recursionLimit)
-                    throw Error("maximum nesting depth exceeded");
+                    throw Error("max depth exceeded");
                 var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.jspb.test.Deeply();
                 while (reader.pos < end) {
                     var tag = reader.uint32();
-                    if (tag === _end)
+                    if (tag === _end) {
+                        _end = undefined;
                         break;
+                    }
                     switch (tag) {
                     default:
-                        reader.skipType(tag & 7, _depth);
+                        reader.skipType(tag & 7, _depth, tag >>> 3);
                         break;
                     }
                 }
+                if (_end !== undefined)
+                    throw Error("missing end group");
                 return message;
             };
 
@@ -9679,7 +9811,7 @@ $root.jspb = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $util.recursionLimit)
-                    return "maximum nesting depth exceeded";
+                    return "max depth exceeded";
                 return null;
             };
 
@@ -9697,7 +9829,7 @@ $root.jspb = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $util.recursionLimit)
-                    throw Error("maximum nesting depth exceeded");
+                    throw Error("max depth exceeded");
                 return new $root.jspb.test.Deeply();
             };
 
@@ -9820,18 +9952,22 @@ $root.jspb = (function() {
                     if (_depth === undefined)
                         _depth = 0;
                     if (_depth > $Reader.recursionLimit)
-                        throw Error("maximum nesting depth exceeded");
+                        throw Error("max depth exceeded");
                     var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.jspb.test.Deeply.Nested();
                     while (reader.pos < end) {
                         var tag = reader.uint32();
-                        if (tag === _end)
+                        if (tag === _end) {
+                            _end = undefined;
                             break;
+                        }
                         switch (tag) {
                         default:
-                            reader.skipType(tag & 7, _depth);
+                            reader.skipType(tag & 7, _depth, tag >>> 3);
                             break;
                         }
                     }
+                    if (_end !== undefined)
+                        throw Error("missing end group");
                     return message;
                 };
 
@@ -9865,7 +10001,7 @@ $root.jspb = (function() {
                     if (_depth === undefined)
                         _depth = 0;
                     if (_depth > $util.recursionLimit)
-                        return "maximum nesting depth exceeded";
+                        return "max depth exceeded";
                     return null;
                 };
 
@@ -9883,7 +10019,7 @@ $root.jspb = (function() {
                     if (_depth === undefined)
                         _depth = 0;
                     if (_depth > $util.recursionLimit)
-                        throw Error("maximum nesting depth exceeded");
+                        throw Error("max depth exceeded");
                     return new $root.jspb.test.Deeply.Nested();
                 };
 
@@ -10017,22 +10153,26 @@ $root.jspb = (function() {
                         if (_depth === undefined)
                             _depth = 0;
                         if (_depth > $Reader.recursionLimit)
-                            throw Error("maximum nesting depth exceeded");
+                            throw Error("max depth exceeded");
                         var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.jspb.test.Deeply.Nested.Message();
                         while (reader.pos < end) {
                             var tag = reader.uint32();
-                            if (tag === _end)
+                            if (tag === _end) {
+                                _end = undefined;
                                 break;
+                            }
                             switch (tag) {
                             case 8: {
                                     message.count = reader.int32();
                                     break;
                                 }
                             default:
-                                reader.skipType(tag & 7, _depth);
+                                reader.skipType(tag & 7, _depth, tag >>> 3);
                                 break;
                             }
                         }
+                        if (_end !== undefined)
+                            throw Error("missing end group");
                         return message;
                     };
 
@@ -10066,7 +10206,7 @@ $root.jspb = (function() {
                         if (_depth === undefined)
                             _depth = 0;
                         if (_depth > $util.recursionLimit)
-                            return "maximum nesting depth exceeded";
+                            return "max depth exceeded";
                         if (message.count != null && message.hasOwnProperty("count"))
                             if (!$util.isInteger(message.count))
                                 return "count: integer expected";
@@ -10087,7 +10227,7 @@ $root.jspb = (function() {
                         if (_depth === undefined)
                             _depth = 0;
                         if (_depth > $util.recursionLimit)
-                            throw Error("maximum nesting depth exceeded");
+                            throw Error("max depth exceeded");
                         var message = new $root.jspb.test.Deeply.Nested.Message();
                         if (object.count != null)
                             message.count = object.count | 0;
@@ -10266,12 +10406,14 @@ $root.google = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $Reader.recursionLimit)
-                    throw Error("maximum nesting depth exceeded");
+                    throw Error("max depth exceeded");
                 var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.google.protobuf.FileDescriptorSet();
                 while (reader.pos < end) {
                     var tag = reader.uint32();
-                    if (tag === _end)
+                    if (tag === _end) {
+                        _end = undefined;
                         break;
+                    }
                     switch (tag) {
                     case 10: {
                             if (!(message.file && message.file.length))
@@ -10280,10 +10422,12 @@ $root.google = (function() {
                             break;
                         }
                     default:
-                        reader.skipType(tag & 7, _depth);
+                        reader.skipType(tag & 7, _depth, tag >>> 3);
                         break;
                     }
                 }
+                if (_end !== undefined)
+                    throw Error("missing end group");
                 return message;
             };
 
@@ -10317,7 +10461,7 @@ $root.google = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $util.recursionLimit)
-                    return "maximum nesting depth exceeded";
+                    return "max depth exceeded";
                 if (message.file != null && message.hasOwnProperty("file")) {
                     if (!Array.isArray(message.file))
                         return "file: array expected";
@@ -10344,7 +10488,7 @@ $root.google = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $util.recursionLimit)
-                    throw Error("maximum nesting depth exceeded");
+                    throw Error("max depth exceeded");
                 var message = new $root.google.protobuf.FileDescriptorSet();
                 if (object.file) {
                     if (!Array.isArray(object.file))
@@ -10695,12 +10839,14 @@ $root.google = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $Reader.recursionLimit)
-                    throw Error("maximum nesting depth exceeded");
+                    throw Error("max depth exceeded");
                 var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.google.protobuf.FileDescriptorProto();
                 while (reader.pos < end) {
                     var tag = reader.uint32();
-                    if (tag === _end)
+                    if (tag === _end) {
+                        _end = undefined;
                         break;
+                    }
                     switch (tag) {
                     case 10: {
                             message.name = reader.string();
@@ -10787,10 +10933,12 @@ $root.google = (function() {
                             break;
                         }
                     default:
-                        reader.skipType(tag & 7, _depth);
+                        reader.skipType(tag & 7, _depth, tag >>> 3);
                         break;
                     }
                 }
+                if (_end !== undefined)
+                    throw Error("missing end group");
                 return message;
             };
 
@@ -10824,7 +10972,7 @@ $root.google = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $util.recursionLimit)
-                    return "maximum nesting depth exceeded";
+                    return "max depth exceeded";
                 if (message.name != null && message.hasOwnProperty("name"))
                     if (!$util.isString(message.name))
                         return "name: string expected";
@@ -10943,7 +11091,7 @@ $root.google = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $util.recursionLimit)
-                    throw Error("maximum nesting depth exceeded");
+                    throw Error("max depth exceeded");
                 var message = new $root.google.protobuf.FileDescriptorProto();
                 if (object.name != null)
                     message.name = String(object.name);
@@ -11420,12 +11568,14 @@ $root.google = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $Reader.recursionLimit)
-                    throw Error("maximum nesting depth exceeded");
+                    throw Error("max depth exceeded");
                 var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.google.protobuf.DescriptorProto();
                 while (reader.pos < end) {
                     var tag = reader.uint32();
-                    if (tag === _end)
+                    if (tag === _end) {
+                        _end = undefined;
                         break;
+                    }
                     switch (tag) {
                     case 10: {
                             message.name = reader.string();
@@ -11488,10 +11638,12 @@ $root.google = (function() {
                             break;
                         }
                     default:
-                        reader.skipType(tag & 7, _depth);
+                        reader.skipType(tag & 7, _depth, tag >>> 3);
                         break;
                     }
                 }
+                if (_end !== undefined)
+                    throw Error("missing end group");
                 return message;
             };
 
@@ -11525,7 +11677,7 @@ $root.google = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $util.recursionLimit)
-                    return "maximum nesting depth exceeded";
+                    return "max depth exceeded";
                 if (message.name != null && message.hasOwnProperty("name"))
                     if (!$util.isString(message.name))
                         return "name: string expected";
@@ -11630,7 +11782,7 @@ $root.google = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $util.recursionLimit)
-                    throw Error("maximum nesting depth exceeded");
+                    throw Error("max depth exceeded");
                 var message = new $root.google.protobuf.DescriptorProto();
                 if (object.name != null)
                     message.name = String(object.name);
@@ -11955,12 +12107,14 @@ $root.google = (function() {
                     if (_depth === undefined)
                         _depth = 0;
                     if (_depth > $Reader.recursionLimit)
-                        throw Error("maximum nesting depth exceeded");
+                        throw Error("max depth exceeded");
                     var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.google.protobuf.DescriptorProto.ExtensionRange();
                     while (reader.pos < end) {
                         var tag = reader.uint32();
-                        if (tag === _end)
+                        if (tag === _end) {
+                            _end = undefined;
                             break;
+                        }
                         switch (tag) {
                         case 8: {
                                 message.start = reader.int32();
@@ -11975,10 +12129,12 @@ $root.google = (function() {
                                 break;
                             }
                         default:
-                            reader.skipType(tag & 7, _depth);
+                            reader.skipType(tag & 7, _depth, tag >>> 3);
                             break;
                         }
                     }
+                    if (_end !== undefined)
+                        throw Error("missing end group");
                     return message;
                 };
 
@@ -12012,7 +12168,7 @@ $root.google = (function() {
                     if (_depth === undefined)
                         _depth = 0;
                     if (_depth > $util.recursionLimit)
-                        return "maximum nesting depth exceeded";
+                        return "max depth exceeded";
                     if (message.start != null && message.hasOwnProperty("start"))
                         if (!$util.isInteger(message.start))
                             return "start: integer expected";
@@ -12041,7 +12197,7 @@ $root.google = (function() {
                     if (_depth === undefined)
                         _depth = 0;
                     if (_depth > $util.recursionLimit)
-                        throw Error("maximum nesting depth exceeded");
+                        throw Error("max depth exceeded");
                     var message = new $root.google.protobuf.DescriptorProto.ExtensionRange();
                     if (object.start != null)
                         message.start = object.start | 0;
@@ -12213,12 +12369,14 @@ $root.google = (function() {
                     if (_depth === undefined)
                         _depth = 0;
                     if (_depth > $Reader.recursionLimit)
-                        throw Error("maximum nesting depth exceeded");
+                        throw Error("max depth exceeded");
                     var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.google.protobuf.DescriptorProto.ReservedRange();
                     while (reader.pos < end) {
                         var tag = reader.uint32();
-                        if (tag === _end)
+                        if (tag === _end) {
+                            _end = undefined;
                             break;
+                        }
                         switch (tag) {
                         case 8: {
                                 message.start = reader.int32();
@@ -12229,10 +12387,12 @@ $root.google = (function() {
                                 break;
                             }
                         default:
-                            reader.skipType(tag & 7, _depth);
+                            reader.skipType(tag & 7, _depth, tag >>> 3);
                             break;
                         }
                     }
+                    if (_end !== undefined)
+                        throw Error("missing end group");
                     return message;
                 };
 
@@ -12266,7 +12426,7 @@ $root.google = (function() {
                     if (_depth === undefined)
                         _depth = 0;
                     if (_depth > $util.recursionLimit)
-                        return "maximum nesting depth exceeded";
+                        return "max depth exceeded";
                     if (message.start != null && message.hasOwnProperty("start"))
                         if (!$util.isInteger(message.start))
                             return "start: integer expected";
@@ -12290,7 +12450,7 @@ $root.google = (function() {
                     if (_depth === undefined)
                         _depth = 0;
                     if (_depth > $util.recursionLimit)
-                        throw Error("maximum nesting depth exceeded");
+                        throw Error("max depth exceeded");
                     var message = new $root.google.protobuf.DescriptorProto.ReservedRange();
                     if (object.start != null)
                         message.start = object.start | 0;
@@ -12483,12 +12643,14 @@ $root.google = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $Reader.recursionLimit)
-                    throw Error("maximum nesting depth exceeded");
+                    throw Error("max depth exceeded");
                 var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.google.protobuf.ExtensionRangeOptions();
                 while (reader.pos < end) {
                     var tag = reader.uint32();
-                    if (tag === _end)
+                    if (tag === _end) {
+                        _end = undefined;
                         break;
+                    }
                     switch (tag) {
                     case 7994: {
                             if (!(message.uninterpretedOption && message.uninterpretedOption.length))
@@ -12511,10 +12673,12 @@ $root.google = (function() {
                             break;
                         }
                     default:
-                        reader.skipType(tag & 7, _depth);
+                        reader.skipType(tag & 7, _depth, tag >>> 3);
                         break;
                     }
                 }
+                if (_end !== undefined)
+                    throw Error("missing end group");
                 return message;
             };
 
@@ -12548,7 +12712,7 @@ $root.google = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $util.recursionLimit)
-                    return "maximum nesting depth exceeded";
+                    return "max depth exceeded";
                 if (message.uninterpretedOption != null && message.hasOwnProperty("uninterpretedOption")) {
                     if (!Array.isArray(message.uninterpretedOption))
                         return "uninterpretedOption: array expected";
@@ -12597,7 +12761,7 @@ $root.google = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $util.recursionLimit)
-                    throw Error("maximum nesting depth exceeded");
+                    throw Error("max depth exceeded");
                 var message = new $root.google.protobuf.ExtensionRangeOptions();
                 if (object.uninterpretedOption) {
                     if (!Array.isArray(object.uninterpretedOption))
@@ -12842,12 +13006,14 @@ $root.google = (function() {
                     if (_depth === undefined)
                         _depth = 0;
                     if (_depth > $Reader.recursionLimit)
-                        throw Error("maximum nesting depth exceeded");
+                        throw Error("max depth exceeded");
                     var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.google.protobuf.ExtensionRangeOptions.Declaration();
                     while (reader.pos < end) {
                         var tag = reader.uint32();
-                        if (tag === _end)
+                        if (tag === _end) {
+                            _end = undefined;
                             break;
+                        }
                         switch (tag) {
                         case 8: {
                                 message.number = reader.int32();
@@ -12870,10 +13036,12 @@ $root.google = (function() {
                                 break;
                             }
                         default:
-                            reader.skipType(tag & 7, _depth);
+                            reader.skipType(tag & 7, _depth, tag >>> 3);
                             break;
                         }
                     }
+                    if (_end !== undefined)
+                        throw Error("missing end group");
                     return message;
                 };
 
@@ -12907,7 +13075,7 @@ $root.google = (function() {
                     if (_depth === undefined)
                         _depth = 0;
                     if (_depth > $util.recursionLimit)
-                        return "maximum nesting depth exceeded";
+                        return "max depth exceeded";
                     if (message.number != null && message.hasOwnProperty("number"))
                         if (!$util.isInteger(message.number))
                             return "number: integer expected";
@@ -12940,7 +13108,7 @@ $root.google = (function() {
                     if (_depth === undefined)
                         _depth = 0;
                     if (_depth > $util.recursionLimit)
-                        throw Error("maximum nesting depth exceeded");
+                        throw Error("max depth exceeded");
                     var message = new $root.google.protobuf.ExtensionRangeOptions.Declaration();
                     if (object.number != null)
                         message.number = object.number | 0;
@@ -13235,12 +13403,14 @@ $root.google = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $Reader.recursionLimit)
-                    throw Error("maximum nesting depth exceeded");
+                    throw Error("max depth exceeded");
                 var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.google.protobuf.FieldDescriptorProto();
                 while (reader.pos < end) {
                     var tag = reader.uint32();
-                    if (tag === _end)
+                    if (tag === _end) {
+                        _end = undefined;
                         break;
+                    }
                     switch (tag) {
                     case 10: {
                             message.name = reader.string();
@@ -13287,10 +13457,12 @@ $root.google = (function() {
                             break;
                         }
                     default:
-                        reader.skipType(tag & 7, _depth);
+                        reader.skipType(tag & 7, _depth, tag >>> 3);
                         break;
                     }
                 }
+                if (_end !== undefined)
+                    throw Error("missing end group");
                 return message;
             };
 
@@ -13324,7 +13496,7 @@ $root.google = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $util.recursionLimit)
-                    return "maximum nesting depth exceeded";
+                    return "max depth exceeded";
                 if (message.name != null && message.hasOwnProperty("name"))
                     if (!$util.isString(message.name))
                         return "name: string expected";
@@ -13404,7 +13576,7 @@ $root.google = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $util.recursionLimit)
-                    throw Error("maximum nesting depth exceeded");
+                    throw Error("max depth exceeded");
                 var message = new $root.google.protobuf.FieldDescriptorProto();
                 if (object.name != null)
                     message.name = String(object.name);
@@ -13774,12 +13946,14 @@ $root.google = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $Reader.recursionLimit)
-                    throw Error("maximum nesting depth exceeded");
+                    throw Error("max depth exceeded");
                 var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.google.protobuf.OneofDescriptorProto();
                 while (reader.pos < end) {
                     var tag = reader.uint32();
-                    if (tag === _end)
+                    if (tag === _end) {
+                        _end = undefined;
                         break;
+                    }
                     switch (tag) {
                     case 10: {
                             message.name = reader.string();
@@ -13790,10 +13964,12 @@ $root.google = (function() {
                             break;
                         }
                     default:
-                        reader.skipType(tag & 7, _depth);
+                        reader.skipType(tag & 7, _depth, tag >>> 3);
                         break;
                     }
                 }
+                if (_end !== undefined)
+                    throw Error("missing end group");
                 return message;
             };
 
@@ -13827,7 +14003,7 @@ $root.google = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $util.recursionLimit)
-                    return "maximum nesting depth exceeded";
+                    return "max depth exceeded";
                 if (message.name != null && message.hasOwnProperty("name"))
                     if (!$util.isString(message.name))
                         return "name: string expected";
@@ -13853,7 +14029,7 @@ $root.google = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $util.recursionLimit)
-                    throw Error("maximum nesting depth exceeded");
+                    throw Error("max depth exceeded");
                 var message = new $root.google.protobuf.OneofDescriptorProto();
                 if (object.name != null)
                     message.name = String(object.name);
@@ -14070,12 +14246,14 @@ $root.google = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $Reader.recursionLimit)
-                    throw Error("maximum nesting depth exceeded");
+                    throw Error("max depth exceeded");
                 var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.google.protobuf.EnumDescriptorProto();
                 while (reader.pos < end) {
                     var tag = reader.uint32();
-                    if (tag === _end)
+                    if (tag === _end) {
+                        _end = undefined;
                         break;
+                    }
                     switch (tag) {
                     case 10: {
                             message.name = reader.string();
@@ -14108,10 +14286,12 @@ $root.google = (function() {
                             break;
                         }
                     default:
-                        reader.skipType(tag & 7, _depth);
+                        reader.skipType(tag & 7, _depth, tag >>> 3);
                         break;
                     }
                 }
+                if (_end !== undefined)
+                    throw Error("missing end group");
                 return message;
             };
 
@@ -14145,7 +14325,7 @@ $root.google = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $util.recursionLimit)
-                    return "maximum nesting depth exceeded";
+                    return "max depth exceeded";
                 if (message.name != null && message.hasOwnProperty("name"))
                     if (!$util.isString(message.name))
                         return "name: string expected";
@@ -14205,7 +14385,7 @@ $root.google = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $util.recursionLimit)
-                    throw Error("maximum nesting depth exceeded");
+                    throw Error("max depth exceeded");
                 var message = new $root.google.protobuf.EnumDescriptorProto();
                 if (object.name != null)
                     message.name = String(object.name);
@@ -14439,12 +14619,14 @@ $root.google = (function() {
                     if (_depth === undefined)
                         _depth = 0;
                     if (_depth > $Reader.recursionLimit)
-                        throw Error("maximum nesting depth exceeded");
+                        throw Error("max depth exceeded");
                     var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.google.protobuf.EnumDescriptorProto.EnumReservedRange();
                     while (reader.pos < end) {
                         var tag = reader.uint32();
-                        if (tag === _end)
+                        if (tag === _end) {
+                            _end = undefined;
                             break;
+                        }
                         switch (tag) {
                         case 8: {
                                 message.start = reader.int32();
@@ -14455,10 +14637,12 @@ $root.google = (function() {
                                 break;
                             }
                         default:
-                            reader.skipType(tag & 7, _depth);
+                            reader.skipType(tag & 7, _depth, tag >>> 3);
                             break;
                         }
                     }
+                    if (_end !== undefined)
+                        throw Error("missing end group");
                     return message;
                 };
 
@@ -14492,7 +14676,7 @@ $root.google = (function() {
                     if (_depth === undefined)
                         _depth = 0;
                     if (_depth > $util.recursionLimit)
-                        return "maximum nesting depth exceeded";
+                        return "max depth exceeded";
                     if (message.start != null && message.hasOwnProperty("start"))
                         if (!$util.isInteger(message.start))
                             return "start: integer expected";
@@ -14516,7 +14700,7 @@ $root.google = (function() {
                     if (_depth === undefined)
                         _depth = 0;
                     if (_depth > $util.recursionLimit)
-                        throw Error("maximum nesting depth exceeded");
+                        throw Error("max depth exceeded");
                     var message = new $root.google.protobuf.EnumDescriptorProto.EnumReservedRange();
                     if (object.start != null)
                         message.start = object.start | 0;
@@ -14694,12 +14878,14 @@ $root.google = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $Reader.recursionLimit)
-                    throw Error("maximum nesting depth exceeded");
+                    throw Error("max depth exceeded");
                 var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.google.protobuf.EnumValueDescriptorProto();
                 while (reader.pos < end) {
                     var tag = reader.uint32();
-                    if (tag === _end)
+                    if (tag === _end) {
+                        _end = undefined;
                         break;
+                    }
                     switch (tag) {
                     case 10: {
                             message.name = reader.string();
@@ -14714,10 +14900,12 @@ $root.google = (function() {
                             break;
                         }
                     default:
-                        reader.skipType(tag & 7, _depth);
+                        reader.skipType(tag & 7, _depth, tag >>> 3);
                         break;
                     }
                 }
+                if (_end !== undefined)
+                    throw Error("missing end group");
                 return message;
             };
 
@@ -14751,7 +14939,7 @@ $root.google = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $util.recursionLimit)
-                    return "maximum nesting depth exceeded";
+                    return "max depth exceeded";
                 if (message.name != null && message.hasOwnProperty("name"))
                     if (!$util.isString(message.name))
                         return "name: string expected";
@@ -14780,7 +14968,7 @@ $root.google = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $util.recursionLimit)
-                    throw Error("maximum nesting depth exceeded");
+                    throw Error("max depth exceeded");
                 var message = new $root.google.protobuf.EnumValueDescriptorProto();
                 if (object.name != null)
                     message.name = String(object.name);
@@ -14965,12 +15153,14 @@ $root.google = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $Reader.recursionLimit)
-                    throw Error("maximum nesting depth exceeded");
+                    throw Error("max depth exceeded");
                 var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.google.protobuf.ServiceDescriptorProto();
                 while (reader.pos < end) {
                     var tag = reader.uint32();
-                    if (tag === _end)
+                    if (tag === _end) {
+                        _end = undefined;
                         break;
+                    }
                     switch (tag) {
                     case 10: {
                             message.name = reader.string();
@@ -14987,10 +15177,12 @@ $root.google = (function() {
                             break;
                         }
                     default:
-                        reader.skipType(tag & 7, _depth);
+                        reader.skipType(tag & 7, _depth, tag >>> 3);
                         break;
                     }
                 }
+                if (_end !== undefined)
+                    throw Error("missing end group");
                 return message;
             };
 
@@ -15024,7 +15216,7 @@ $root.google = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $util.recursionLimit)
-                    return "maximum nesting depth exceeded";
+                    return "max depth exceeded";
                 if (message.name != null && message.hasOwnProperty("name"))
                     if (!$util.isString(message.name))
                         return "name: string expected";
@@ -15059,7 +15251,7 @@ $root.google = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $util.recursionLimit)
-                    throw Error("maximum nesting depth exceeded");
+                    throw Error("max depth exceeded");
                 var message = new $root.google.protobuf.ServiceDescriptorProto();
                 if (object.name != null)
                     message.name = String(object.name);
@@ -15287,12 +15479,14 @@ $root.google = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $Reader.recursionLimit)
-                    throw Error("maximum nesting depth exceeded");
+                    throw Error("max depth exceeded");
                 var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.google.protobuf.MethodDescriptorProto();
                 while (reader.pos < end) {
                     var tag = reader.uint32();
-                    if (tag === _end)
+                    if (tag === _end) {
+                        _end = undefined;
                         break;
+                    }
                     switch (tag) {
                     case 10: {
                             message.name = reader.string();
@@ -15319,10 +15513,12 @@ $root.google = (function() {
                             break;
                         }
                     default:
-                        reader.skipType(tag & 7, _depth);
+                        reader.skipType(tag & 7, _depth, tag >>> 3);
                         break;
                     }
                 }
+                if (_end !== undefined)
+                    throw Error("missing end group");
                 return message;
             };
 
@@ -15356,7 +15552,7 @@ $root.google = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $util.recursionLimit)
-                    return "maximum nesting depth exceeded";
+                    return "max depth exceeded";
                 if (message.name != null && message.hasOwnProperty("name"))
                     if (!$util.isString(message.name))
                         return "name: string expected";
@@ -15394,7 +15590,7 @@ $root.google = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $util.recursionLimit)
-                    throw Error("maximum nesting depth exceeded");
+                    throw Error("max depth exceeded");
                 var message = new $root.google.protobuf.MethodDescriptorProto();
                 if (object.name != null)
                     message.name = String(object.name);
@@ -15792,12 +15988,14 @@ $root.google = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $Reader.recursionLimit)
-                    throw Error("maximum nesting depth exceeded");
+                    throw Error("max depth exceeded");
                 var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.google.protobuf.FileOptions();
                 while (reader.pos < end) {
                     var tag = reader.uint32();
-                    if (tag === _end)
+                    if (tag === _end) {
+                        _end = undefined;
                         break;
+                    }
                     switch (tag) {
                     case 10: {
                             message.javaPackage = reader.string();
@@ -15886,10 +16084,12 @@ $root.google = (function() {
                             break;
                         }
                     default:
-                        reader.skipType(tag & 7, _depth);
+                        reader.skipType(tag & 7, _depth, tag >>> 3);
                         break;
                     }
                 }
+                if (_end !== undefined)
+                    throw Error("missing end group");
                 return message;
             };
 
@@ -15923,7 +16123,7 @@ $root.google = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $util.recursionLimit)
-                    return "maximum nesting depth exceeded";
+                    return "max depth exceeded";
                 if (message.javaPackage != null && message.hasOwnProperty("javaPackage"))
                     if (!$util.isString(message.javaPackage))
                         return "javaPackage: string expected";
@@ -16018,7 +16218,7 @@ $root.google = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $util.recursionLimit)
-                    throw Error("maximum nesting depth exceeded");
+                    throw Error("max depth exceeded");
                 var message = new $root.google.protobuf.FileOptions();
                 if (object.javaPackage != null)
                     message.javaPackage = String(object.javaPackage);
@@ -16383,12 +16583,14 @@ $root.google = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $Reader.recursionLimit)
-                    throw Error("maximum nesting depth exceeded");
+                    throw Error("max depth exceeded");
                 var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.google.protobuf.MessageOptions();
                 while (reader.pos < end) {
                     var tag = reader.uint32();
-                    if (tag === _end)
+                    if (tag === _end) {
+                        _end = undefined;
                         break;
+                    }
                     switch (tag) {
                     case 8: {
                             message.messageSetWireFormat = reader.bool();
@@ -16421,10 +16623,12 @@ $root.google = (function() {
                             break;
                         }
                     default:
-                        reader.skipType(tag & 7, _depth);
+                        reader.skipType(tag & 7, _depth, tag >>> 3);
                         break;
                     }
                 }
+                if (_end !== undefined)
+                    throw Error("missing end group");
                 return message;
             };
 
@@ -16458,7 +16662,7 @@ $root.google = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $util.recursionLimit)
-                    return "maximum nesting depth exceeded";
+                    return "max depth exceeded";
                 if (message.messageSetWireFormat != null && message.hasOwnProperty("messageSetWireFormat"))
                     if (typeof message.messageSetWireFormat !== "boolean")
                         return "messageSetWireFormat: boolean expected";
@@ -16505,7 +16709,7 @@ $root.google = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $util.recursionLimit)
-                    throw Error("maximum nesting depth exceeded");
+                    throw Error("max depth exceeded");
                 var message = new $root.google.protobuf.MessageOptions();
                 if (object.messageSetWireFormat != null)
                     message.messageSetWireFormat = Boolean(object.messageSetWireFormat);
@@ -16847,12 +17051,14 @@ $root.google = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $Reader.recursionLimit)
-                    throw Error("maximum nesting depth exceeded");
+                    throw Error("max depth exceeded");
                 var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.google.protobuf.FieldOptions();
                 while (reader.pos < end) {
                     var tag = reader.uint32();
-                    if (tag === _end)
+                    if (tag === _end) {
+                        _end = undefined;
                         break;
+                    }
                     switch (tag) {
                     case 8: {
                             message.ctype = reader.int32();
@@ -16923,10 +17129,12 @@ $root.google = (function() {
                             break;
                         }
                     default:
-                        reader.skipType(tag & 7, _depth);
+                        reader.skipType(tag & 7, _depth, tag >>> 3);
                         break;
                     }
                 }
+                if (_end !== undefined)
+                    throw Error("missing end group");
                 return message;
             };
 
@@ -16960,7 +17168,7 @@ $root.google = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $util.recursionLimit)
-                    return "maximum nesting depth exceeded";
+                    return "max depth exceeded";
                 if (message.ctype != null && message.hasOwnProperty("ctype"))
                     switch (message.ctype) {
                     default:
@@ -17071,7 +17279,7 @@ $root.google = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $util.recursionLimit)
-                    throw Error("maximum nesting depth exceeded");
+                    throw Error("max depth exceeded");
                 var message = new $root.google.protobuf.FieldOptions();
                 switch (object.ctype) {
                 default:
@@ -17508,12 +17716,14 @@ $root.google = (function() {
                     if (_depth === undefined)
                         _depth = 0;
                     if (_depth > $Reader.recursionLimit)
-                        throw Error("maximum nesting depth exceeded");
+                        throw Error("max depth exceeded");
                     var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.google.protobuf.FieldOptions.EditionDefault();
                     while (reader.pos < end) {
                         var tag = reader.uint32();
-                        if (tag === _end)
+                        if (tag === _end) {
+                            _end = undefined;
                             break;
+                        }
                         switch (tag) {
                         case 24: {
                                 message.edition = reader.int32();
@@ -17524,10 +17734,12 @@ $root.google = (function() {
                                 break;
                             }
                         default:
-                            reader.skipType(tag & 7, _depth);
+                            reader.skipType(tag & 7, _depth, tag >>> 3);
                             break;
                         }
                     }
+                    if (_end !== undefined)
+                        throw Error("missing end group");
                     return message;
                 };
 
@@ -17561,7 +17773,7 @@ $root.google = (function() {
                     if (_depth === undefined)
                         _depth = 0;
                     if (_depth > $util.recursionLimit)
-                        return "maximum nesting depth exceeded";
+                        return "max depth exceeded";
                     if (message.edition != null && message.hasOwnProperty("edition"))
                         switch (message.edition) {
                         default:
@@ -17600,7 +17812,7 @@ $root.google = (function() {
                     if (_depth === undefined)
                         _depth = 0;
                     if (_depth > $util.recursionLimit)
-                        throw Error("maximum nesting depth exceeded");
+                        throw Error("max depth exceeded");
                     var message = new $root.google.protobuf.FieldOptions.EditionDefault();
                     switch (object.edition) {
                     default:
@@ -17840,12 +18052,14 @@ $root.google = (function() {
                     if (_depth === undefined)
                         _depth = 0;
                     if (_depth > $Reader.recursionLimit)
-                        throw Error("maximum nesting depth exceeded");
+                        throw Error("max depth exceeded");
                     var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.google.protobuf.FieldOptions.FeatureSupport();
                     while (reader.pos < end) {
                         var tag = reader.uint32();
-                        if (tag === _end)
+                        if (tag === _end) {
+                            _end = undefined;
                             break;
+                        }
                         switch (tag) {
                         case 8: {
                                 message.editionIntroduced = reader.int32();
@@ -17864,10 +18078,12 @@ $root.google = (function() {
                                 break;
                             }
                         default:
-                            reader.skipType(tag & 7, _depth);
+                            reader.skipType(tag & 7, _depth, tag >>> 3);
                             break;
                         }
                     }
+                    if (_end !== undefined)
+                        throw Error("missing end group");
                     return message;
                 };
 
@@ -17901,7 +18117,7 @@ $root.google = (function() {
                     if (_depth === undefined)
                         _depth = 0;
                     if (_depth > $util.recursionLimit)
-                        return "maximum nesting depth exceeded";
+                        return "max depth exceeded";
                     if (message.editionIntroduced != null && message.hasOwnProperty("editionIntroduced"))
                         switch (message.editionIntroduced) {
                         default:
@@ -17976,7 +18192,7 @@ $root.google = (function() {
                     if (_depth === undefined)
                         _depth = 0;
                     if (_depth > $util.recursionLimit)
-                        throw Error("maximum nesting depth exceeded");
+                        throw Error("max depth exceeded");
                     var message = new $root.google.protobuf.FieldOptions.FeatureSupport();
                     switch (object.editionIntroduced) {
                     default:
@@ -18317,12 +18533,14 @@ $root.google = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $Reader.recursionLimit)
-                    throw Error("maximum nesting depth exceeded");
+                    throw Error("max depth exceeded");
                 var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.google.protobuf.OneofOptions();
                 while (reader.pos < end) {
                     var tag = reader.uint32();
-                    if (tag === _end)
+                    if (tag === _end) {
+                        _end = undefined;
                         break;
+                    }
                     switch (tag) {
                     case 10: {
                             message.features = $root.google.protobuf.FeatureSet.decode(reader, reader.uint32(), undefined, _depth + 1, message.features);
@@ -18335,10 +18553,12 @@ $root.google = (function() {
                             break;
                         }
                     default:
-                        reader.skipType(tag & 7, _depth);
+                        reader.skipType(tag & 7, _depth, tag >>> 3);
                         break;
                     }
                 }
+                if (_end !== undefined)
+                    throw Error("missing end group");
                 return message;
             };
 
@@ -18372,7 +18592,7 @@ $root.google = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $util.recursionLimit)
-                    return "maximum nesting depth exceeded";
+                    return "max depth exceeded";
                 if (message.features != null && message.hasOwnProperty("features")) {
                     var error = $root.google.protobuf.FeatureSet.verify(message.features, _depth + 1);
                     if (error)
@@ -18404,7 +18624,7 @@ $root.google = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $util.recursionLimit)
-                    throw Error("maximum nesting depth exceeded");
+                    throw Error("max depth exceeded");
                 var message = new $root.google.protobuf.OneofOptions();
                 if (object.features != null) {
                     if (typeof object.features !== "object")
@@ -18623,12 +18843,14 @@ $root.google = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $Reader.recursionLimit)
-                    throw Error("maximum nesting depth exceeded");
+                    throw Error("max depth exceeded");
                 var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.google.protobuf.EnumOptions();
                 while (reader.pos < end) {
                     var tag = reader.uint32();
-                    if (tag === _end)
+                    if (tag === _end) {
+                        _end = undefined;
                         break;
+                    }
                     switch (tag) {
                     case 16: {
                             message.allowAlias = reader.bool();
@@ -18657,10 +18879,12 @@ $root.google = (function() {
                             break;
                         }
                     default:
-                        reader.skipType(tag & 7, _depth);
+                        reader.skipType(tag & 7, _depth, tag >>> 3);
                         break;
                     }
                 }
+                if (_end !== undefined)
+                    throw Error("missing end group");
                 return message;
             };
 
@@ -18694,7 +18918,7 @@ $root.google = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $util.recursionLimit)
-                    return "maximum nesting depth exceeded";
+                    return "max depth exceeded";
                 if (message.allowAlias != null && message.hasOwnProperty("allowAlias"))
                     if (typeof message.allowAlias !== "boolean")
                         return "allowAlias: boolean expected";
@@ -18738,7 +18962,7 @@ $root.google = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $util.recursionLimit)
-                    throw Error("maximum nesting depth exceeded");
+                    throw Error("max depth exceeded");
                 var message = new $root.google.protobuf.EnumOptions();
                 if (object.allowAlias != null)
                     message.allowAlias = Boolean(object.allowAlias);
@@ -18972,12 +19196,14 @@ $root.google = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $Reader.recursionLimit)
-                    throw Error("maximum nesting depth exceeded");
+                    throw Error("max depth exceeded");
                 var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.google.protobuf.EnumValueOptions();
                 while (reader.pos < end) {
                     var tag = reader.uint32();
-                    if (tag === _end)
+                    if (tag === _end) {
+                        _end = undefined;
                         break;
+                    }
                     switch (tag) {
                     case 8: {
                             message.deprecated = reader.bool();
@@ -19002,10 +19228,12 @@ $root.google = (function() {
                             break;
                         }
                     default:
-                        reader.skipType(tag & 7, _depth);
+                        reader.skipType(tag & 7, _depth, tag >>> 3);
                         break;
                     }
                 }
+                if (_end !== undefined)
+                    throw Error("missing end group");
                 return message;
             };
 
@@ -19039,7 +19267,7 @@ $root.google = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $util.recursionLimit)
-                    return "maximum nesting depth exceeded";
+                    return "max depth exceeded";
                 if (message.deprecated != null && message.hasOwnProperty("deprecated"))
                     if (typeof message.deprecated !== "boolean")
                         return "deprecated: boolean expected";
@@ -19082,7 +19310,7 @@ $root.google = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $util.recursionLimit)
-                    throw Error("maximum nesting depth exceeded");
+                    throw Error("max depth exceeded");
                 var message = new $root.google.protobuf.EnumValueOptions();
                 if (object.deprecated != null)
                     message.deprecated = Boolean(object.deprecated);
@@ -19292,12 +19520,14 @@ $root.google = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $Reader.recursionLimit)
-                    throw Error("maximum nesting depth exceeded");
+                    throw Error("max depth exceeded");
                 var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.google.protobuf.ServiceOptions();
                 while (reader.pos < end) {
                     var tag = reader.uint32();
-                    if (tag === _end)
+                    if (tag === _end) {
+                        _end = undefined;
                         break;
+                    }
                     switch (tag) {
                     case 274: {
                             message.features = $root.google.protobuf.FeatureSet.decode(reader, reader.uint32(), undefined, _depth + 1, message.features);
@@ -19314,10 +19544,12 @@ $root.google = (function() {
                             break;
                         }
                     default:
-                        reader.skipType(tag & 7, _depth);
+                        reader.skipType(tag & 7, _depth, tag >>> 3);
                         break;
                     }
                 }
+                if (_end !== undefined)
+                    throw Error("missing end group");
                 return message;
             };
 
@@ -19351,7 +19583,7 @@ $root.google = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $util.recursionLimit)
-                    return "maximum nesting depth exceeded";
+                    return "max depth exceeded";
                 if (message.features != null && message.hasOwnProperty("features")) {
                     var error = $root.google.protobuf.FeatureSet.verify(message.features, _depth + 1);
                     if (error)
@@ -19386,7 +19618,7 @@ $root.google = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $util.recursionLimit)
-                    throw Error("maximum nesting depth exceeded");
+                    throw Error("max depth exceeded");
                 var message = new $root.google.protobuf.ServiceOptions();
                 if (object.features != null) {
                     if (typeof object.features !== "object")
@@ -19594,12 +19826,14 @@ $root.google = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $Reader.recursionLimit)
-                    throw Error("maximum nesting depth exceeded");
+                    throw Error("max depth exceeded");
                 var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.google.protobuf.MethodOptions();
                 while (reader.pos < end) {
                     var tag = reader.uint32();
-                    if (tag === _end)
+                    if (tag === _end) {
+                        _end = undefined;
                         break;
+                    }
                     switch (tag) {
                     case 264: {
                             message.deprecated = reader.bool();
@@ -19620,10 +19854,12 @@ $root.google = (function() {
                             break;
                         }
                     default:
-                        reader.skipType(tag & 7, _depth);
+                        reader.skipType(tag & 7, _depth, tag >>> 3);
                         break;
                     }
                 }
+                if (_end !== undefined)
+                    throw Error("missing end group");
                 return message;
             };
 
@@ -19657,7 +19893,7 @@ $root.google = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $util.recursionLimit)
-                    return "maximum nesting depth exceeded";
+                    return "max depth exceeded";
                 if (message.deprecated != null && message.hasOwnProperty("deprecated"))
                     if (typeof message.deprecated !== "boolean")
                         return "deprecated: boolean expected";
@@ -19701,7 +19937,7 @@ $root.google = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $util.recursionLimit)
-                    throw Error("maximum nesting depth exceeded");
+                    throw Error("max depth exceeded");
                 var message = new $root.google.protobuf.MethodOptions();
                 if (object.deprecated != null)
                     message.deprecated = Boolean(object.deprecated);
@@ -19981,12 +20217,14 @@ $root.google = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $Reader.recursionLimit)
-                    throw Error("maximum nesting depth exceeded");
+                    throw Error("max depth exceeded");
                 var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.google.protobuf.UninterpretedOption();
                 while (reader.pos < end) {
                     var tag = reader.uint32();
-                    if (tag === _end)
+                    if (tag === _end) {
+                        _end = undefined;
                         break;
+                    }
                     switch (tag) {
                     case 18: {
                             if (!(message.name && message.name.length))
@@ -20019,10 +20257,12 @@ $root.google = (function() {
                             break;
                         }
                     default:
-                        reader.skipType(tag & 7, _depth);
+                        reader.skipType(tag & 7, _depth, tag >>> 3);
                         break;
                     }
                 }
+                if (_end !== undefined)
+                    throw Error("missing end group");
                 return message;
             };
 
@@ -20056,7 +20296,7 @@ $root.google = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $util.recursionLimit)
-                    return "maximum nesting depth exceeded";
+                    return "max depth exceeded";
                 if (message.name != null && message.hasOwnProperty("name")) {
                     if (!Array.isArray(message.name))
                         return "name: array expected";
@@ -20101,7 +20341,7 @@ $root.google = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $util.recursionLimit)
-                    throw Error("maximum nesting depth exceeded");
+                    throw Error("max depth exceeded");
                 var message = new $root.google.protobuf.UninterpretedOption();
                 if (object.name) {
                     if (!Array.isArray(object.name))
@@ -20334,12 +20574,14 @@ $root.google = (function() {
                     if (_depth === undefined)
                         _depth = 0;
                     if (_depth > $Reader.recursionLimit)
-                        throw Error("maximum nesting depth exceeded");
+                        throw Error("max depth exceeded");
                     var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.google.protobuf.UninterpretedOption.NamePart();
                     while (reader.pos < end) {
                         var tag = reader.uint32();
-                        if (tag === _end)
+                        if (tag === _end) {
+                            _end = undefined;
                             break;
+                        }
                         switch (tag) {
                         case 10: {
                                 message.namePart = reader.string();
@@ -20350,10 +20592,12 @@ $root.google = (function() {
                                 break;
                             }
                         default:
-                            reader.skipType(tag & 7, _depth);
+                            reader.skipType(tag & 7, _depth, tag >>> 3);
                             break;
                         }
                     }
+                    if (_end !== undefined)
+                        throw Error("missing end group");
                     if (!message.hasOwnProperty("namePart"))
                         throw $util.ProtocolError("missing required 'namePart'", { instance: message });
                     if (!message.hasOwnProperty("isExtension"))
@@ -20391,7 +20635,7 @@ $root.google = (function() {
                     if (_depth === undefined)
                         _depth = 0;
                     if (_depth > $util.recursionLimit)
-                        return "maximum nesting depth exceeded";
+                        return "max depth exceeded";
                     if (!$util.isString(message.namePart))
                         return "namePart: string expected";
                     if (typeof message.isExtension !== "boolean")
@@ -20413,7 +20657,7 @@ $root.google = (function() {
                     if (_depth === undefined)
                         _depth = 0;
                     if (_depth > $util.recursionLimit)
-                        throw Error("maximum nesting depth exceeded");
+                        throw Error("max depth exceeded");
                     var message = new $root.google.protobuf.UninterpretedOption.NamePart();
                     if (object.namePart != null)
                         message.namePart = String(object.namePart);
@@ -20646,12 +20890,14 @@ $root.google = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $Reader.recursionLimit)
-                    throw Error("maximum nesting depth exceeded");
+                    throw Error("max depth exceeded");
                 var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.google.protobuf.FeatureSet();
                 while (reader.pos < end) {
                     var tag = reader.uint32();
-                    if (tag === _end)
+                    if (tag === _end) {
+                        _end = undefined;
                         break;
+                    }
                     switch (tag) {
                     case 8: {
                             message.fieldPresence = reader.int32();
@@ -20686,10 +20932,12 @@ $root.google = (function() {
                             break;
                         }
                     default:
-                        reader.skipType(tag & 7, _depth);
+                        reader.skipType(tag & 7, _depth, tag >>> 3);
                         break;
                     }
                 }
+                if (_end !== undefined)
+                    throw Error("missing end group");
                 return message;
             };
 
@@ -20723,7 +20971,7 @@ $root.google = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $util.recursionLimit)
-                    return "maximum nesting depth exceeded";
+                    return "max depth exceeded";
                 if (message.fieldPresence != null && message.hasOwnProperty("fieldPresence"))
                     switch (message.fieldPresence) {
                     default:
@@ -20816,7 +21064,7 @@ $root.google = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $util.recursionLimit)
-                    throw Error("maximum nesting depth exceeded");
+                    throw Error("max depth exceeded");
                 var message = new $root.google.protobuf.FeatureSet();
                 switch (object.fieldPresence) {
                 default:
@@ -21255,18 +21503,22 @@ $root.google = (function() {
                     if (_depth === undefined)
                         _depth = 0;
                     if (_depth > $Reader.recursionLimit)
-                        throw Error("maximum nesting depth exceeded");
+                        throw Error("max depth exceeded");
                     var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.google.protobuf.FeatureSet.VisibilityFeature();
                     while (reader.pos < end) {
                         var tag = reader.uint32();
-                        if (tag === _end)
+                        if (tag === _end) {
+                            _end = undefined;
                             break;
+                        }
                         switch (tag) {
                         default:
-                            reader.skipType(tag & 7, _depth);
+                            reader.skipType(tag & 7, _depth, tag >>> 3);
                             break;
                         }
                     }
+                    if (_end !== undefined)
+                        throw Error("missing end group");
                     return message;
                 };
 
@@ -21300,7 +21552,7 @@ $root.google = (function() {
                     if (_depth === undefined)
                         _depth = 0;
                     if (_depth > $util.recursionLimit)
-                        return "maximum nesting depth exceeded";
+                        return "max depth exceeded";
                     return null;
                 };
 
@@ -21318,7 +21570,7 @@ $root.google = (function() {
                     if (_depth === undefined)
                         _depth = 0;
                     if (_depth > $util.recursionLimit)
-                        throw Error("maximum nesting depth exceeded");
+                        throw Error("max depth exceeded");
                     return new $root.google.protobuf.FeatureSet.VisibilityFeature();
                 };
 
@@ -21502,12 +21754,14 @@ $root.google = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $Reader.recursionLimit)
-                    throw Error("maximum nesting depth exceeded");
+                    throw Error("max depth exceeded");
                 var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.google.protobuf.FeatureSetDefaults();
                 while (reader.pos < end) {
                     var tag = reader.uint32();
-                    if (tag === _end)
+                    if (tag === _end) {
+                        _end = undefined;
                         break;
+                    }
                     switch (tag) {
                     case 10: {
                             if (!(message.defaults && message.defaults.length))
@@ -21524,10 +21778,12 @@ $root.google = (function() {
                             break;
                         }
                     default:
-                        reader.skipType(tag & 7, _depth);
+                        reader.skipType(tag & 7, _depth, tag >>> 3);
                         break;
                     }
                 }
+                if (_end !== undefined)
+                    throw Error("missing end group");
                 return message;
             };
 
@@ -21561,7 +21817,7 @@ $root.google = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $util.recursionLimit)
-                    return "maximum nesting depth exceeded";
+                    return "max depth exceeded";
                 if (message.defaults != null && message.hasOwnProperty("defaults")) {
                     if (!Array.isArray(message.defaults))
                         return "defaults: array expected";
@@ -21624,7 +21880,7 @@ $root.google = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $util.recursionLimit)
-                    throw Error("maximum nesting depth exceeded");
+                    throw Error("max depth exceeded");
                 var message = new $root.google.protobuf.FeatureSetDefaults();
                 if (object.defaults) {
                     if (!Array.isArray(object.defaults))
@@ -21921,12 +22177,14 @@ $root.google = (function() {
                     if (_depth === undefined)
                         _depth = 0;
                     if (_depth > $Reader.recursionLimit)
-                        throw Error("maximum nesting depth exceeded");
+                        throw Error("max depth exceeded");
                     var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.google.protobuf.FeatureSetDefaults.FeatureSetEditionDefault();
                     while (reader.pos < end) {
                         var tag = reader.uint32();
-                        if (tag === _end)
+                        if (tag === _end) {
+                            _end = undefined;
                             break;
+                        }
                         switch (tag) {
                         case 24: {
                                 message.edition = reader.int32();
@@ -21941,10 +22199,12 @@ $root.google = (function() {
                                 break;
                             }
                         default:
-                            reader.skipType(tag & 7, _depth);
+                            reader.skipType(tag & 7, _depth, tag >>> 3);
                             break;
                         }
                     }
+                    if (_end !== undefined)
+                        throw Error("missing end group");
                     return message;
                 };
 
@@ -21978,7 +22238,7 @@ $root.google = (function() {
                     if (_depth === undefined)
                         _depth = 0;
                     if (_depth > $util.recursionLimit)
-                        return "maximum nesting depth exceeded";
+                        return "max depth exceeded";
                     if (message.edition != null && message.hasOwnProperty("edition"))
                         switch (message.edition) {
                         default:
@@ -22024,7 +22284,7 @@ $root.google = (function() {
                     if (_depth === undefined)
                         _depth = 0;
                     if (_depth > $util.recursionLimit)
-                        throw Error("maximum nesting depth exceeded");
+                        throw Error("max depth exceeded");
                     var message = new $root.google.protobuf.FeatureSetDefaults.FeatureSetEditionDefault();
                     switch (object.edition) {
                     default:
@@ -22247,12 +22507,14 @@ $root.google = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $Reader.recursionLimit)
-                    throw Error("maximum nesting depth exceeded");
+                    throw Error("max depth exceeded");
                 var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.google.protobuf.SourceCodeInfo();
                 while (reader.pos < end) {
                     var tag = reader.uint32();
-                    if (tag === _end)
+                    if (tag === _end) {
+                        _end = undefined;
                         break;
+                    }
                     switch (tag) {
                     case 10: {
                             if (!(message.location && message.location.length))
@@ -22261,10 +22523,12 @@ $root.google = (function() {
                             break;
                         }
                     default:
-                        reader.skipType(tag & 7, _depth);
+                        reader.skipType(tag & 7, _depth, tag >>> 3);
                         break;
                     }
                 }
+                if (_end !== undefined)
+                    throw Error("missing end group");
                 return message;
             };
 
@@ -22298,7 +22562,7 @@ $root.google = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $util.recursionLimit)
-                    return "maximum nesting depth exceeded";
+                    return "max depth exceeded";
                 if (message.location != null && message.hasOwnProperty("location")) {
                     if (!Array.isArray(message.location))
                         return "location: array expected";
@@ -22325,7 +22589,7 @@ $root.google = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $util.recursionLimit)
-                    throw Error("maximum nesting depth exceeded");
+                    throw Error("max depth exceeded");
                 var message = new $root.google.protobuf.SourceCodeInfo();
                 if (object.location) {
                     if (!Array.isArray(object.location))
@@ -22536,12 +22800,14 @@ $root.google = (function() {
                     if (_depth === undefined)
                         _depth = 0;
                     if (_depth > $Reader.recursionLimit)
-                        throw Error("maximum nesting depth exceeded");
+                        throw Error("max depth exceeded");
                     var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.google.protobuf.SourceCodeInfo.Location();
                     while (reader.pos < end) {
                         var tag = reader.uint32();
-                        if (tag === _end)
+                        if (tag === _end) {
+                            _end = undefined;
                             break;
+                        }
                         switch (tag) {
                         case 8:
                         case 10: {
@@ -22582,10 +22848,12 @@ $root.google = (function() {
                                 break;
                             }
                         default:
-                            reader.skipType(tag & 7, _depth);
+                            reader.skipType(tag & 7, _depth, tag >>> 3);
                             break;
                         }
                     }
+                    if (_end !== undefined)
+                        throw Error("missing end group");
                     return message;
                 };
 
@@ -22619,7 +22887,7 @@ $root.google = (function() {
                     if (_depth === undefined)
                         _depth = 0;
                     if (_depth > $util.recursionLimit)
-                        return "maximum nesting depth exceeded";
+                        return "max depth exceeded";
                     if (message.path != null && message.hasOwnProperty("path")) {
                         if (!Array.isArray(message.path))
                             return "path: array expected";
@@ -22664,7 +22932,7 @@ $root.google = (function() {
                     if (_depth === undefined)
                         _depth = 0;
                     if (_depth > $util.recursionLimit)
-                        throw Error("maximum nesting depth exceeded");
+                        throw Error("max depth exceeded");
                     var message = new $root.google.protobuf.SourceCodeInfo.Location();
                     if (object.path) {
                         if (!Array.isArray(object.path))
@@ -22863,12 +23131,14 @@ $root.google = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $Reader.recursionLimit)
-                    throw Error("maximum nesting depth exceeded");
+                    throw Error("max depth exceeded");
                 var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.google.protobuf.GeneratedCodeInfo();
                 while (reader.pos < end) {
                     var tag = reader.uint32();
-                    if (tag === _end)
+                    if (tag === _end) {
+                        _end = undefined;
                         break;
+                    }
                     switch (tag) {
                     case 10: {
                             if (!(message.annotation && message.annotation.length))
@@ -22877,10 +23147,12 @@ $root.google = (function() {
                             break;
                         }
                     default:
-                        reader.skipType(tag & 7, _depth);
+                        reader.skipType(tag & 7, _depth, tag >>> 3);
                         break;
                     }
                 }
+                if (_end !== undefined)
+                    throw Error("missing end group");
                 return message;
             };
 
@@ -22914,7 +23186,7 @@ $root.google = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $util.recursionLimit)
-                    return "maximum nesting depth exceeded";
+                    return "max depth exceeded";
                 if (message.annotation != null && message.hasOwnProperty("annotation")) {
                     if (!Array.isArray(message.annotation))
                         return "annotation: array expected";
@@ -22941,7 +23213,7 @@ $root.google = (function() {
                 if (_depth === undefined)
                     _depth = 0;
                 if (_depth > $util.recursionLimit)
-                    throw Error("maximum nesting depth exceeded");
+                    throw Error("max depth exceeded");
                 var message = new $root.google.protobuf.GeneratedCodeInfo();
                 if (object.annotation) {
                     if (!Array.isArray(object.annotation))
@@ -23145,12 +23417,14 @@ $root.google = (function() {
                     if (_depth === undefined)
                         _depth = 0;
                     if (_depth > $Reader.recursionLimit)
-                        throw Error("maximum nesting depth exceeded");
+                        throw Error("max depth exceeded");
                     var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.google.protobuf.GeneratedCodeInfo.Annotation();
                     while (reader.pos < end) {
                         var tag = reader.uint32();
-                        if (tag === _end)
+                        if (tag === _end) {
+                            _end = undefined;
                             break;
+                        }
                         switch (tag) {
                         case 8:
                         case 10: {
@@ -23181,10 +23455,12 @@ $root.google = (function() {
                                 break;
                             }
                         default:
-                            reader.skipType(tag & 7, _depth);
+                            reader.skipType(tag & 7, _depth, tag >>> 3);
                             break;
                         }
                     }
+                    if (_end !== undefined)
+                        throw Error("missing end group");
                     return message;
                 };
 
@@ -23218,7 +23494,7 @@ $root.google = (function() {
                     if (_depth === undefined)
                         _depth = 0;
                     if (_depth > $util.recursionLimit)
-                        return "maximum nesting depth exceeded";
+                        return "max depth exceeded";
                     if (message.path != null && message.hasOwnProperty("path")) {
                         if (!Array.isArray(message.path))
                             return "path: array expected";
@@ -23261,7 +23537,7 @@ $root.google = (function() {
                     if (_depth === undefined)
                         _depth = 0;
                     if (_depth > $util.recursionLimit)
-                        throw Error("maximum nesting depth exceeded");
+                        throw Error("max depth exceeded");
                     var message = new $root.google.protobuf.GeneratedCodeInfo.Annotation();
                     if (object.path) {
                         if (!Array.isArray(object.path))

--- a/tests/data/type_url.js
+++ b/tests/data/type_url.js
@@ -100,22 +100,26 @@ $root.TypeUrlTest = (function() {
         if (_depth === undefined)
             _depth = 0;
         if (_depth > $Reader.recursionLimit)
-            throw Error("maximum nesting depth exceeded");
+            throw Error("max depth exceeded");
         var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.TypeUrlTest();
         while (reader.pos < end) {
             var tag = reader.uint32();
-            if (tag === _end)
+            if (tag === _end) {
+                _end = undefined;
                 break;
+            }
             switch (tag) {
             case 10: {
                     message.nested = $root.TypeUrlTest.Nested.decode(reader, reader.uint32(), undefined, _depth + 1, message.nested);
                     break;
                 }
             default:
-                reader.skipType(tag & 7, _depth);
+                reader.skipType(tag & 7, _depth, tag >>> 3);
                 break;
             }
         }
+        if (_end !== undefined)
+            throw Error("missing end group");
         return message;
     };
 
@@ -149,7 +153,7 @@ $root.TypeUrlTest = (function() {
         if (_depth === undefined)
             _depth = 0;
         if (_depth > $util.recursionLimit)
-            return "maximum nesting depth exceeded";
+            return "max depth exceeded";
         if (message.nested != null && message.hasOwnProperty("nested")) {
             var error = $root.TypeUrlTest.Nested.verify(message.nested, _depth + 1);
             if (error)
@@ -172,7 +176,7 @@ $root.TypeUrlTest = (function() {
         if (_depth === undefined)
             _depth = 0;
         if (_depth > $util.recursionLimit)
-            throw Error("maximum nesting depth exceeded");
+            throw Error("max depth exceeded");
         var message = new $root.TypeUrlTest();
         if (object.nested != null) {
             if (typeof object.nested !== "object")
@@ -319,22 +323,26 @@ $root.TypeUrlTest = (function() {
             if (_depth === undefined)
                 _depth = 0;
             if (_depth > $Reader.recursionLimit)
-                throw Error("maximum nesting depth exceeded");
+                throw Error("max depth exceeded");
             var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.TypeUrlTest.Nested();
             while (reader.pos < end) {
                 var tag = reader.uint32();
-                if (tag === _end)
+                if (tag === _end) {
+                    _end = undefined;
                     break;
+                }
                 switch (tag) {
                 case 10: {
                         message.a = reader.string();
                         break;
                     }
                 default:
-                    reader.skipType(tag & 7, _depth);
+                    reader.skipType(tag & 7, _depth, tag >>> 3);
                     break;
                 }
             }
+            if (_end !== undefined)
+                throw Error("missing end group");
             return message;
         };
 
@@ -368,7 +376,7 @@ $root.TypeUrlTest = (function() {
             if (_depth === undefined)
                 _depth = 0;
             if (_depth > $util.recursionLimit)
-                return "maximum nesting depth exceeded";
+                return "max depth exceeded";
             if (message.a != null && message.hasOwnProperty("a"))
                 if (!$util.isString(message.a))
                     return "a: string expected";
@@ -389,7 +397,7 @@ $root.TypeUrlTest = (function() {
             if (_depth === undefined)
                 _depth = 0;
             if (_depth > $util.recursionLimit)
-                throw Error("maximum nesting depth exceeded");
+                throw Error("max depth exceeded");
             var message = new $root.TypeUrlTest.Nested();
             if (object.a != null)
                 message.a = String(object.a);


### PR DESCRIPTION
Updates decoding to reject invalid field and group tags more consistently with the protobuf wire format. Invalid field numbers, reserved wire types, mismatched group end tags, and missing group end tags are now rejected instead of being accepted or decoded incorrectly.

Also unifies adjacent recursion-depth errors and refreshes affected fixtures.

---

This is just #2199 again, where I accidentally messed up the PR stack and merged into the wrong branch to celebrate the 1000th commit (I suppose).