### PR TITLE
fix: Omit proto3 implicit scalar defaults

### DIFF
--- a/bench/data/static_pbjs.js
+++ b/bench/data/static_pbjs.js
@@ -24,13 +24,13 @@ $root.Test = (function() {
     Test.encode = function encode(message, writer) {
         if (!writer)
             writer = $Writer.create();
-        if (message.string != null && Object.hasOwnProperty.call(message, "string"))
+        if (message.string != null && message.string.length)
             writer.uint32(10).string(message.string);
-        if (message.uint32 != null && Object.hasOwnProperty.call(message, "uint32"))
+        if (message.uint32 != null && Number(message.uint32) !== 0)
             writer.uint32(16).uint32(message.uint32);
         if (message.inner != null && Object.hasOwnProperty.call(message, "inner"))
             $root.Test.Inner.encode(message.inner, writer.uint32(26).fork()).ldelim();
-        if (message.float != null && Object.hasOwnProperty.call(message, "float"))
+        if (message.float != null && Number(message.float) !== 0)
             writer.uint32(37).float(message.float);
         return writer;
     };
@@ -92,7 +92,7 @@ $root.Test = (function() {
         Inner.encode = function encode(message, writer) {
             if (!writer)
                 writer = $Writer.create();
-            if (message.int32 != null && Object.hasOwnProperty.call(message, "int32"))
+            if (message.int32 != null && Number(message.int32) !== 0)
                 writer.uint32(8).int32(message.int32);
             if (message.innerInner != null && Object.hasOwnProperty.call(message, "innerInner"))
                 $root.Test.Inner.InnerInner.encode(message.innerInner, writer.uint32(18).fork()).ldelim();
@@ -154,11 +154,11 @@ $root.Test = (function() {
             InnerInner.encode = function encode(message, writer) {
                 if (!writer)
                     writer = $Writer.create();
-                if (message.long != null && Object.hasOwnProperty.call(message, "long"))
+                if (message.long != null && (typeof message.long === "object" ? message.long.low || message.long.high : Number(message.long) !== 0))
                     writer.uint32(8).int64(message.long);
-                if (message["enum"] != null && Object.hasOwnProperty.call(message, "enum"))
+                if (message["enum"] != null && Number(message["enum"]) !== 0)
                     writer.uint32(16).int32(message["enum"]);
-                if (message.sint32 != null && Object.hasOwnProperty.call(message, "sint32"))
+                if (message.sint32 != null && Number(message.sint32) !== 0)
                     writer.uint32(24).sint32(message.sint32);
                 return writer;
             };
@@ -241,7 +241,7 @@ $root.Outer = (function() {
                 writer.bool(message.bool[i]);
             writer.ldelim();
         }
-        if (message.double != null && Object.hasOwnProperty.call(message, "double"))
+        if (message.double != null && Number(message.double) !== 0)
             writer.uint32(17).double(message.double);
         return writer;
     };

--- a/src/encoder.js
+++ b/src/encoder.js
@@ -88,8 +88,18 @@ function encoder(mtype) {
 
         // Non-repeated
         } else {
-            if (field.optional) gen
+            if (!field.required) {
+                if (wireType === undefined || field.hasPresence) gen
     ("if(%s!=null&&Object.hasOwnProperty.call(m,%j))", ref, field.name); // !== undefined && !== null
+                else if (type === "string" || type === "bytes") gen
+    ("if(%s!=null&&%s.length)", ref, ref);
+                else if (types.long[type] !== undefined) gen
+    ("if(%s!=null&&(typeof %s===\"object\"?%s.low||%s.high:Number(%s)!==0))", ref, ref, ref, ref, ref);
+                else if (type === "bool") gen
+    ("if(%s)", ref);
+                else gen
+    ("if(%s!=null&&Number(%s)!==0)", ref, ref);
+            }
 
             if (wireType === undefined)
         genTypePartial(gen, field, index, ref);

--- a/tests/comp_optional.js
+++ b/tests/comp_optional.js
@@ -4,12 +4,20 @@ var protobuf = require("..");
 
 var proto = "syntax = \"proto3\";\
 \
+message Nested {\
+}\
+\
 message Message {\
     int32 regular_int32 = 1;\
     optional int32 optional_int32 = 2;\
     oneof _oneof_int32 {\
         int32 oneof_int32 = 3;\
     }\
+    string regular_string = 4;\
+    bytes regular_bytes = 5;\
+    int64 regular_int64 = 6;\
+    bool regular_bool = 7;\
+    Nested regular_message = 8;\
 }\
 ";
 
@@ -25,6 +33,28 @@ tape.test("proto3 optional", function(test) {
     var m = Message.create({});
     test.strictEqual(m.regularInt32, 0);
     test.strictEqual(m.optionalInt32, null);
+
+    test.end();
+});
+
+tape.test("proto3 implicit scalar defaults", function(test) {
+    var root = protobuf.parse(proto).root;
+    root.resolveAll();
+
+    var Message = root.lookupType("Message");
+
+    function reencode(buf) {
+        return Array.prototype.slice.call(Message.encode(Message.decode(buf)).finish());
+    }
+
+    test.same(reencode([8, 0]), [], "should omit default int32");
+    test.same(reencode([26, 0]), [], "should omit default string");
+    test.same(reencode([34, 0]), [], "should omit default bytes");
+    test.same(reencode([48, 0]), [], "should omit default int64");
+    test.same(reencode([56, 0]), [], "should omit default bool");
+    test.same(reencode([16, 0]), [16, 0], "should preserve proto3 optional default");
+    test.same(reencode([24, 0]), [24, 0], "should preserve oneof default");
+    test.same(reencode([66, 0]), [66, 0], "should preserve empty message");
 
     test.end();
 });

--- a/tests/data/comments.js
+++ b/tests/data/comments.js
@@ -86,11 +86,11 @@ $root.Test1 = (function() {
     Test1.encode = function encode(message, writer) {
         if (!writer)
             writer = $Writer.create();
-        if (message.field1 != null && Object.hasOwnProperty.call(message, "field1"))
+        if (message.field1 != null && message.field1.length)
             writer.uint32(/* id 1, wireType 2 =*/10).string(message.field1);
-        if (message.field2 != null && Object.hasOwnProperty.call(message, "field2"))
+        if (message.field2 != null && Number(message.field2) !== 0)
             writer.uint32(/* id 2, wireType 0 =*/16).uint32(message.field2);
-        if (message.field3 != null && Object.hasOwnProperty.call(message, "field3"))
+        if (message.field3)
             writer.uint32(/* id 3, wireType 0 =*/24).bool(message.field3);
         return writer;
     };

--- a/tests/data/convert.js
+++ b/tests/data/convert.js
@@ -142,12 +142,12 @@ $root.Message = (function() {
     Message.encode = function encode(message, writer) {
         if (!writer)
             writer = $Writer.create();
-        if (message.stringVal != null && Object.hasOwnProperty.call(message, "stringVal"))
+        if (message.stringVal != null && message.stringVal.length)
             writer.uint32(/* id 1, wireType 2 =*/10).string(message.stringVal);
         if (message.stringRepeated != null && message.stringRepeated.length)
             for (var i = 0; i < message.stringRepeated.length; ++i)
                 writer.uint32(/* id 2, wireType 2 =*/18).string(message.stringRepeated[i]);
-        if (message.uint64Val != null && Object.hasOwnProperty.call(message, "uint64Val"))
+        if (message.uint64Val != null && (typeof message.uint64Val === "object" ? message.uint64Val.low || message.uint64Val.high : Number(message.uint64Val) !== 0))
             writer.uint32(/* id 3, wireType 0 =*/24).uint64(message.uint64Val);
         if (message.uint64Repeated != null && message.uint64Repeated.length) {
             writer.uint32(/* id 4, wireType 2 =*/34).fork();
@@ -155,12 +155,12 @@ $root.Message = (function() {
                 writer.uint64(message.uint64Repeated[i]);
             writer.ldelim();
         }
-        if (message.bytesVal != null && Object.hasOwnProperty.call(message, "bytesVal"))
+        if (message.bytesVal != null && message.bytesVal.length)
             writer.uint32(/* id 5, wireType 2 =*/42).bytes(message.bytesVal);
         if (message.bytesRepeated != null && message.bytesRepeated.length)
             for (var i = 0; i < message.bytesRepeated.length; ++i)
                 writer.uint32(/* id 6, wireType 2 =*/50).bytes(message.bytesRepeated[i]);
-        if (message.enumVal != null && Object.hasOwnProperty.call(message, "enumVal"))
+        if (message.enumVal != null && Number(message.enumVal) !== 0)
             writer.uint32(/* id 7, wireType 0 =*/56).int32(message.enumVal);
         if (message.enumRepeated != null && message.enumRepeated.length) {
             writer.uint32(/* id 8, wireType 2 =*/66).fork();

--- a/tests/data/package.js
+++ b/tests/data/package.js
@@ -215,26 +215,26 @@ $root.Package = (function() {
     Package.encode = function encode(message, writer) {
         if (!writer)
             writer = $Writer.create();
-        if (message.name != null && Object.hasOwnProperty.call(message, "name"))
+        if (message.name != null && message.name.length)
             writer.uint32(/* id 1, wireType 2 =*/10).string(message.name);
-        if (message.version != null && Object.hasOwnProperty.call(message, "version"))
+        if (message.version != null && message.version.length)
             writer.uint32(/* id 2, wireType 2 =*/18).string(message.version);
-        if (message.description != null && Object.hasOwnProperty.call(message, "description"))
+        if (message.description != null && message.description.length)
             writer.uint32(/* id 3, wireType 2 =*/26).string(message.description);
-        if (message.author != null && Object.hasOwnProperty.call(message, "author"))
+        if (message.author != null && message.author.length)
             writer.uint32(/* id 4, wireType 2 =*/34).string(message.author);
-        if (message.license != null && Object.hasOwnProperty.call(message, "license"))
+        if (message.license != null && message.license.length)
             writer.uint32(/* id 5, wireType 2 =*/42).string(message.license);
         if (message.repository != null && Object.hasOwnProperty.call(message, "repository"))
             $root.Package.Repository.encode(message.repository, writer.uint32(/* id 6, wireType 2 =*/50).fork()).ldelim();
-        if (message.bugs != null && Object.hasOwnProperty.call(message, "bugs"))
+        if (message.bugs != null && message.bugs.length)
             writer.uint32(/* id 7, wireType 2 =*/58).string(message.bugs);
-        if (message.homepage != null && Object.hasOwnProperty.call(message, "homepage"))
+        if (message.homepage != null && message.homepage.length)
             writer.uint32(/* id 8, wireType 2 =*/66).string(message.homepage);
         if (message.keywords != null && message.keywords.length)
             for (var i = 0; i < message.keywords.length; ++i)
                 writer.uint32(/* id 9, wireType 2 =*/74).string(message.keywords[i]);
-        if (message.main != null && Object.hasOwnProperty.call(message, "main"))
+        if (message.main != null && message.main.length)
             writer.uint32(/* id 10, wireType 2 =*/82).string(message.main);
         if (message.bin != null && Object.hasOwnProperty.call(message, "bin"))
             for (var keys = Object.keys(message.bin), i = 0; i < keys.length; ++i)
@@ -248,12 +248,12 @@ $root.Package = (function() {
         if (message.devDependencies != null && Object.hasOwnProperty.call(message, "devDependencies"))
             for (var keys = Object.keys(message.devDependencies), i = 0; i < keys.length; ++i)
                 writer.uint32(/* id 15, wireType 2 =*/122).fork().uint32(/* id 1, wireType 2 =*/10).string(keys[i]).uint32(/* id 2, wireType 2 =*/18).string(message.devDependencies[keys[i]]).ldelim();
-        if (message.types != null && Object.hasOwnProperty.call(message, "types"))
+        if (message.types != null && message.types.length)
             writer.uint32(/* id 17, wireType 2 =*/138).string(message.types);
         if (message.cliDependencies != null && message.cliDependencies.length)
             for (var i = 0; i < message.cliDependencies.length; ++i)
                 writer.uint32(/* id 18, wireType 2 =*/146).string(message.cliDependencies[i]);
-        if (message.versionScheme != null && Object.hasOwnProperty.call(message, "versionScheme"))
+        if (message.versionScheme != null && message.versionScheme.length)
             writer.uint32(/* id 19, wireType 2 =*/154).string(message.versionScheme);
         return writer;
     };
@@ -871,9 +871,9 @@ $root.Package = (function() {
         Repository.encode = function encode(message, writer) {
             if (!writer)
                 writer = $Writer.create();
-            if (message.type != null && Object.hasOwnProperty.call(message, "type"))
+            if (message.type != null && message.type.length)
                 writer.uint32(/* id 1, wireType 2 =*/10).string(message.type);
-            if (message.url != null && Object.hasOwnProperty.call(message, "url"))
+            if (message.url != null && message.url.length)
                 writer.uint32(/* id 2, wireType 2 =*/18).string(message.url);
             return writer;
         };

--- a/tests/data/rpc-es6.js
+++ b/tests/data/rpc-es6.js
@@ -131,7 +131,7 @@ export const MyRequest = $root.MyRequest = (() => {
     MyRequest.encode = function encode(message, writer) {
         if (!writer)
             writer = $Writer.create();
-        if (message.path != null && Object.hasOwnProperty.call(message, "path"))
+        if (message.path != null && message.path.length)
             writer.uint32(/* id 1, wireType 2 =*/10).string(message.path);
         return writer;
     };
@@ -352,7 +352,7 @@ export const MyResponse = $root.MyResponse = (() => {
     MyResponse.encode = function encode(message, writer) {
         if (!writer)
             writer = $Writer.create();
-        if (message.status != null && Object.hasOwnProperty.call(message, "status"))
+        if (message.status != null && Number(message.status) !== 0)
             writer.uint32(/* id 2, wireType 0 =*/16).int32(message.status);
         return writer;
     };

--- a/tests/data/rpc-reserved.js
+++ b/tests/data/rpc-reserved.js
@@ -133,7 +133,7 @@ $root.MyRequest = (function() {
     MyRequest.encode = function encode(message, writer) {
         if (!writer)
             writer = $Writer.create();
-        if (message.path != null && Object.hasOwnProperty.call(message, "path"))
+        if (message.path != null && message.path.length)
             writer.uint32(/* id 1, wireType 2 =*/10).string(message.path);
         return writer;
     };
@@ -354,7 +354,7 @@ $root.MyResponse = (function() {
     MyResponse.encode = function encode(message, writer) {
         if (!writer)
             writer = $Writer.create();
-        if (message.status != null && Object.hasOwnProperty.call(message, "status"))
+        if (message.status != null && Number(message.status) !== 0)
             writer.uint32(/* id 2, wireType 0 =*/16).int32(message.status);
         return writer;
     };

--- a/tests/data/rpc.js
+++ b/tests/data/rpc.js
@@ -133,7 +133,7 @@ $root.MyRequest = (function() {
     MyRequest.encode = function encode(message, writer) {
         if (!writer)
             writer = $Writer.create();
-        if (message.path != null && Object.hasOwnProperty.call(message, "path"))
+        if (message.path != null && message.path.length)
             writer.uint32(/* id 1, wireType 2 =*/10).string(message.path);
         return writer;
     };
@@ -354,7 +354,7 @@ $root.MyResponse = (function() {
     MyResponse.encode = function encode(message, writer) {
         if (!writer)
             writer = $Writer.create();
-        if (message.status != null && Object.hasOwnProperty.call(message, "status"))
+        if (message.status != null && Number(message.status) !== 0)
             writer.uint32(/* id 2, wireType 0 =*/16).int32(message.status);
         return writer;
     };

--- a/tests/data/type_url.js
+++ b/tests/data/type_url.js
@@ -288,7 +288,7 @@ $root.TypeUrlTest = (function() {
         Nested.encode = function encode(message, writer) {
             if (!writer)
                 writer = $Writer.create();
-            if (message.a != null && Object.hasOwnProperty.call(message, "a"))
+            if (message.a != null && message.a.length)
                 writer.uint32(/* id 1, wireType 2 =*/10).string(message.a);
             return writer;
         };


### PR DESCRIPTION
Updates generated encoders to handle scalar field presence more like protoc.

For implicit-presence scalar fields, default values are now omitted when encoding. Fields with explicit presence still preserve explicitly set defaults, including proto2 fields, proto3 optional fields, oneofs, extensions, message fields, and editions explicit/required fields.

Also refreshes affected fixtures.