### PR TITLE
fix: Accept URL-safe base64 input

### DIFF
--- a/src/util/base64.js
+++ b/src/util/base64.js
@@ -16,10 +16,9 @@ base64.length = function length(string) {
     var p = string.length;
     if (!p)
         return 0;
-    var n = 0;
-    while (--p % 4 > 1 && string.charAt(p) === "=")
-        ++n;
-    return Math.ceil(string.length * 3) / 4 - n;
+    while (p > 0 && string.charAt(p - 1) === "=")
+        --p;
+    return Math.floor(p * 3 / 4);
 };
 
 // Base64 encoding table
@@ -31,6 +30,9 @@ var s64 = new Array(123);
 // 65..90, 97..122, 48..57, 43, 47
 for (var i = 0; i < 64;)
     s64[b64[i] = i < 26 ? i + 65 : i < 52 ? i + 71 : i < 62 ? i - 4 : i - 59 | 43] = i++;
+
+s64[45] = 62; // - -> +
+s64[95] = 63; // _ -> /
 
 /**
  * Encodes a buffer to a base64 encoded string.
@@ -129,11 +131,16 @@ base64.decode = function decode(string, buffer, offset) {
     return offset - start;
 };
 
+var base64Re = /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/,
+    base64UrlRe = /[-_]/,
+    base64UrlNoPaddingRe = /^(?:[A-Za-z0-9_-]{4})*(?:[A-Za-z0-9_-]{2}(?:==)?|[A-Za-z0-9_-]{3}=?)?$/;
+
 /**
  * Tests if the specified string appears to be base64 encoded.
  * @param {string} string String to test
  * @returns {boolean} `true` if probably base64 encoded, otherwise false
  */
 base64.test = function test(string) {
-    return /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/.test(string);
+    return base64Re.test(string)
+        || base64UrlRe.test(string) && base64UrlNoPaddingRe.test(string);
 };

--- a/tests/util_base64.js
+++ b/tests/util_base64.js
@@ -42,5 +42,25 @@ tape.test("base64", function(test) {
         base64.decode("Y", buf, 0);
     }, Error, "should throw if string is truncated");
 
+    test.equal(base64.test("teststr"), false, "should not detect ambiguous strings as base64 encoded");
+
+    var unpadded = "AQI";
+    test.equal(base64.length(unpadded), 2, "should calculate unpadded base64 length");
+    var unpaddedBuf = new Array(2);
+    test.equal(base64.decode(unpadded, unpaddedBuf, 0), 2, "should decode unpadded base64");
+    test.same(unpaddedBuf, [ 1, 2 ], "should decode unpadded base64 bytes");
+
+    [ "-_8=", "-_8" ].forEach(function(enc) {
+        test.equal(base64.test(enc), true, "should detect '" + enc + "' to be base64 encoded");
+
+        var len = base64.length(enc);
+        test.equal(len, 2, "should calculate '" + enc + "' as 2 bytes");
+
+        var buf = new Array(len);
+        var len2 = base64.decode(enc, buf, 0);
+        test.equal(len2, len, "should decode '" + enc + "' to " + len + " bytes");
+        test.same(buf, [ 251, 255 ], "should decode URL-safe base64");
+    });
+
     test.end();
 });


### PR DESCRIPTION
Adds support for URL-safe base64 input when decoding bytes from plain objects or JSON, using `-` and `_` as aliases for `+` and `/` during decode. Also accepts unpadded base64 input without changing existing base64 output encoding.