### PR TITLE
fix: Consistently reject truncated strings

### DIFF
--- a/src/reader_buffer.js
+++ b/src/reader_buffer.js
@@ -35,10 +35,18 @@ BufferReader._configure = function () {
  * @override
  */
 BufferReader.prototype.string = function read_string_buffer() {
-    var len = this.uint32(); // modifies pos
+    var len = this.uint32(), // modifies pos
+        start = this.pos,
+        end = this.pos + len;
+
+    /* istanbul ignore if */
+    if (end > this.len)
+        throw RangeError("index out of range: " + this.pos + " + " + len + " > " + this.len);
+
+    this.pos = end;
     return this.buf.utf8Slice
-        ? this.buf.utf8Slice(this.pos, this.pos = Math.min(this.pos + len, this.len))
-        : this.buf.toString("utf-8", this.pos, this.pos = Math.min(this.pos + len, this.len));
+        ? this.buf.utf8Slice(start, end)
+        : this.buf.toString("utf-8", start, end);
 };
 
 /**

--- a/tests/api_writer-reader.js
+++ b/tests/api_writer-reader.js
@@ -99,6 +99,9 @@ tape.test("writer & reader", function(test) {
 
     test.ok(expect("string", "123", [3,49,50,51]), "should write \"123\" as a string prefixed with its length as a varint and read it back equally");
     test.ok(expect("string", "", [0]), "should write \"\" as a string prefixed with its length as a varint and read it back equally");
+    test.throws(function() {
+        Reader.create(protobuf.util.newBuffer([ 3, 49, 50 ])).string();
+    }, /index out of range/, "should throw on truncated strings");
 
     // bytes
 


### PR DESCRIPTION
Rejects truncated length-delimited strings in the Buffer-backed reader instead of silently clamping reads to the remaining buffer length. The generic Reader path already rejected this, so this makes BufferReader behave the same way.