### PR TITLE
fix: Decode missing map message values as empty messages

### DIFF
--- a/cli/targets/static.js
+++ b/cli/targets/static.js
@@ -261,6 +261,18 @@ function buildFunction(type, functionName, gen, scope) {
                     "type": "Identifier",
                     "name": "$root" + type.fullName
                 };
+            // replace types[N].ctor with the field's actual type constructor
+            if (
+                node.type === "MemberExpression"
+             && node.object.type === "MemberExpression"
+             && node.object.object.type === "Identifier" && node.object.object.name === "types"
+             && node.object.property.type === "Literal"
+             && node.property.type === "Identifier" && node.property.name === "ctor"
+            )
+                return {
+                    "type": "Identifier",
+                    "name": "$root" + type.fieldsArray[node.object.property.value].resolvedType.fullName
+                };
             // replace types[N] with the field's actual type
             if (
                 node.type === "MemberExpression"

--- a/cli/targets/static.js
+++ b/cli/targets/static.js
@@ -232,8 +232,7 @@ var renameVars = {
 };
 
 function buildFunction(type, functionName, gen, scope) {
-    var code = gen.toString(functionName)
-        .replace(/((?!\.)types\[\d+])(\.values)/g, "$1"); // enums: use types[N] instead of reflected types[N].values
+    var code = gen.toString(functionName);
 
     var ast = espree.parse(code);
     /* eslint-disable no-extra-parens */
@@ -268,6 +267,18 @@ function buildFunction(type, functionName, gen, scope) {
              && node.object.object.type === "Identifier" && node.object.object.name === "types"
              && node.object.property.type === "Literal"
              && node.property.type === "Identifier" && node.property.name === "ctor"
+            )
+                return {
+                    "type": "Identifier",
+                    "name": "$root" + type.fieldsArray[node.object.property.value].resolvedType.fullName
+                };
+            // replace types[N].values with the field's actual enum object
+            if (
+                node.type === "MemberExpression"
+             && node.object.type === "MemberExpression"
+             && node.object.object.type === "Identifier" && node.object.object.name === "types"
+             && node.object.property.type === "Literal"
+             && node.property.type === "Identifier" && node.property.name === "values"
             )
                 return {
                     "type": "Identifier",

--- a/src/decoder.js
+++ b/src/decoder.js
@@ -51,6 +51,8 @@ function decoder(mtype) {
 
             if (types.defaults[type] !== undefined) gen
                 ("value=%j", types.defaults[type]);
+            else if (types.basic[type] === undefined) gen
+                ("value=new types[%i].ctor", i);
             else gen
                 ("value=null");
 

--- a/src/decoder.js
+++ b/src/decoder.js
@@ -52,7 +52,7 @@ function decoder(mtype) {
             if (types.defaults[type] !== undefined) gen
                 ("value=%j", types.defaults[type]);
             else if (types.basic[type] === undefined) gen
-                ("value=new types[%i].ctor", i);
+                ("value=new (types[%i].ctor||types[%i])", i, i);
             else gen
                 ("value=null");
 

--- a/src/decoder.js
+++ b/src/decoder.js
@@ -52,7 +52,7 @@ function decoder(mtype) {
             if (types.defaults[type] !== undefined) gen
                 ("value=%j", types.defaults[type]);
             else if (types.basic[type] === undefined) gen
-                ("value=new (types[%i].ctor||types[%i])", i, i);
+                ("value=new types[%i].ctor", i);
             else gen
                 ("value=null");
 

--- a/tests/cli.js
+++ b/tests/cli.js
@@ -82,7 +82,7 @@ tape.test("pbjs generates static code", function(test) {
             instance.regularField = "abc";
             instance.enumField = 0;
             var instance1 = OneofContainerDynamic.toObject(OneofContainerDynamic.fromObject(instance));
-            test.deepEqual(instance, instance1, "fromObject and toObject work for instance of the static type");
+            test.deepEqual(OneofContainer.toObject(instance), instance1, "fromObject and toObject work for instance of the static type");
 
             // Check that getTypeUrl works
             var defaultTypeUrl = Message.getTypeUrl();

--- a/tests/comp_maps.js
+++ b/tests/comp_maps.js
@@ -92,6 +92,19 @@ tape.test("maps", function(test) {
         test.end();
     });
 
+    test.test(test.name + " - omitted message value", function(test) {
+
+        var dec = Outer.decode(Uint8Array.of(0x0a, 0x03, 0x0a, 0x01, 0x61));
+        test.ok(dec.value.a instanceof Inner.ctor, "should decode an omitted message value as a default message");
+        test.deepEqual(
+            Array.prototype.slice.call(Outer.encode(dec).finish()),
+            [ 0x0a, 0x05, 0x0a, 0x01, 0x61, 0x12, 0x00 ],
+            "should re-encode the default message value"
+        );
+
+        test.end();
+    });
+
     test.test(test.name + " - special string key", function(test) {
 
         var map = {};

--- a/tests/comp_maps.js
+++ b/tests/comp_maps.js
@@ -63,7 +63,7 @@ tape.test("maps", function(test) {
         var buf = Outer.encode(outer).finish();
         var dec = Outer.decode(buf);
 
-        test.deepEqual(dec, outer, "should decode back the original random map");
+        test.deepEqual(Outer.toObject(dec), outer, "should decode back the original random map");
 
         test.end();
     });
@@ -87,7 +87,7 @@ tape.test("maps", function(test) {
         verifyEncode(test, buf);
 
         var dec = Outer.decode(buf);
-        test.deepEqual(dec, outer, "should decode back the original map");
+        test.deepEqual(Outer.toObject(dec), outer, "should decode back the original map");
 
         test.end();
     });
@@ -168,19 +168,19 @@ tape.test("maps", function(test) {
 
         // 1 <chunk> = message(1 <varint> = 0, 2 <chunk> = empty chunk)
         dec = MapMessage.decode(Uint8Array.of(0x0a, 0x04, 0x08, 0x00, 0x12, 0x00));
-        test.deepEqual(dec, value, "should correct decode the buffer without omitted fields");
+        test.deepEqual(MapMessage.toObject(dec), value, "should correct decode the buffer without omitted fields");
 
         // 1 <chunk> = message(1 <varint> = 0)
         dec = MapMessage.decode(Uint8Array.of(0x0a, 0x02, 0x08, 0x00));
-        test.deepEqual(dec, value, "should correct decode the buffer with omitted value");
+        test.deepEqual(MapMessage.toObject(dec), value, "should correct decode the buffer with omitted value");
 
         // 1 <chunk> = message(2 <chunk> = empty chunk)
         dec = MapMessage.decode(Uint8Array.of(0x0a, 0x02, 0x12, 0x00));
-        test.deepEqual(dec, value, "should correct decode the buffer with omitted key");
+        test.deepEqual(MapMessage.toObject(dec), value, "should correct decode the buffer with omitted key");
 
         // 1 <chunk> = empty chunk
         dec = MapMessage.decode(Uint8Array.of(0x0a, 0x00));
-        test.deepEqual(dec, value, "should correct decode the buffer with both key and value omitted");
+        test.deepEqual(MapMessage.toObject(dec), value, "should correct decode the buffer with both key and value omitted");
 
         test.end();
     });

--- a/tests/comp_static_maps.js
+++ b/tests/comp_static_maps.js
@@ -1,0 +1,19 @@
+var tape = require("tape");
+
+var staticRoot = require("./data/test");
+
+tape.test("static maps - omitted message value", function(test) {
+
+    var TestMapFields = staticRoot.jspb.test.TestMapFieldsNoBinary;
+    var MapValueMessage = staticRoot.jspb.test.MapValueMessageNoBinary;
+    var dec = TestMapFields.decode(Uint8Array.of(0x3a, 0x03, 0x0a, 0x01, 0x61));
+
+    test.ok(dec.mapStringMsg.a instanceof MapValueMessage, "should decode an omitted message value as a default message");
+    test.deepEqual(
+        Array.prototype.slice.call(TestMapFields.encode(dec).finish()),
+        [ 0x3a, 0x05, 0x0a, 0x01, 0x61, 0x12, 0x00 ],
+        "should re-encode the default message value"
+    );
+
+    test.end();
+});

--- a/tests/data/test.js
+++ b/tests/data/test.js
@@ -8852,7 +8852,7 @@ $root.jspb = (function() {
                                 message.mapStringMsg = {};
                             var end2 = reader.uint32() + reader.pos;
                             key = "";
-                            value = null;
+                            value = new $root.jspb.test.MapValueMessageNoBinary.ctor();
                             while (reader.pos < end2) {
                                 var tag2 = reader.uint32();
                                 switch (tag2) {
@@ -8950,7 +8950,7 @@ $root.jspb = (function() {
                                 message.mapStringTestmapfields = {};
                             var end2 = reader.uint32() + reader.pos;
                             key = "";
-                            value = null;
+                            value = new $root.jspb.test.TestMapFieldsNoBinary.ctor();
                             while (reader.pos < end2) {
                                 var tag2 = reader.uint32();
                                 switch (tag2) {

--- a/tests/data/test.js
+++ b/tests/data/test.js
@@ -8852,7 +8852,7 @@ $root.jspb = (function() {
                                 message.mapStringMsg = {};
                             var end2 = reader.uint32() + reader.pos;
                             key = "";
-                            value = new $root.jspb.test.MapValueMessageNoBinary.ctor();
+                            value = new ($root.jspb.test.MapValueMessageNoBinary.ctor || $root.jspb.test.MapValueMessageNoBinary)();
                             while (reader.pos < end2) {
                                 var tag2 = reader.uint32();
                                 switch (tag2) {
@@ -8950,7 +8950,7 @@ $root.jspb = (function() {
                                 message.mapStringTestmapfields = {};
                             var end2 = reader.uint32() + reader.pos;
                             key = "";
-                            value = new $root.jspb.test.TestMapFieldsNoBinary.ctor();
+                            value = new ($root.jspb.test.TestMapFieldsNoBinary.ctor || $root.jspb.test.TestMapFieldsNoBinary)();
                             while (reader.pos < end2) {
                                 var tag2 = reader.uint32();
                                 switch (tag2) {

--- a/tests/data/test.js
+++ b/tests/data/test.js
@@ -8852,7 +8852,7 @@ $root.jspb = (function() {
                                 message.mapStringMsg = {};
                             var end2 = reader.uint32() + reader.pos;
                             key = "";
-                            value = new ($root.jspb.test.MapValueMessageNoBinary.ctor || $root.jspb.test.MapValueMessageNoBinary)();
+                            value = new $root.jspb.test.MapValueMessageNoBinary();
                             while (reader.pos < end2) {
                                 var tag2 = reader.uint32();
                                 switch (tag2) {
@@ -8950,7 +8950,7 @@ $root.jspb = (function() {
                                 message.mapStringTestmapfields = {};
                             var end2 = reader.uint32() + reader.pos;
                             key = "";
-                            value = new ($root.jspb.test.TestMapFieldsNoBinary.ctor || $root.jspb.test.TestMapFieldsNoBinary)();
+                            value = new $root.jspb.test.TestMapFieldsNoBinary();
                             while (reader.pos < end2) {
                                 var tag2 = reader.uint32();
                                 switch (tag2) {


### PR DESCRIPTION
Decodes map entries with missing message values as empty message instances instead of `null`, so message values now follow the same defaulting semantics as scalar values and re-encoding behavior remains consistent.

Addresses #1828
Follow-up to #1348, which handled omitted map values for scalar values.