### PR TITLE
feat: Roundtrip unknown fields

### DIFF
--- a/bench/data/static_pbjs.js
+++ b/bench/data/static_pbjs.js
@@ -32,6 +32,9 @@ $root.Test = (function() {
             $root.Test.Inner.encode(message.inner, writer.uint32(26).fork()).ldelim();
         if (message.float != null && Object.hasOwnProperty.call(message, "float"))
             writer.uint32(37).float(message.float);
+        if (message.$unknowns != null && Object.hasOwnProperty.call(message, "$unknowns"))
+            for (var i = 0; i < message.$unknowns.length; ++i)
+                writer.raw(message.$unknowns[i]);
         return writer;
     };
 
@@ -44,6 +47,7 @@ $root.Test = (function() {
             throw Error("max depth exceeded");
         var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.Test();
         while (reader.pos < end) {
+            var start = reader.pos;
             var tag = reader.uint32();
             if (tag === _end) {
                 _end = undefined;
@@ -68,6 +72,8 @@ $root.Test = (function() {
                 }
             default:
                 reader.skipType(tag & 7, _depth, tag >>> 3);
+                $util.makeProp(message, "$unknowns", false);
+                (message.$unknowns || (message.$unknowns = [])).push(reader.raw(start, reader.pos));
                 break;
             }
         }
@@ -98,6 +104,9 @@ $root.Test = (function() {
                 $root.Test.Inner.InnerInner.encode(message.innerInner, writer.uint32(18).fork()).ldelim();
             if (message.outer != null && Object.hasOwnProperty.call(message, "outer"))
                 $root.Outer.encode(message.outer, writer.uint32(26).fork()).ldelim();
+            if (message.$unknowns != null && Object.hasOwnProperty.call(message, "$unknowns"))
+                for (var i = 0; i < message.$unknowns.length; ++i)
+                    writer.raw(message.$unknowns[i]);
             return writer;
         };
 
@@ -110,6 +119,7 @@ $root.Test = (function() {
                 throw Error("max depth exceeded");
             var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.Test.Inner();
             while (reader.pos < end) {
+                var start = reader.pos;
                 var tag = reader.uint32();
                 if (tag === _end) {
                     _end = undefined;
@@ -130,6 +140,8 @@ $root.Test = (function() {
                     }
                 default:
                     reader.skipType(tag & 7, _depth, tag >>> 3);
+                    $util.makeProp(message, "$unknowns", false);
+                    (message.$unknowns || (message.$unknowns = [])).push(reader.raw(start, reader.pos));
                     break;
                 }
             }
@@ -160,6 +172,9 @@ $root.Test = (function() {
                     writer.uint32(16).int32(message["enum"]);
                 if (message.sint32 != null && Object.hasOwnProperty.call(message, "sint32"))
                     writer.uint32(24).sint32(message.sint32);
+                if (message.$unknowns != null && Object.hasOwnProperty.call(message, "$unknowns"))
+                    for (var i = 0; i < message.$unknowns.length; ++i)
+                        writer.raw(message.$unknowns[i]);
                 return writer;
             };
 
@@ -172,6 +187,7 @@ $root.Test = (function() {
                     throw Error("max depth exceeded");
                 var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.Test.Inner.InnerInner();
                 while (reader.pos < end) {
+                    var start = reader.pos;
                     var tag = reader.uint32();
                     if (tag === _end) {
                         _end = undefined;
@@ -192,6 +208,8 @@ $root.Test = (function() {
                         }
                     default:
                         reader.skipType(tag & 7, _depth, tag >>> 3);
+                        $util.makeProp(message, "$unknowns", false);
+                        (message.$unknowns || (message.$unknowns = [])).push(reader.raw(start, reader.pos));
                         break;
                     }
                 }
@@ -243,6 +261,9 @@ $root.Outer = (function() {
         }
         if (message.double != null && Object.hasOwnProperty.call(message, "double"))
             writer.uint32(17).double(message.double);
+        if (message.$unknowns != null && Object.hasOwnProperty.call(message, "$unknowns"))
+            for (var i = 0; i < message.$unknowns.length; ++i)
+                writer.raw(message.$unknowns[i]);
         return writer;
     };
 
@@ -255,6 +276,7 @@ $root.Outer = (function() {
             throw Error("max depth exceeded");
         var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.Outer();
         while (reader.pos < end) {
+            var start = reader.pos;
             var tag = reader.uint32();
             if (tag === _end) {
                 _end = undefined;
@@ -279,6 +301,8 @@ $root.Outer = (function() {
                 }
             default:
                 reader.skipType(tag & 7, _depth, tag >>> 3);
+                $util.makeProp(message, "$unknowns", false);
+                (message.$unknowns || (message.$unknowns = [])).push(reader.raw(start, reader.pos));
                 break;
             }
         }

--- a/cli/targets/static.js
+++ b/cli/targets/static.js
@@ -167,6 +167,7 @@ var shortVars = {
     "m": "message",
     "t": "tag",
     "l": "length",
+    "s": "start",
     "c": "end", "c2": "end2",
     "k": "key",
     "ks": "keys", "ks2": "keys2",
@@ -433,6 +434,7 @@ function buildType(ref, type) {
             }
             typeDef.push("@property {" + jsType + "} " + toPropName(field, nullable) + " " + (field.comment || type.name + " " + field.name));
         });
+        typeDef.push("@property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding");
         push("");
         pushComment(typeDef);
     }
@@ -456,6 +458,7 @@ function buildType(ref, type) {
             var propType = optional ? jsType.replace(/\|undefined\b/g, "") : jsType;
             classDef.push("@property {" + propType + "} " + toPropName(field, optional) + " " + (field.comment || type.name + " " + field.name));
         });
+        classDef.push("@property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding");
     }
     pushComment(classDef);
     buildFunction(type, type.name, Type.generateConstructor(type));

--- a/index.d.ts
+++ b/index.d.ts
@@ -545,6 +545,9 @@ export class Message<T extends object = object> {
     /** Reference to the reflected type. */
     public readonly $type: Type;
 
+    /** Unknown fields preserved while decoding. */
+    public $unknowns?: Uint8Array[];
+
     /**
      * Creates a new message of this type using the specified properties.
      * @param [properties] Properties to set
@@ -1175,6 +1178,14 @@ export class Reader {
     public static create(buffer: (Uint8Array|Buffer)): (Reader|BufferReader);
 
     /**
+     * Returns raw bytes from the backing buffer without advancing the reader.
+     * @param start Start offset
+     * @param end End offset
+     * @returns Raw bytes
+     */
+    public raw(start: number, end: number): Uint8Array;
+
+    /**
      * Reads a varint as an unsigned 32 bit value.
      * @returns Value read
      */
@@ -1292,6 +1303,14 @@ export class BufferReader extends Reader {
      * @param buffer Buffer to read from
      */
     constructor(buffer: Buffer);
+
+    /**
+     * Returns raw bytes from the backing buffer without advancing the reader.
+     * @param start Start offset
+     * @param end End offset
+     * @returns Raw bytes
+     */
+    public raw(start: number, end: number): Buffer;
 
     /**
      * Reads a sequence of bytes preceeded by its length as a varint.
@@ -2397,8 +2416,9 @@ export namespace util {
      * Makes a property safe for assignment as an own property.
      * @param obj Object
      * @param key Property key
+     * @param [enumerable=true] Whether the property should be enumerable
      */
-    function makeProp(obj: { [k: string]: any }, key: string): void;
+    function makeProp(obj: { [k: string]: any }, key: string, enumerable?: boolean): void;
 
     /**
      * Converts the first character of a string to lower case.
@@ -2776,6 +2796,13 @@ export class Writer {
     public bytes(value: (Uint8Array|string)): Writer;
 
     /**
+     * Writes raw bytes without a tag or length prefix.
+     * @param value Raw bytes
+     * @returns `this`
+     */
+    public raw(value: Uint8Array): Writer;
+
+    /**
      * Writes a string.
      * @param value Value to write
      * @returns `this`
@@ -2820,6 +2847,13 @@ export class BufferWriter extends Writer {
      * @returns Buffer
      */
     public static alloc(size: number): Buffer;
+
+    /**
+     * Writes raw bytes without a tag or length prefix.
+     * @param value Raw bytes
+     * @returns `this`
+     */
+    public raw(value: Uint8Array): BufferWriter;
 
     /**
      * Finishes the write operation.

--- a/src/decoder.js
+++ b/src/decoder.js
@@ -24,6 +24,7 @@ function decoder(mtype) {
         ("throw Error(\"max depth exceeded\")")
     ("var c=l===undefined?r.len:r.pos+l,m=g||new this.ctor" + (mtype.fieldsArray.filter(function(field) { return field.map; }).length ? ",k,value" : ""))
     ("while(r.pos<c){")
+        ("var s=r.pos")
         ("var t=r.uint32()")
         ("if(t===z){")
             ("z=undefined")
@@ -135,6 +136,8 @@ function decoder(mtype) {
     } gen
             ("default:")
                 ("r.skipType(t&7,q,t>>>3)")
+                ("util.makeProp(m,\"$unknowns\",false);")
+                ("(m.$unknowns||(m.$unknowns=[])).push(r.raw(s,r.pos))")
                 ("break")
 
         ("}")

--- a/src/encoder.js
+++ b/src/encoder.js
@@ -100,6 +100,9 @@ function encoder(mtype) {
     }
 
     return gen
+    ("if(m.$unknowns!=null&&Object.hasOwnProperty.call(m,\"$unknowns\"))")
+        ("for(var i=0;i<m.$unknowns.length;++i)")
+            ("w.raw(m.$unknowns[i])")
     ("return w");
     /* eslint-enable no-unexpected-multiline, block-scoped-var, no-redeclare */
 }

--- a/src/message.js
+++ b/src/message.js
@@ -8,6 +8,7 @@ var util = require("./util/minimal");
  * @classdesc Abstract runtime message.
  * @constructor
  * @param {Properties<T>} [properties] Properties to set
+ * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
  * @template T extends object = object
  */
 function Message(properties) {

--- a/src/reader.js
+++ b/src/reader.js
@@ -79,6 +79,21 @@ Reader.create = create();
 Reader.prototype._slice = util.Array.prototype.subarray || /* istanbul ignore next */ util.Array.prototype.slice;
 
 /**
+ * Returns raw bytes from the backing buffer without advancing the reader.
+ * @param {number} start Start offset
+ * @param {number} end End offset
+ * @returns {Uint8Array} Raw bytes
+ */
+Reader.prototype.raw = function read_raw(start, end) {
+    if (Array.isArray(this.buf)) // plain array
+        return this.buf.slice(start, end);
+
+    if (start === end) // fix for IE 10/Win8 and others' subarray returning array of size 1
+        return new this.buf.constructor(0);
+    return this._slice.call(this.buf, start, end);
+};
+
+/**
  * Reads a varint as an unsigned 32 bit value.
  * @function
  * @returns {number} Value read
@@ -325,17 +340,8 @@ Reader.prototype.bytes = function read_bytes() {
     if (end > this.len)
         throw indexOutOfRange(this, length);
 
-    this.pos += length;
-    if (Array.isArray(this.buf)) // plain array
-        return this.buf.slice(start, end);
-
-    if (start === end) { // fix for IE 10/Win8 and others' subarray returning array of size 1
-        var nativeBuffer = util.Buffer;
-        return nativeBuffer
-            ? nativeBuffer.alloc(0)
-            : new this.buf.constructor(0);
-    }
-    return this._slice.call(this.buf, start, end);
+    this.pos = end;
+    return this.raw(start, end);
 };
 
 /**

--- a/src/reader_buffer.js
+++ b/src/reader_buffer.js
@@ -30,6 +30,19 @@ BufferReader._configure = function () {
         BufferReader.prototype._slice = util.Buffer.prototype.slice;
 };
 
+/**
+ * Returns raw bytes from the backing buffer without advancing the reader.
+ * @name BufferReader#raw
+ * @function
+ * @param {number} start Start offset
+ * @param {number} end End offset
+ * @returns {Buffer} Raw bytes
+ */
+BufferReader.prototype.raw = function read_raw_buffer(start, end) {
+    if (start === end)
+        return util.Buffer.alloc(0);
+    return this._slice.call(this.buf, start, end);
+};
 
 /**
  * @override

--- a/src/util/minimal.js
+++ b/src/util/minimal.js
@@ -277,11 +277,14 @@ util.recursionLimit = 100;
  * @memberof util
  * @param {Object.<string,*>} obj Object
  * @param {string} key Property key
+ * @param {boolean} [enumerable=true] Whether the property should be enumerable
  * @returns {undefined}
  */
-util.makeProp = function makeProp(obj, key) {
+util.makeProp = function makeProp(obj, key, enumerable) {
+    if (Object.prototype.hasOwnProperty.call(obj, key))
+        return;
     Object.defineProperty(obj, key, {
-        enumerable: true,
+        enumerable: enumerable === undefined ? true : enumerable,
         configurable: true,
         writable: true
     });

--- a/src/writer.js
+++ b/src/writer.js
@@ -384,6 +384,16 @@ Writer.prototype.bytes = function write_bytes(value) {
 };
 
 /**
+ * Writes raw bytes without a tag or length prefix.
+ * @param {Uint8Array} value Raw bytes
+ * @returns {Writer} `this`
+ */
+Writer.prototype.raw = function write_raw(value) {
+    var len = value.length >>> 0;
+    return len ? this._push(writeBytes, len, value) : this;
+};
+
+/**
  * Writes a string.
  * @param {string} value Value to write
  * @returns {Writer} `this`

--- a/src/writer_buffer.js
+++ b/src/writer_buffer.js
@@ -54,6 +54,18 @@ BufferWriter.prototype.bytes = function write_bytes_buffer(value) {
     return this;
 };
 
+/**
+ * Writes raw bytes without a tag or length prefix.
+ * @name BufferWriter#raw
+ * @function
+ * @param {Uint8Array} value Raw bytes
+ * @returns {BufferWriter} `this`
+ */
+BufferWriter.prototype.raw = function write_raw_buffer(value) {
+    var len = value.length >>> 0;
+    return len ? this._push(BufferWriter.writeBytesBuffer, len, value) : this;
+};
+
 function writeStringBuffer(val, buf, pos) {
     if (val.length < 40) // plain js is faster for short strings (probably due to redundant assertions)
         util.utf8.write(val, buf, pos);

--- a/tests/api_writer-reader.js
+++ b/tests/api_writer-reader.js
@@ -106,6 +106,15 @@ tape.test("writer & reader", function(test) {
     test.ok(expect("bytes", [], [0]), "should write [] as bytes prefixed with its length as a varint and read it back equally");
     test.ok(expect("bytes", "MTIz", [3,49,50,51]), "should write MTIz as bytes prefixed with its length as a varint and read it back equally");
 
+    // raw bytes
+
+    var rawReader = Reader.create([0,1,2,3]);
+    test.deepEqual(Array.prototype.slice.call(rawReader.raw(1, 3)), [1,2], "should read raw bytes without a length prefix");
+    test.equal(rawReader.pos, 0, "should read raw bytes without advancing");
+    if (protobuf.util.Buffer)
+        test.deepEqual(Reader.create(protobuf.util.Buffer.from([0,1,2,3])).raw(1, 3), protobuf.util.Buffer.from([1,2]), "should preserve buffer backed raw bytes");
+    test.deepEqual(Array.prototype.slice.call(Writer.create().raw([1,2,3]).finish()), [1,2,3], "should write raw bytes without a length prefix");
+
     // skipType
 
     test.test(test.name + " - should allow to skip", function(test) {

--- a/tests/comp_unknown-fields.js
+++ b/tests/comp_unknown-fields.js
@@ -1,0 +1,109 @@
+"use strict";
+
+var tape = require("tape");
+
+var protobuf = require("..");
+
+var proto = "syntax = \"proto3\";\n"
+    + "message SimpleV1 {\n"
+    + "  int32 known = 1;\n"
+    + "}\n"
+    + "message SimpleV2 {\n"
+    + "  int32 known = 1;\n"
+    + "  bool future_bool = 2;\n"
+    + "  string future_string = 3;\n"
+    + "}\n";
+
+tape.test("unknown fields - preserve through decode and encode", function(test) {
+    var root = protobuf.parse(proto).root,
+        SimpleV1 = root.lookupType("SimpleV1"),
+        SimpleV2 = root.lookupType("SimpleV2");
+
+    var original = {
+        known: 1,
+        futureBool: true,
+        futureString: "hello"
+    };
+    var decoded = SimpleV1.decode(SimpleV2.encode(original).finish());
+
+    test.equal(decoded.known, 1, "should decode known fields");
+    test.deepEqual(Object.keys(decoded), [ "known" ], "should keep unknown fields non-enumerable");
+    test.equal(decoded.$unknowns.length, 2, "should store unknown fields");
+
+    var restored = SimpleV2.decode(SimpleV1.encode(decoded).finish());
+    test.equal(restored.known, original.known, "should preserve known fields");
+    test.equal(restored.futureBool, original.futureBool, "should preserve unknown bool field");
+    test.equal(restored.futureString, original.futureString, "should preserve unknown string field");
+    test.end();
+});
+
+tape.test("unknown fields - preserve unknown field order", function(test) {
+    var root = protobuf.parse(proto).root,
+        SimpleV1 = root.lookupType("SimpleV1");
+
+    var original = protobuf.Writer.create()
+        .uint32(26).string("abc")
+        .uint32(16).bool(true)
+        .uint32(26).string("def")
+        .finish();
+    var decoded = SimpleV1.decode(original);
+
+    test.deepEqual(SimpleV1.encode(decoded).finish(), original, "should preserve relative unknown field order");
+    test.end();
+});
+
+tape.test("unknown fields - can be discarded", function(test) {
+    var root = protobuf.parse(proto).root,
+        SimpleV1 = root.lookupType("SimpleV1"),
+        SimpleV2 = root.lookupType("SimpleV2");
+
+    var decoded = SimpleV1.decode(SimpleV2.encode({
+        known: 1,
+        futureBool: true,
+        futureString: "hello"
+    }).finish());
+
+    delete decoded.$unknowns;
+
+    var restored = SimpleV2.decode(SimpleV1.encode(decoded).finish());
+    test.equal(restored.known, 1, "should preserve known fields");
+    test.equal(Object.hasOwnProperty.call(restored, "futureBool"), false, "should discard unknown bool field");
+    test.equal(Object.hasOwnProperty.call(restored, "futureString"), false, "should discard unknown string field");
+    test.end();
+});
+
+tape.test("unknown fields - only encode own unknown fields", function(test) {
+    var root = protobuf.parse(proto).root,
+        SimpleV1 = root.lookupType("SimpleV1"),
+        SimpleV2 = root.lookupType("SimpleV2");
+
+    var unknownBool = SimpleV2.encode({ futureBool: true }).finish();
+    var message = Object.create({ $unknowns: [ unknownBool ] });
+    message.known = 1;
+
+    var restored = SimpleV2.decode(SimpleV1.encode(message).finish());
+    test.equal(restored.known, 1, "should preserve known fields");
+    test.equal(Object.hasOwnProperty.call(restored, "futureBool"), false, "should ignore inherited unknown fields");
+
+    message.$unknowns = [ unknownBool ];
+    restored = SimpleV2.decode(SimpleV1.encode(message).finish());
+    test.equal(restored.futureBool, true, "should encode own unknown fields");
+    test.end();
+});
+
+tape.test("unknown fields - ignore nullish own unknown fields", function(test) {
+    var root = protobuf.parse(proto).root,
+        SimpleV1 = root.lookupType("SimpleV1"),
+        SimpleV2 = root.lookupType("SimpleV2");
+
+    var message = { known: 1, $unknowns: null };
+    var restored = SimpleV2.decode(SimpleV1.encode(message).finish());
+    test.equal(restored.known, 1, "should encode with null unknown fields");
+    test.equal(Object.hasOwnProperty.call(restored, "futureBool"), false, "should ignore null unknown fields");
+
+    message.$unknowns = undefined;
+    restored = SimpleV2.decode(SimpleV1.encode(message).finish());
+    test.equal(restored.known, 1, "should encode with undefined unknown fields");
+    test.equal(Object.hasOwnProperty.call(restored, "futureBool"), false, "should ignore undefined unknown fields");
+    test.end();
+});

--- a/tests/data/comments.d.ts
+++ b/tests/data/comments.d.ts
@@ -4,10 +4,12 @@ export interface ITest1 {
     field1?: (string|null);
     field2?: (number|null);
     field3?: (boolean|null);
+    $unknowns?: Uint8Array[];
 }
 
 export class Test1 implements ITest1 {
     constructor(properties?: ITest1);
+    public $unknowns?: Uint8Array[];
     public field1: string;
     public field2: number;
     public field3: boolean;
@@ -24,10 +26,12 @@ export class Test1 implements ITest1 {
 }
 
 export interface ITest2 {
+    $unknowns?: Uint8Array[];
 }
 
 export class Test2 implements ITest2 {
     constructor(properties?: ITest2);
+    public $unknowns?: Uint8Array[];
     public static create(properties?: ITest2): Test2;
     public static encode(message: ITest2, writer?: $protobuf.Writer): $protobuf.Writer;
     public static encodeDelimited(message: ITest2, writer?: $protobuf.Writer): $protobuf.Writer;

--- a/tests/data/comments.js
+++ b/tests/data/comments.js
@@ -18,6 +18,7 @@ $root.Test1 = (function() {
      * @property {string|null} [field1] Field with a comment.
      * @property {number|null} [field2] Test1 field2
      * @property {boolean|null} [field3] Field with a comment and a <a href="http://example.com/foo/">link</a>
+     * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
      */
 
     /**
@@ -30,6 +31,7 @@ $root.Test1 = (function() {
      * @implements ITest1
      * @constructor
      * @param {ITest1=} [properties] Properties to set
+     * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
      */
     function Test1(properties) {
         if (properties)
@@ -92,6 +94,9 @@ $root.Test1 = (function() {
             writer.uint32(/* id 2, wireType 0 =*/16).uint32(message.field2);
         if (message.field3 != null && Object.hasOwnProperty.call(message, "field3"))
             writer.uint32(/* id 3, wireType 0 =*/24).bool(message.field3);
+        if (message.$unknowns != null && Object.hasOwnProperty.call(message, "$unknowns"))
+            for (var i = 0; i < message.$unknowns.length; ++i)
+                writer.raw(message.$unknowns[i]);
         return writer;
     };
 
@@ -128,6 +133,7 @@ $root.Test1 = (function() {
             throw Error("max depth exceeded");
         var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.Test1();
         while (reader.pos < end) {
+            var start = reader.pos;
             var tag = reader.uint32();
             if (tag === _end) {
                 _end = undefined;
@@ -148,6 +154,8 @@ $root.Test1 = (function() {
                 }
             default:
                 reader.skipType(tag & 7, _depth, tag >>> 3);
+                $util.makeProp(message, "$unknowns", false);
+                (message.$unknowns || (message.$unknowns = [])).push(reader.raw(start, reader.pos));
                 break;
             }
         }
@@ -286,6 +294,7 @@ $root.Test2 = (function() {
      * Properties of a Test2.
      * @exports ITest2
      * @interface ITest2
+     * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
      */
 
     /**
@@ -295,6 +304,7 @@ $root.Test2 = (function() {
      * @implements ITest2
      * @constructor
      * @param {ITest2=} [properties] Properties to set
+     * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
      */
     function Test2(properties) {
         if (properties)
@@ -327,6 +337,9 @@ $root.Test2 = (function() {
     Test2.encode = function encode(message, writer) {
         if (!writer)
             writer = $Writer.create();
+        if (message.$unknowns != null && Object.hasOwnProperty.call(message, "$unknowns"))
+            for (var i = 0; i < message.$unknowns.length; ++i)
+                writer.raw(message.$unknowns[i]);
         return writer;
     };
 
@@ -363,6 +376,7 @@ $root.Test2 = (function() {
             throw Error("max depth exceeded");
         var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.Test2();
         while (reader.pos < end) {
+            var start = reader.pos;
             var tag = reader.uint32();
             if (tag === _end) {
                 _end = undefined;
@@ -371,6 +385,8 @@ $root.Test2 = (function() {
             switch (tag) {
             default:
                 reader.skipType(tag & 7, _depth, tag >>> 3);
+                $util.makeProp(message, "$unknowns", false);
+                (message.$unknowns || (message.$unknowns = [])).push(reader.raw(start, reader.pos));
                 break;
             }
         }

--- a/tests/data/convert.d.ts
+++ b/tests/data/convert.d.ts
@@ -10,10 +10,12 @@ export interface IMessage {
     enumVal?: (Message.SomeEnum|null);
     enumRepeated?: (Message.SomeEnum[]|null);
     int64Map?: ({ [k: string]: (number|Long) }|null);
+    $unknowns?: Uint8Array[];
 }
 
 export class Message implements IMessage {
     constructor(properties?: IMessage);
+    public $unknowns?: Uint8Array[];
     public stringVal: string;
     public stringRepeated: string[];
     public uint64Val: (number|Long);

--- a/tests/data/convert.js
+++ b/tests/data/convert.js
@@ -24,6 +24,7 @@ $root.Message = (function() {
      * @property {Message.SomeEnum|null} [enumVal] Message enumVal
      * @property {Array.<Message.SomeEnum>|null} [enumRepeated] Message enumRepeated
      * @property {Object.<string,number|Long>|null} [int64Map] Message int64Map
+     * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
      */
 
     /**
@@ -33,6 +34,7 @@ $root.Message = (function() {
      * @implements IMessage
      * @constructor
      * @param {IMessage=} [properties] Properties to set
+     * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
      */
     function Message(properties) {
         this.stringRepeated = [];
@@ -171,6 +173,9 @@ $root.Message = (function() {
         if (message.int64Map != null && Object.hasOwnProperty.call(message, "int64Map"))
             for (var keys = Object.keys(message.int64Map), i = 0; i < keys.length; ++i)
                 writer.uint32(/* id 9, wireType 2 =*/74).fork().uint32(/* id 1, wireType 2 =*/10).string(keys[i]).uint32(/* id 2, wireType 0 =*/16).int64(message.int64Map[keys[i]]).ldelim();
+        if (message.$unknowns != null && Object.hasOwnProperty.call(message, "$unknowns"))
+            for (var i = 0; i < message.$unknowns.length; ++i)
+                writer.raw(message.$unknowns[i]);
         return writer;
     };
 
@@ -207,6 +212,7 @@ $root.Message = (function() {
             throw Error("max depth exceeded");
         var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.Message(), key, value;
         while (reader.pos < end) {
+            var start = reader.pos;
             var tag = reader.uint32();
             if (tag === _end) {
                 _end = undefined;
@@ -292,6 +298,8 @@ $root.Message = (function() {
                 }
             default:
                 reader.skipType(tag & 7, _depth, tag >>> 3);
+                $util.makeProp(message, "$unknowns", false);
+                (message.$unknowns || (message.$unknowns = [])).push(reader.raw(start, reader.pos));
                 break;
             }
         }

--- a/tests/data/mapbox/vector_tile.d.ts
+++ b/tests/data/mapbox/vector_tile.d.ts
@@ -4,10 +4,12 @@ export namespace vector_tile {
 
     interface ITile {
         layers?: (vector_tile.Tile.ILayer[]|null);
+        $unknowns?: Uint8Array[];
     }
 
     class Tile implements ITile {
         constructor(properties?: vector_tile.ITile);
+        public $unknowns?: Uint8Array[];
         public layers: vector_tile.Tile.ILayer[];
         public static create(properties?: vector_tile.ITile): vector_tile.Tile;
         public static encode(message: vector_tile.ITile, writer?: $protobuf.Writer): $protobuf.Writer;
@@ -38,10 +40,12 @@ export namespace vector_tile {
             uintValue?: (number|Long|null);
             sintValue?: (number|Long|null);
             boolValue?: (boolean|null);
+            $unknowns?: Uint8Array[];
         }
 
         class Value implements IValue {
             constructor(properties?: vector_tile.Tile.IValue);
+            public $unknowns?: Uint8Array[];
             public stringValue: string;
             public floatValue: number;
             public doubleValue: number;
@@ -66,10 +70,12 @@ export namespace vector_tile {
             tags?: (number[]|null);
             type?: (vector_tile.Tile.GeomType|null);
             geometry?: (number[]|null);
+            $unknowns?: Uint8Array[];
         }
 
         class Feature implements IFeature {
             constructor(properties?: vector_tile.Tile.IFeature);
+            public $unknowns?: Uint8Array[];
             public id: (number|Long);
             public tags: number[];
             public type: vector_tile.Tile.GeomType;
@@ -93,10 +99,12 @@ export namespace vector_tile {
             keys?: (string[]|null);
             values?: (vector_tile.Tile.IValue[]|null);
             extent?: (number|null);
+            $unknowns?: Uint8Array[];
         }
 
         class Layer implements ILayer {
             constructor(properties?: vector_tile.Tile.ILayer);
+            public $unknowns?: Uint8Array[];
             public version: number;
             public name: string;
             public features: vector_tile.Tile.IFeature[];

--- a/tests/data/mapbox/vector_tile.js
+++ b/tests/data/mapbox/vector_tile.js
@@ -25,6 +25,7 @@ $root.vector_tile = (function() {
          * @memberof vector_tile
          * @interface ITile
          * @property {Array.<vector_tile.Tile.ILayer>|null} [layers] Tile layers
+         * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
          */
 
         /**
@@ -34,6 +35,7 @@ $root.vector_tile = (function() {
          * @implements ITile
          * @constructor
          * @param {vector_tile.ITile=} [properties] Properties to set
+         * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
          */
         function Tile(properties) {
             this.layers = [];
@@ -78,6 +80,9 @@ $root.vector_tile = (function() {
             if (message.layers != null && message.layers.length)
                 for (var i = 0; i < message.layers.length; ++i)
                     $root.vector_tile.Tile.Layer.encode(message.layers[i], writer.uint32(/* id 3, wireType 2 =*/26).fork()).ldelim();
+            if (message.$unknowns != null && Object.hasOwnProperty.call(message, "$unknowns"))
+                for (var i = 0; i < message.$unknowns.length; ++i)
+                    writer.raw(message.$unknowns[i]);
             return writer;
         };
 
@@ -114,6 +119,7 @@ $root.vector_tile = (function() {
                 throw Error("max depth exceeded");
             var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.vector_tile.Tile();
             while (reader.pos < end) {
+                var start = reader.pos;
                 var tag = reader.uint32();
                 if (tag === _end) {
                     _end = undefined;
@@ -128,6 +134,8 @@ $root.vector_tile = (function() {
                     }
                 default:
                     reader.skipType(tag & 7, _depth, tag >>> 3);
+                    $util.makeProp(message, "$unknowns", false);
+                    (message.$unknowns || (message.$unknowns = [])).push(reader.raw(start, reader.pos));
                     break;
                 }
             }
@@ -288,6 +296,7 @@ $root.vector_tile = (function() {
              * @property {number|Long|null} [uintValue] Value uintValue
              * @property {number|Long|null} [sintValue] Value sintValue
              * @property {boolean|null} [boolValue] Value boolValue
+             * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
              */
 
             /**
@@ -297,6 +306,7 @@ $root.vector_tile = (function() {
              * @implements IValue
              * @constructor
              * @param {vector_tile.Tile.IValue=} [properties] Properties to set
+             * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
              */
             function Value(properties) {
                 if (properties)
@@ -399,6 +409,9 @@ $root.vector_tile = (function() {
                     writer.uint32(/* id 6, wireType 0 =*/48).sint64(message.sintValue);
                 if (message.boolValue != null && Object.hasOwnProperty.call(message, "boolValue"))
                     writer.uint32(/* id 7, wireType 0 =*/56).bool(message.boolValue);
+                if (message.$unknowns != null && Object.hasOwnProperty.call(message, "$unknowns"))
+                    for (var i = 0; i < message.$unknowns.length; ++i)
+                        writer.raw(message.$unknowns[i]);
                 return writer;
             };
 
@@ -435,6 +448,7 @@ $root.vector_tile = (function() {
                     throw Error("max depth exceeded");
                 var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.vector_tile.Tile.Value();
                 while (reader.pos < end) {
+                    var start = reader.pos;
                     var tag = reader.uint32();
                     if (tag === _end) {
                         _end = undefined;
@@ -471,6 +485,8 @@ $root.vector_tile = (function() {
                         }
                     default:
                         reader.skipType(tag & 7, _depth, tag >>> 3);
+                        $util.makeProp(message, "$unknowns", false);
+                        (message.$unknowns || (message.$unknowns = [])).push(reader.raw(start, reader.pos));
                         break;
                     }
                 }
@@ -687,6 +703,7 @@ $root.vector_tile = (function() {
              * @property {Array.<number>|null} [tags] Feature tags
              * @property {vector_tile.Tile.GeomType|null} [type] Feature type
              * @property {Array.<number>|null} [geometry] Feature geometry
+             * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
              */
 
             /**
@@ -696,6 +713,7 @@ $root.vector_tile = (function() {
              * @implements IFeature
              * @constructor
              * @param {vector_tile.Tile.IFeature=} [properties] Properties to set
+             * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
              */
             function Feature(properties) {
                 this.tags = [];
@@ -778,6 +796,9 @@ $root.vector_tile = (function() {
                         writer.uint32(message.geometry[i]);
                     writer.ldelim();
                 }
+                if (message.$unknowns != null && Object.hasOwnProperty.call(message, "$unknowns"))
+                    for (var i = 0; i < message.$unknowns.length; ++i)
+                        writer.raw(message.$unknowns[i]);
                 return writer;
             };
 
@@ -814,6 +835,7 @@ $root.vector_tile = (function() {
                     throw Error("max depth exceeded");
                 var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.vector_tile.Tile.Feature();
                 while (reader.pos < end) {
+                    var start = reader.pos;
                     var tag = reader.uint32();
                     if (tag === _end) {
                         _end = undefined;
@@ -854,6 +876,8 @@ $root.vector_tile = (function() {
                         }
                     default:
                         reader.skipType(tag & 7, _depth, tag >>> 3);
+                        $util.makeProp(message, "$unknowns", false);
+                        (message.$unknowns || (message.$unknowns = [])).push(reader.raw(start, reader.pos));
                         break;
                     }
                 }
@@ -1075,6 +1099,7 @@ $root.vector_tile = (function() {
              * @property {Array.<string>|null} [keys] Layer keys
              * @property {Array.<vector_tile.Tile.IValue>|null} [values] Layer values
              * @property {number|null} [extent] Layer extent
+             * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
              */
 
             /**
@@ -1084,6 +1109,7 @@ $root.vector_tile = (function() {
              * @implements ILayer
              * @constructor
              * @param {vector_tile.Tile.ILayer=} [properties] Properties to set
+             * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
              */
             function Layer(properties) {
                 this.features = [];
@@ -1180,6 +1206,9 @@ $root.vector_tile = (function() {
                 if (message.extent != null && Object.hasOwnProperty.call(message, "extent"))
                     writer.uint32(/* id 5, wireType 0 =*/40).uint32(message.extent);
                 writer.uint32(/* id 15, wireType 0 =*/120).uint32(message.version);
+                if (message.$unknowns != null && Object.hasOwnProperty.call(message, "$unknowns"))
+                    for (var i = 0; i < message.$unknowns.length; ++i)
+                        writer.raw(message.$unknowns[i]);
                 return writer;
             };
 
@@ -1216,6 +1245,7 @@ $root.vector_tile = (function() {
                     throw Error("max depth exceeded");
                 var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.vector_tile.Tile.Layer();
                 while (reader.pos < end) {
+                    var start = reader.pos;
                     var tag = reader.uint32();
                     if (tag === _end) {
                         _end = undefined;
@@ -1254,6 +1284,8 @@ $root.vector_tile = (function() {
                         }
                     default:
                         reader.skipType(tag & 7, _depth, tag >>> 3);
+                        $util.makeProp(message, "$unknowns", false);
+                        (message.$unknowns || (message.$unknowns = [])).push(reader.raw(start, reader.pos));
                         break;
                     }
                 }

--- a/tests/data/package.d.ts
+++ b/tests/data/package.d.ts
@@ -18,10 +18,12 @@ export interface IPackage {
     devDependencies?: ({ [k: string]: string }|null);
     types?: (string|null);
     cliDependencies?: (string[]|null);
+    $unknowns?: Uint8Array[];
 }
 
 export class Package implements IPackage {
     constructor(properties?: IPackage);
+    public $unknowns?: Uint8Array[];
     public name: string;
     public version: string;
     public versionScheme: string;
@@ -56,10 +58,12 @@ export namespace Package {
     interface IRepository {
         type?: (string|null);
         url?: (string|null);
+        $unknowns?: Uint8Array[];
     }
 
     class Repository implements IRepository {
         constructor(properties?: Package.IRepository);
+        public $unknowns?: Uint8Array[];
         public type: string;
         public url: string;
         public static create(properties?: Package.IRepository): Package.Repository;

--- a/tests/data/package.js
+++ b/tests/data/package.js
@@ -32,6 +32,7 @@ $root.Package = (function() {
      * @property {Object.<string,string>|null} [devDependencies] Package devDependencies
      * @property {string|null} [types] Package types
      * @property {Array.<string>|null} [cliDependencies] Package cliDependencies
+     * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
      */
 
     /**
@@ -41,6 +42,7 @@ $root.Package = (function() {
      * @implements IPackage
      * @constructor
      * @param {IPackage=} [properties] Properties to set
+     * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
      */
     function Package(properties) {
         this.keywords = [];
@@ -255,6 +257,9 @@ $root.Package = (function() {
                 writer.uint32(/* id 18, wireType 2 =*/146).string(message.cliDependencies[i]);
         if (message.versionScheme != null && Object.hasOwnProperty.call(message, "versionScheme"))
             writer.uint32(/* id 19, wireType 2 =*/154).string(message.versionScheme);
+        if (message.$unknowns != null && Object.hasOwnProperty.call(message, "$unknowns"))
+            for (var i = 0; i < message.$unknowns.length; ++i)
+                writer.raw(message.$unknowns[i]);
         return writer;
     };
 
@@ -291,6 +296,7 @@ $root.Package = (function() {
             throw Error("max depth exceeded");
         var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.Package(), key, value;
         while (reader.pos < end) {
+            var start = reader.pos;
             var tag = reader.uint32();
             if (tag === _end) {
                 _end = undefined;
@@ -455,6 +461,8 @@ $root.Package = (function() {
                 }
             default:
                 reader.skipType(tag & 7, _depth, tag >>> 3);
+                $util.makeProp(message, "$unknowns", false);
+                (message.$unknowns || (message.$unknowns = [])).push(reader.raw(start, reader.pos));
                 break;
             }
         }
@@ -814,6 +822,7 @@ $root.Package = (function() {
          * @interface IRepository
          * @property {string|null} [type] Repository type
          * @property {string|null} [url] Repository url
+         * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
          */
 
         /**
@@ -823,6 +832,7 @@ $root.Package = (function() {
          * @implements IRepository
          * @constructor
          * @param {Package.IRepository=} [properties] Properties to set
+         * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
          */
         function Repository(properties) {
             if (properties)
@@ -875,6 +885,9 @@ $root.Package = (function() {
                 writer.uint32(/* id 1, wireType 2 =*/10).string(message.type);
             if (message.url != null && Object.hasOwnProperty.call(message, "url"))
                 writer.uint32(/* id 2, wireType 2 =*/18).string(message.url);
+            if (message.$unknowns != null && Object.hasOwnProperty.call(message, "$unknowns"))
+                for (var i = 0; i < message.$unknowns.length; ++i)
+                    writer.raw(message.$unknowns[i]);
             return writer;
         };
 
@@ -911,6 +924,7 @@ $root.Package = (function() {
                 throw Error("max depth exceeded");
             var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.Package.Repository();
             while (reader.pos < end) {
+                var start = reader.pos;
                 var tag = reader.uint32();
                 if (tag === _end) {
                     _end = undefined;
@@ -927,6 +941,8 @@ $root.Package = (function() {
                     }
                 default:
                     reader.skipType(tag & 7, _depth, tag >>> 3);
+                    $util.makeProp(message, "$unknowns", false);
+                    (message.$unknowns || (message.$unknowns = [])).push(reader.raw(start, reader.pos));
                     break;
                 }
             }

--- a/tests/data/rpc-es6.d.ts
+++ b/tests/data/rpc-es6.d.ts
@@ -14,10 +14,12 @@ export namespace MyService {
 
 export interface IMyRequest {
     path?: (string|null);
+    $unknowns?: Uint8Array[];
 }
 
 export class MyRequest implements IMyRequest {
     constructor(properties?: IMyRequest);
+    public $unknowns?: Uint8Array[];
     public path: string;
     public static create(properties?: IMyRequest): MyRequest;
     public static encode(message: IMyRequest, writer?: $protobuf.Writer): $protobuf.Writer;
@@ -33,10 +35,12 @@ export class MyRequest implements IMyRequest {
 
 export interface IMyResponse {
     status?: (number|null);
+    $unknowns?: Uint8Array[];
 }
 
 export class MyResponse implements IMyResponse {
     constructor(properties?: IMyResponse);
+    public $unknowns?: Uint8Array[];
     public status: number;
     public static create(properties?: IMyResponse): MyResponse;
     public static encode(message: IMyResponse, writer?: $protobuf.Writer): $protobuf.Writer;

--- a/tests/data/rpc-es6.js
+++ b/tests/data/rpc-es6.js
@@ -82,6 +82,7 @@ export const MyRequest = $root.MyRequest = (() => {
      * @exports IMyRequest
      * @interface IMyRequest
      * @property {string|null} [path] MyRequest path
+     * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
      */
 
     /**
@@ -91,6 +92,7 @@ export const MyRequest = $root.MyRequest = (() => {
      * @implements IMyRequest
      * @constructor
      * @param {IMyRequest=} [properties] Properties to set
+     * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
      */
     function MyRequest(properties) {
         if (properties)
@@ -133,6 +135,9 @@ export const MyRequest = $root.MyRequest = (() => {
             writer = $Writer.create();
         if (message.path != null && Object.hasOwnProperty.call(message, "path"))
             writer.uint32(/* id 1, wireType 2 =*/10).string(message.path);
+        if (message.$unknowns != null && Object.hasOwnProperty.call(message, "$unknowns"))
+            for (let i = 0; i < message.$unknowns.length; ++i)
+                writer.raw(message.$unknowns[i]);
         return writer;
     };
 
@@ -169,6 +174,7 @@ export const MyRequest = $root.MyRequest = (() => {
             throw Error("max depth exceeded");
         let end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.MyRequest();
         while (reader.pos < end) {
+            let start = reader.pos;
             let tag = reader.uint32();
             if (tag === _end) {
                 _end = undefined;
@@ -181,6 +187,8 @@ export const MyRequest = $root.MyRequest = (() => {
                 }
             default:
                 reader.skipType(tag & 7, _depth, tag >>> 3);
+                $util.makeProp(message, "$unknowns", false);
+                (message.$unknowns || (message.$unknowns = [])).push(reader.raw(start, reader.pos));
                 break;
             }
         }
@@ -303,6 +311,7 @@ export const MyResponse = $root.MyResponse = (() => {
      * @exports IMyResponse
      * @interface IMyResponse
      * @property {number|null} [status] MyResponse status
+     * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
      */
 
     /**
@@ -312,6 +321,7 @@ export const MyResponse = $root.MyResponse = (() => {
      * @implements IMyResponse
      * @constructor
      * @param {IMyResponse=} [properties] Properties to set
+     * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
      */
     function MyResponse(properties) {
         if (properties)
@@ -354,6 +364,9 @@ export const MyResponse = $root.MyResponse = (() => {
             writer = $Writer.create();
         if (message.status != null && Object.hasOwnProperty.call(message, "status"))
             writer.uint32(/* id 2, wireType 0 =*/16).int32(message.status);
+        if (message.$unknowns != null && Object.hasOwnProperty.call(message, "$unknowns"))
+            for (let i = 0; i < message.$unknowns.length; ++i)
+                writer.raw(message.$unknowns[i]);
         return writer;
     };
 
@@ -390,6 +403,7 @@ export const MyResponse = $root.MyResponse = (() => {
             throw Error("max depth exceeded");
         let end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.MyResponse();
         while (reader.pos < end) {
+            let start = reader.pos;
             let tag = reader.uint32();
             if (tag === _end) {
                 _end = undefined;
@@ -402,6 +416,8 @@ export const MyResponse = $root.MyResponse = (() => {
                 }
             default:
                 reader.skipType(tag & 7, _depth, tag >>> 3);
+                $util.makeProp(message, "$unknowns", false);
+                (message.$unknowns || (message.$unknowns = [])).push(reader.raw(start, reader.pos));
                 break;
             }
         }

--- a/tests/data/rpc-reserved.d.ts
+++ b/tests/data/rpc-reserved.d.ts
@@ -14,10 +14,12 @@ export namespace MyService {
 
 export interface IMyRequest {
     path?: (string|null);
+    $unknowns?: Uint8Array[];
 }
 
 export class MyRequest implements IMyRequest {
     constructor(properties?: IMyRequest);
+    public $unknowns?: Uint8Array[];
     public path: string;
     public static create(properties?: IMyRequest): MyRequest;
     public static encode(message: IMyRequest, writer?: $protobuf.Writer): $protobuf.Writer;
@@ -33,10 +35,12 @@ export class MyRequest implements IMyRequest {
 
 export interface IMyResponse {
     status?: (number|null);
+    $unknowns?: Uint8Array[];
 }
 
 export class MyResponse implements IMyResponse {
     constructor(properties?: IMyResponse);
+    public $unknowns?: Uint8Array[];
     public status: number;
     public static create(properties?: IMyResponse): MyResponse;
     public static encode(message: IMyResponse, writer?: $protobuf.Writer): $protobuf.Writer;

--- a/tests/data/rpc-reserved.js
+++ b/tests/data/rpc-reserved.js
@@ -84,6 +84,7 @@ $root.MyRequest = (function() {
      * @exports IMyRequest
      * @interface IMyRequest
      * @property {string|null} [path] MyRequest path
+     * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
      */
 
     /**
@@ -93,6 +94,7 @@ $root.MyRequest = (function() {
      * @implements IMyRequest
      * @constructor
      * @param {IMyRequest=} [properties] Properties to set
+     * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
      */
     function MyRequest(properties) {
         if (properties)
@@ -135,6 +137,9 @@ $root.MyRequest = (function() {
             writer = $Writer.create();
         if (message.path != null && Object.hasOwnProperty.call(message, "path"))
             writer.uint32(/* id 1, wireType 2 =*/10).string(message.path);
+        if (message.$unknowns != null && Object.hasOwnProperty.call(message, "$unknowns"))
+            for (var i = 0; i < message.$unknowns.length; ++i)
+                writer.raw(message.$unknowns[i]);
         return writer;
     };
 
@@ -171,6 +176,7 @@ $root.MyRequest = (function() {
             throw Error("max depth exceeded");
         var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.MyRequest();
         while (reader.pos < end) {
+            var start = reader.pos;
             var tag = reader.uint32();
             if (tag === _end) {
                 _end = undefined;
@@ -183,6 +189,8 @@ $root.MyRequest = (function() {
                 }
             default:
                 reader.skipType(tag & 7, _depth, tag >>> 3);
+                $util.makeProp(message, "$unknowns", false);
+                (message.$unknowns || (message.$unknowns = [])).push(reader.raw(start, reader.pos));
                 break;
             }
         }
@@ -305,6 +313,7 @@ $root.MyResponse = (function() {
      * @exports IMyResponse
      * @interface IMyResponse
      * @property {number|null} [status] MyResponse status
+     * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
      */
 
     /**
@@ -314,6 +323,7 @@ $root.MyResponse = (function() {
      * @implements IMyResponse
      * @constructor
      * @param {IMyResponse=} [properties] Properties to set
+     * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
      */
     function MyResponse(properties) {
         if (properties)
@@ -356,6 +366,9 @@ $root.MyResponse = (function() {
             writer = $Writer.create();
         if (message.status != null && Object.hasOwnProperty.call(message, "status"))
             writer.uint32(/* id 2, wireType 0 =*/16).int32(message.status);
+        if (message.$unknowns != null && Object.hasOwnProperty.call(message, "$unknowns"))
+            for (var i = 0; i < message.$unknowns.length; ++i)
+                writer.raw(message.$unknowns[i]);
         return writer;
     };
 
@@ -392,6 +405,7 @@ $root.MyResponse = (function() {
             throw Error("max depth exceeded");
         var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.MyResponse();
         while (reader.pos < end) {
+            var start = reader.pos;
             var tag = reader.uint32();
             if (tag === _end) {
                 _end = undefined;
@@ -404,6 +418,8 @@ $root.MyResponse = (function() {
                 }
             default:
                 reader.skipType(tag & 7, _depth, tag >>> 3);
+                $util.makeProp(message, "$unknowns", false);
+                (message.$unknowns || (message.$unknowns = [])).push(reader.raw(start, reader.pos));
                 break;
             }
         }

--- a/tests/data/rpc.d.ts
+++ b/tests/data/rpc.d.ts
@@ -14,10 +14,12 @@ export namespace MyService {
 
 export interface IMyRequest {
     path?: (string|null);
+    $unknowns?: Uint8Array[];
 }
 
 export class MyRequest implements IMyRequest {
     constructor(properties?: IMyRequest);
+    public $unknowns?: Uint8Array[];
     public path: string;
     public static create(properties?: IMyRequest): MyRequest;
     public static encode(message: IMyRequest, writer?: $protobuf.Writer): $protobuf.Writer;
@@ -33,10 +35,12 @@ export class MyRequest implements IMyRequest {
 
 export interface IMyResponse {
     status?: (number|null);
+    $unknowns?: Uint8Array[];
 }
 
 export class MyResponse implements IMyResponse {
     constructor(properties?: IMyResponse);
+    public $unknowns?: Uint8Array[];
     public status: number;
     public static create(properties?: IMyResponse): MyResponse;
     public static encode(message: IMyResponse, writer?: $protobuf.Writer): $protobuf.Writer;

--- a/tests/data/rpc.js
+++ b/tests/data/rpc.js
@@ -84,6 +84,7 @@ $root.MyRequest = (function() {
      * @exports IMyRequest
      * @interface IMyRequest
      * @property {string|null} [path] MyRequest path
+     * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
      */
 
     /**
@@ -93,6 +94,7 @@ $root.MyRequest = (function() {
      * @implements IMyRequest
      * @constructor
      * @param {IMyRequest=} [properties] Properties to set
+     * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
      */
     function MyRequest(properties) {
         if (properties)
@@ -135,6 +137,9 @@ $root.MyRequest = (function() {
             writer = $Writer.create();
         if (message.path != null && Object.hasOwnProperty.call(message, "path"))
             writer.uint32(/* id 1, wireType 2 =*/10).string(message.path);
+        if (message.$unknowns != null && Object.hasOwnProperty.call(message, "$unknowns"))
+            for (var i = 0; i < message.$unknowns.length; ++i)
+                writer.raw(message.$unknowns[i]);
         return writer;
     };
 
@@ -171,6 +176,7 @@ $root.MyRequest = (function() {
             throw Error("max depth exceeded");
         var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.MyRequest();
         while (reader.pos < end) {
+            var start = reader.pos;
             var tag = reader.uint32();
             if (tag === _end) {
                 _end = undefined;
@@ -183,6 +189,8 @@ $root.MyRequest = (function() {
                 }
             default:
                 reader.skipType(tag & 7, _depth, tag >>> 3);
+                $util.makeProp(message, "$unknowns", false);
+                (message.$unknowns || (message.$unknowns = [])).push(reader.raw(start, reader.pos));
                 break;
             }
         }
@@ -305,6 +313,7 @@ $root.MyResponse = (function() {
      * @exports IMyResponse
      * @interface IMyResponse
      * @property {number|null} [status] MyResponse status
+     * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
      */
 
     /**
@@ -314,6 +323,7 @@ $root.MyResponse = (function() {
      * @implements IMyResponse
      * @constructor
      * @param {IMyResponse=} [properties] Properties to set
+     * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
      */
     function MyResponse(properties) {
         if (properties)
@@ -356,6 +366,9 @@ $root.MyResponse = (function() {
             writer = $Writer.create();
         if (message.status != null && Object.hasOwnProperty.call(message, "status"))
             writer.uint32(/* id 2, wireType 0 =*/16).int32(message.status);
+        if (message.$unknowns != null && Object.hasOwnProperty.call(message, "$unknowns"))
+            for (var i = 0; i < message.$unknowns.length; ++i)
+                writer.raw(message.$unknowns[i]);
         return writer;
     };
 
@@ -392,6 +405,7 @@ $root.MyResponse = (function() {
             throw Error("max depth exceeded");
         var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.MyResponse();
         while (reader.pos < end) {
+            var start = reader.pos;
             var tag = reader.uint32();
             if (tag === _end) {
                 _end = undefined;
@@ -404,6 +418,8 @@ $root.MyResponse = (function() {
                 }
             default:
                 reader.skipType(tag & 7, _depth, tag >>> 3);
+                $util.makeProp(message, "$unknowns", false);
+                (message.$unknowns || (message.$unknowns = [])).push(reader.raw(start, reader.pos));
                 break;
             }
         }

--- a/tests/data/test.d.ts
+++ b/tests/data/test.d.ts
@@ -5,10 +5,12 @@ export namespace jspb {
     namespace test {
 
         interface IEmpty {
+            $unknowns?: Uint8Array[];
         }
 
         class Empty implements IEmpty {
             constructor(properties?: jspb.test.IEmpty);
+            public $unknowns?: Uint8Array[];
             public static create(properties?: jspb.test.IEmpty): jspb.test.Empty;
             public static encode(message: jspb.test.IEmpty, writer?: $protobuf.Writer): $protobuf.Writer;
             public static encodeDelimited(message: jspb.test.IEmpty, writer?: $protobuf.Writer): $protobuf.Writer;
@@ -28,10 +30,12 @@ export namespace jspb {
 
         interface IEnumContainer {
             outerEnum?: (jspb.test.OuterEnum|null);
+            $unknowns?: Uint8Array[];
         }
 
         class EnumContainer implements IEnumContainer {
             constructor(properties?: jspb.test.IEnumContainer);
+            public $unknowns?: Uint8Array[];
             public outerEnum: jspb.test.OuterEnum;
             public static create(properties?: jspb.test.IEnumContainer): jspb.test.EnumContainer;
             public static encode(message: jspb.test.IEnumContainer, writer?: $protobuf.Writer): $protobuf.Writer;
@@ -49,10 +53,12 @@ export namespace jspb {
             aString: string;
             aRepeatedString?: (string[]|null);
             aBoolean?: (boolean|null);
+            $unknowns?: Uint8Array[];
         }
 
         class Simple1 implements ISimple1 {
             constructor(properties?: jspb.test.ISimple1);
+            public $unknowns?: Uint8Array[];
             public aString: string;
             public aRepeatedString: string[];
             public aBoolean: boolean;
@@ -71,10 +77,12 @@ export namespace jspb {
         interface ISimple2 {
             aString: string;
             aRepeatedString?: (string[]|null);
+            $unknowns?: Uint8Array[];
         }
 
         class Simple2 implements ISimple2 {
             constructor(properties?: jspb.test.ISimple2);
+            public $unknowns?: Uint8Array[];
             public aString: string;
             public aRepeatedString: string[];
             public static create(properties?: jspb.test.ISimple2): jspb.test.Simple2;
@@ -94,10 +102,12 @@ export namespace jspb {
             "default": string;
             "function": string;
             "var": string;
+            $unknowns?: Uint8Array[];
         }
 
         class SpecialCases implements ISpecialCases {
             constructor(properties?: jspb.test.ISpecialCases);
+            public $unknowns?: Uint8Array[];
             public normal: string;
             public default: string;
             public function: string;
@@ -120,10 +130,12 @@ export namespace jspb {
             aNestedMessage?: (jspb.test.OptionalFields.INested|null);
             aRepeatedMessage?: (jspb.test.OptionalFields.INested[]|null);
             aRepeatedString?: (string[]|null);
+            $unknowns?: Uint8Array[];
         }
 
         class OptionalFields implements IOptionalFields {
             constructor(properties?: jspb.test.IOptionalFields);
+            public $unknowns?: Uint8Array[];
             public aString: string;
             public aBool: boolean;
             public aNestedMessage?: (jspb.test.OptionalFields.INested|null);
@@ -145,10 +157,12 @@ export namespace jspb {
 
             interface INested {
                 anInt?: (number|null);
+                $unknowns?: Uint8Array[];
             }
 
             class Nested implements INested {
                 constructor(properties?: jspb.test.OptionalFields.INested);
+                public $unknowns?: Uint8Array[];
                 public anInt: number;
                 public static create(properties?: jspb.test.OptionalFields.INested): jspb.test.OptionalFields.Nested;
                 public static encode(message: jspb.test.OptionalFields.INested, writer?: $protobuf.Writer): $protobuf.Writer;
@@ -173,6 +187,7 @@ export namespace jspb {
             ".jspb.test.IndirectExtension.repeatedStr"?: (string[]|null);
             ".jspb.test.IndirectExtension.repeatedSimple"?: (jspb.test.ISimple1[]|null);
             ".jspb.test.simple1"?: (jspb.test.ISimple1|null);
+            $unknowns?: Uint8Array[];
         }
 
         class HasExtensions implements IHasExtensions {
@@ -183,6 +198,7 @@ export namespace jspb {
             public ".jspb.test.IndirectExtension.repeatedStr": string[];
             public ".jspb.test.IndirectExtension.repeatedSimple": jspb.test.ISimple1[];
             public ".jspb.test.simple1"?: (jspb.test.ISimple1|null);
+            public $unknowns?: Uint8Array[];
             public str1: string;
             public str2: string;
             public str3: string;
@@ -204,10 +220,12 @@ export namespace jspb {
             aNestedMessage?: (jspb.test.Complex.INested|null);
             aRepeatedMessage?: (jspb.test.Complex.INested[]|null);
             aRepeatedString?: (string[]|null);
+            $unknowns?: Uint8Array[];
         }
 
         class Complex implements IComplex {
             constructor(properties?: jspb.test.IComplex);
+            public $unknowns?: Uint8Array[];
             public aString: string;
             public anOutOfOrderBool: boolean;
             public aNestedMessage?: (jspb.test.Complex.INested|null);
@@ -229,10 +247,12 @@ export namespace jspb {
 
             interface INested {
                 anInt: number;
+                $unknowns?: Uint8Array[];
             }
 
             class Nested implements INested {
                 constructor(properties?: jspb.test.Complex.INested);
+                public $unknowns?: Uint8Array[];
                 public anInt: number;
                 public static create(properties?: jspb.test.Complex.INested): jspb.test.Complex.Nested;
                 public static encode(message: jspb.test.Complex.INested, writer?: $protobuf.Writer): $protobuf.Writer;
@@ -248,10 +268,12 @@ export namespace jspb {
         }
 
         interface IOuterMessage {
+            $unknowns?: Uint8Array[];
         }
 
         class OuterMessage implements IOuterMessage {
             constructor(properties?: jspb.test.IOuterMessage);
+            public $unknowns?: Uint8Array[];
             public static create(properties?: jspb.test.IOuterMessage): jspb.test.OuterMessage;
             public static encode(message: jspb.test.IOuterMessage, writer?: $protobuf.Writer): $protobuf.Writer;
             public static encodeDelimited(message: jspb.test.IOuterMessage, writer?: $protobuf.Writer): $protobuf.Writer;
@@ -268,10 +290,12 @@ export namespace jspb {
 
             interface IComplex {
                 innerComplexField?: (number|null);
+                $unknowns?: Uint8Array[];
             }
 
             class Complex implements IComplex {
                 constructor(properties?: jspb.test.OuterMessage.IComplex);
+                public $unknowns?: Uint8Array[];
                 public innerComplexField: number;
                 public static create(properties?: jspb.test.OuterMessage.IComplex): jspb.test.OuterMessage.Complex;
                 public static encode(message: jspb.test.OuterMessage.IComplex, writer?: $protobuf.Writer): $protobuf.Writer;
@@ -288,10 +312,12 @@ export namespace jspb {
 
         interface IIsExtension {
             ext1?: (string|null);
+            $unknowns?: Uint8Array[];
         }
 
         class IsExtension implements IIsExtension {
             constructor(properties?: jspb.test.IIsExtension);
+            public $unknowns?: Uint8Array[];
             public ext1: string;
             public static create(properties?: jspb.test.IIsExtension): jspb.test.IsExtension;
             public static encode(message: jspb.test.IIsExtension, writer?: $protobuf.Writer): $protobuf.Writer;
@@ -306,10 +332,12 @@ export namespace jspb {
         }
 
         interface IIndirectExtension {
+            $unknowns?: Uint8Array[];
         }
 
         class IndirectExtension implements IIndirectExtension {
             constructor(properties?: jspb.test.IIndirectExtension);
+            public $unknowns?: Uint8Array[];
             public static create(properties?: jspb.test.IIndirectExtension): jspb.test.IndirectExtension;
             public static encode(message: jspb.test.IIndirectExtension, writer?: $protobuf.Writer): $protobuf.Writer;
             public static encodeDelimited(message: jspb.test.IIndirectExtension, writer?: $protobuf.Writer): $protobuf.Writer;
@@ -329,10 +357,12 @@ export namespace jspb {
             enumField?: (jspb.test.DefaultValues.Enum|null);
             emptyField?: (string|null);
             bytesField?: (Uint8Array|null);
+            $unknowns?: Uint8Array[];
         }
 
         class DefaultValues implements IDefaultValues {
             constructor(properties?: jspb.test.IDefaultValues);
+            public $unknowns?: Uint8Array[];
             public stringField: string;
             public boolField: boolean;
             public intField: (number|Long);
@@ -368,10 +398,12 @@ export namespace jspb {
             requiredDoubleField: number;
             repeatedDoubleField?: (number[]|null);
             defaultDoubleField?: (number|null);
+            $unknowns?: Uint8Array[];
         }
 
         class FloatingPointFields implements IFloatingPointFields {
             constructor(properties?: jspb.test.IFloatingPointFields);
+            public $unknowns?: Uint8Array[];
             public optionalFloatField: number;
             public requiredFloatField: number;
             public repeatedFloatField: number[];
@@ -399,11 +431,13 @@ export namespace jspb {
             bytesField?: (Uint8Array|null);
             unused?: (string|null);
             ".jspb.test.CloneExtension.extField"?: (jspb.test.ICloneExtension|null);
+            $unknowns?: Uint8Array[];
         }
 
         class TestClone implements ITestClone {
             constructor(properties?: jspb.test.ITestClone);
             public ".jspb.test.CloneExtension.extField"?: (jspb.test.ICloneExtension|null);
+            public $unknowns?: Uint8Array[];
             public str: string;
             public simple1?: (jspb.test.ISimple1|null);
             public simple2: jspb.test.ISimple1[];
@@ -423,10 +457,12 @@ export namespace jspb {
 
         interface ICloneExtension {
             ext?: (string|null);
+            $unknowns?: Uint8Array[];
         }
 
         class CloneExtension implements ICloneExtension {
             constructor(properties?: jspb.test.ICloneExtension);
+            public $unknowns?: Uint8Array[];
             public ext: string;
             public static create(properties?: jspb.test.ICloneExtension): jspb.test.CloneExtension;
             public static encode(message: jspb.test.ICloneExtension, writer?: $protobuf.Writer): $protobuf.Writer;
@@ -449,10 +485,12 @@ export namespace jspb {
             id?: (string|null);
             requiredSimple: jspb.test.ISimple2;
             optionalSimple?: (jspb.test.ISimple2|null);
+            $unknowns?: Uint8Array[];
         }
 
         class TestGroup implements ITestGroup {
             constructor(properties?: jspb.test.ITestGroup);
+            public $unknowns?: Uint8Array[];
             public repeatedGroup: jspb.test.TestGroup.IRepeatedGroup[];
             public requiredGroup: jspb.test.TestGroup.IRequiredGroup;
             public optionalGroup?: (jspb.test.TestGroup.IOptionalGroup|null);
@@ -478,10 +516,12 @@ export namespace jspb {
             interface IRepeatedGroup {
                 id: string;
                 someBool?: (boolean[]|null);
+                $unknowns?: Uint8Array[];
             }
 
             class RepeatedGroup implements IRepeatedGroup {
                 constructor(properties?: jspb.test.TestGroup.IRepeatedGroup);
+                public $unknowns?: Uint8Array[];
                 public id: string;
                 public someBool: boolean[];
                 public static create(properties?: jspb.test.TestGroup.IRepeatedGroup): jspb.test.TestGroup.RepeatedGroup;
@@ -498,10 +538,12 @@ export namespace jspb {
 
             interface IRequiredGroup {
                 id: string;
+                $unknowns?: Uint8Array[];
             }
 
             class RequiredGroup implements IRequiredGroup {
                 constructor(properties?: jspb.test.TestGroup.IRequiredGroup);
+                public $unknowns?: Uint8Array[];
                 public id: string;
                 public static create(properties?: jspb.test.TestGroup.IRequiredGroup): jspb.test.TestGroup.RequiredGroup;
                 public static encode(message: jspb.test.TestGroup.IRequiredGroup, writer?: $protobuf.Writer): $protobuf.Writer;
@@ -517,10 +559,12 @@ export namespace jspb {
 
             interface IOptionalGroup {
                 id: string;
+                $unknowns?: Uint8Array[];
             }
 
             class OptionalGroup implements IOptionalGroup {
                 constructor(properties?: jspb.test.TestGroup.IOptionalGroup);
+                public $unknowns?: Uint8Array[];
                 public id: string;
                 public static create(properties?: jspb.test.TestGroup.IOptionalGroup): jspb.test.TestGroup.OptionalGroup;
                 public static encode(message: jspb.test.TestGroup.IOptionalGroup, writer?: $protobuf.Writer): $protobuf.Writer;
@@ -536,10 +580,12 @@ export namespace jspb {
 
             interface IMessageInGroup {
                 id: jspb.test.TestGroup.MessageInGroup.INestedMessage;
+                $unknowns?: Uint8Array[];
             }
 
             class MessageInGroup implements IMessageInGroup {
                 constructor(properties?: jspb.test.TestGroup.IMessageInGroup);
+                public $unknowns?: Uint8Array[];
                 public id: jspb.test.TestGroup.MessageInGroup.INestedMessage;
                 public static create(properties?: jspb.test.TestGroup.IMessageInGroup): jspb.test.TestGroup.MessageInGroup;
                 public static encode(message: jspb.test.TestGroup.IMessageInGroup, writer?: $protobuf.Writer): $protobuf.Writer;
@@ -557,10 +603,12 @@ export namespace jspb {
 
                 interface INestedMessage {
                     id?: (string|null);
+                    $unknowns?: Uint8Array[];
                 }
 
                 class NestedMessage implements INestedMessage {
                     constructor(properties?: jspb.test.TestGroup.MessageInGroup.INestedMessage);
+                    public $unknowns?: Uint8Array[];
                     public id: string;
                     public static create(properties?: jspb.test.TestGroup.MessageInGroup.INestedMessage): jspb.test.TestGroup.MessageInGroup.NestedMessage;
                     public static encode(message: jspb.test.TestGroup.MessageInGroup.INestedMessage, writer?: $protobuf.Writer): $protobuf.Writer;
@@ -577,10 +625,12 @@ export namespace jspb {
 
             interface IEnumInGroup {
                 id: jspb.test.TestGroup.EnumInGroup.NestedEnum;
+                $unknowns?: Uint8Array[];
             }
 
             class EnumInGroup implements IEnumInGroup {
                 constructor(properties?: jspb.test.TestGroup.IEnumInGroup);
+                public $unknowns?: Uint8Array[];
                 public id: jspb.test.TestGroup.EnumInGroup.NestedEnum;
                 public static create(properties?: jspb.test.TestGroup.IEnumInGroup): jspb.test.TestGroup.EnumInGroup;
                 public static encode(message: jspb.test.TestGroup.IEnumInGroup, writer?: $protobuf.Writer): $protobuf.Writer;
@@ -605,10 +655,12 @@ export namespace jspb {
 
         interface ITestGroup1 {
             group?: (jspb.test.TestGroup.IRepeatedGroup|null);
+            $unknowns?: Uint8Array[];
         }
 
         class TestGroup1 implements ITestGroup1 {
             constructor(properties?: jspb.test.ITestGroup1);
+            public $unknowns?: Uint8Array[];
             public group?: (jspb.test.TestGroup.IRepeatedGroup|null);
             public static create(properties?: jspb.test.ITestGroup1): jspb.test.TestGroup1;
             public static encode(message: jspb.test.ITestGroup1, writer?: $protobuf.Writer): $protobuf.Writer;
@@ -625,11 +677,13 @@ export namespace jspb {
         interface ITestReservedNames {
             extension?: (number|null);
             ".jspb.test.TestReservedNamesExtension.foo"?: (number|null);
+            $unknowns?: Uint8Array[];
         }
 
         class TestReservedNames implements ITestReservedNames {
             constructor(properties?: jspb.test.ITestReservedNames);
             public ".jspb.test.TestReservedNamesExtension.foo": number;
+            public $unknowns?: Uint8Array[];
             public extension: number;
             public static create(properties?: jspb.test.ITestReservedNames): jspb.test.TestReservedNames;
             public static encode(message: jspb.test.ITestReservedNames, writer?: $protobuf.Writer): $protobuf.Writer;
@@ -644,10 +698,12 @@ export namespace jspb {
         }
 
         interface ITestReservedNamesExtension {
+            $unknowns?: Uint8Array[];
         }
 
         class TestReservedNamesExtension implements ITestReservedNamesExtension {
             constructor(properties?: jspb.test.ITestReservedNamesExtension);
+            public $unknowns?: Uint8Array[];
             public static create(properties?: jspb.test.ITestReservedNamesExtension): jspb.test.TestReservedNamesExtension;
             public static encode(message: jspb.test.ITestReservedNamesExtension, writer?: $protobuf.Writer): $protobuf.Writer;
             public static encodeDelimited(message: jspb.test.ITestReservedNamesExtension, writer?: $protobuf.Writer): $protobuf.Writer;
@@ -671,10 +727,12 @@ export namespace jspb {
             atwo?: (number|null);
             bone?: (number|null);
             btwo?: (number|null);
+            $unknowns?: Uint8Array[];
         }
 
         class TestMessageWithOneof implements ITestMessageWithOneof {
             constructor(properties?: jspb.test.ITestMessageWithOneof);
+            public $unknowns?: Uint8Array[];
             public pone?: (string|null);
             public pthree?: (string|null);
             public rone?: (jspb.test.ITestMessageWithOneof|null);
@@ -704,10 +762,12 @@ export namespace jspb {
         interface ITestEndsWithBytes {
             value?: (number|null);
             data?: (Uint8Array|null);
+            $unknowns?: Uint8Array[];
         }
 
         class TestEndsWithBytes implements ITestEndsWithBytes {
             constructor(properties?: jspb.test.ITestEndsWithBytes);
+            public $unknowns?: Uint8Array[];
             public value: number;
             public data: Uint8Array;
             public static create(properties?: jspb.test.ITestEndsWithBytes): jspb.test.TestEndsWithBytes;
@@ -735,10 +795,12 @@ export namespace jspb {
             mapBoolString?: ({ [k: string]: string }|null);
             testMapFields?: (jspb.test.ITestMapFieldsNoBinary|null);
             mapStringTestmapfields?: ({ [k: string]: jspb.test.ITestMapFieldsNoBinary }|null);
+            $unknowns?: Uint8Array[];
         }
 
         class TestMapFieldsNoBinary implements ITestMapFieldsNoBinary {
             constructor(properties?: jspb.test.ITestMapFieldsNoBinary);
+            public $unknowns?: Uint8Array[];
             public mapStringString: { [k: string]: string };
             public mapStringInt32: { [k: string]: number };
             public mapStringInt64: { [k: string]: (number|Long) };
@@ -771,10 +833,12 @@ export namespace jspb {
 
         interface IMapValueMessageNoBinary {
             foo?: (number|null);
+            $unknowns?: Uint8Array[];
         }
 
         class MapValueMessageNoBinary implements IMapValueMessageNoBinary {
             constructor(properties?: jspb.test.IMapValueMessageNoBinary);
+            public $unknowns?: Uint8Array[];
             public foo: number;
             public static create(properties?: jspb.test.IMapValueMessageNoBinary): jspb.test.MapValueMessageNoBinary;
             public static encode(message: jspb.test.IMapValueMessageNoBinary, writer?: $protobuf.Writer): $protobuf.Writer;
@@ -789,10 +853,12 @@ export namespace jspb {
         }
 
         interface IDeeply {
+            $unknowns?: Uint8Array[];
         }
 
         class Deeply implements IDeeply {
             constructor(properties?: jspb.test.IDeeply);
+            public $unknowns?: Uint8Array[];
             public static create(properties?: jspb.test.IDeeply): jspb.test.Deeply;
             public static encode(message: jspb.test.IDeeply, writer?: $protobuf.Writer): $protobuf.Writer;
             public static encodeDelimited(message: jspb.test.IDeeply, writer?: $protobuf.Writer): $protobuf.Writer;
@@ -808,10 +874,12 @@ export namespace jspb {
         namespace Deeply {
 
             interface INested {
+                $unknowns?: Uint8Array[];
             }
 
             class Nested implements INested {
                 constructor(properties?: jspb.test.Deeply.INested);
+                public $unknowns?: Uint8Array[];
                 public static create(properties?: jspb.test.Deeply.INested): jspb.test.Deeply.Nested;
                 public static encode(message: jspb.test.Deeply.INested, writer?: $protobuf.Writer): $protobuf.Writer;
                 public static encodeDelimited(message: jspb.test.Deeply.INested, writer?: $protobuf.Writer): $protobuf.Writer;
@@ -828,10 +896,12 @@ export namespace jspb {
 
                 interface IMessage {
                     count?: (number|null);
+                    $unknowns?: Uint8Array[];
                 }
 
                 class Message implements IMessage {
                     constructor(properties?: jspb.test.Deeply.Nested.IMessage);
+                    public $unknowns?: Uint8Array[];
                     public count: number;
                     public static create(properties?: jspb.test.Deeply.Nested.IMessage): jspb.test.Deeply.Nested.Message;
                     public static encode(message: jspb.test.Deeply.Nested.IMessage, writer?: $protobuf.Writer): $protobuf.Writer;
@@ -855,10 +925,12 @@ export namespace google {
 
         interface IFileDescriptorSet {
             file?: (google.protobuf.IFileDescriptorProto[]|null);
+            $unknowns?: Uint8Array[];
         }
 
         class FileDescriptorSet implements IFileDescriptorSet {
             constructor(properties?: google.protobuf.IFileDescriptorSet);
+            public $unknowns?: Uint8Array[];
             public file: google.protobuf.IFileDescriptorProto[];
             public static create(properties?: google.protobuf.IFileDescriptorSet): google.protobuf.FileDescriptorSet;
             public static encode(message: google.protobuf.IFileDescriptorSet, writer?: $protobuf.Writer): $protobuf.Writer;
@@ -902,10 +974,12 @@ export namespace google {
             sourceCodeInfo?: (google.protobuf.ISourceCodeInfo|null);
             syntax?: (string|null);
             edition?: (google.protobuf.Edition|null);
+            $unknowns?: Uint8Array[];
         }
 
         class FileDescriptorProto implements IFileDescriptorProto {
             constructor(properties?: google.protobuf.IFileDescriptorProto);
+            public $unknowns?: Uint8Array[];
             public name: string;
             public package: string;
             public dependency: string[];
@@ -944,10 +1018,12 @@ export namespace google {
             reservedRange?: (google.protobuf.DescriptorProto.IReservedRange[]|null);
             reservedName?: (string[]|null);
             visibility?: (google.protobuf.SymbolVisibility|null);
+            $unknowns?: Uint8Array[];
         }
 
         class DescriptorProto implements IDescriptorProto {
             constructor(properties?: google.protobuf.IDescriptorProto);
+            public $unknowns?: Uint8Array[];
             public name: string;
             public field: google.protobuf.IFieldDescriptorProto[];
             public extension: google.protobuf.IFieldDescriptorProto[];
@@ -977,10 +1053,12 @@ export namespace google {
                 start?: (number|null);
                 end?: (number|null);
                 options?: (google.protobuf.IExtensionRangeOptions|null);
+                $unknowns?: Uint8Array[];
             }
 
             class ExtensionRange implements IExtensionRange {
                 constructor(properties?: google.protobuf.DescriptorProto.IExtensionRange);
+                public $unknowns?: Uint8Array[];
                 public start: number;
                 public end: number;
                 public options?: (google.protobuf.IExtensionRangeOptions|null);
@@ -999,10 +1077,12 @@ export namespace google {
             interface IReservedRange {
                 start?: (number|null);
                 end?: (number|null);
+                $unknowns?: Uint8Array[];
             }
 
             class ReservedRange implements IReservedRange {
                 constructor(properties?: google.protobuf.DescriptorProto.IReservedRange);
+                public $unknowns?: Uint8Array[];
                 public start: number;
                 public end: number;
                 public static create(properties?: google.protobuf.DescriptorProto.IReservedRange): google.protobuf.DescriptorProto.ReservedRange;
@@ -1023,10 +1103,12 @@ export namespace google {
             declaration?: (google.protobuf.ExtensionRangeOptions.IDeclaration[]|null);
             features?: (google.protobuf.IFeatureSet|null);
             verification?: (google.protobuf.ExtensionRangeOptions.VerificationState|null);
+            $unknowns?: Uint8Array[];
         }
 
         class ExtensionRangeOptions implements IExtensionRangeOptions {
             constructor(properties?: google.protobuf.IExtensionRangeOptions);
+            public $unknowns?: Uint8Array[];
             public uninterpretedOption: google.protobuf.IUninterpretedOption[];
             public declaration: google.protobuf.ExtensionRangeOptions.IDeclaration[];
             public features?: (google.protobuf.IFeatureSet|null);
@@ -1051,10 +1133,12 @@ export namespace google {
                 type?: (string|null);
                 reserved?: (boolean|null);
                 repeated?: (boolean|null);
+                $unknowns?: Uint8Array[];
             }
 
             class Declaration implements IDeclaration {
                 constructor(properties?: google.protobuf.ExtensionRangeOptions.IDeclaration);
+                public $unknowns?: Uint8Array[];
                 public number: number;
                 public fullName: string;
                 public type: string;
@@ -1090,10 +1174,12 @@ export namespace google {
             jsonName?: (string|null);
             options?: (google.protobuf.IFieldOptions|null);
             proto3Optional?: (boolean|null);
+            $unknowns?: Uint8Array[];
         }
 
         class FieldDescriptorProto implements IFieldDescriptorProto {
             constructor(properties?: google.protobuf.IFieldDescriptorProto);
+            public $unknowns?: Uint8Array[];
             public name: string;
             public number: number;
             public label: google.protobuf.FieldDescriptorProto.Label;
@@ -1150,10 +1236,12 @@ export namespace google {
         interface IOneofDescriptorProto {
             name?: (string|null);
             options?: (google.protobuf.IOneofOptions|null);
+            $unknowns?: Uint8Array[];
         }
 
         class OneofDescriptorProto implements IOneofDescriptorProto {
             constructor(properties?: google.protobuf.IOneofDescriptorProto);
+            public $unknowns?: Uint8Array[];
             public name: string;
             public options?: (google.protobuf.IOneofOptions|null);
             public static create(properties?: google.protobuf.IOneofDescriptorProto): google.protobuf.OneofDescriptorProto;
@@ -1175,10 +1263,12 @@ export namespace google {
             reservedRange?: (google.protobuf.EnumDescriptorProto.IEnumReservedRange[]|null);
             reservedName?: (string[]|null);
             visibility?: (google.protobuf.SymbolVisibility|null);
+            $unknowns?: Uint8Array[];
         }
 
         class EnumDescriptorProto implements IEnumDescriptorProto {
             constructor(properties?: google.protobuf.IEnumDescriptorProto);
+            public $unknowns?: Uint8Array[];
             public name: string;
             public value: google.protobuf.IEnumValueDescriptorProto[];
             public options?: (google.protobuf.IEnumOptions|null);
@@ -1202,10 +1292,12 @@ export namespace google {
             interface IEnumReservedRange {
                 start?: (number|null);
                 end?: (number|null);
+                $unknowns?: Uint8Array[];
             }
 
             class EnumReservedRange implements IEnumReservedRange {
                 constructor(properties?: google.protobuf.EnumDescriptorProto.IEnumReservedRange);
+                public $unknowns?: Uint8Array[];
                 public start: number;
                 public end: number;
                 public static create(properties?: google.protobuf.EnumDescriptorProto.IEnumReservedRange): google.protobuf.EnumDescriptorProto.EnumReservedRange;
@@ -1225,10 +1317,12 @@ export namespace google {
             name?: (string|null);
             number?: (number|null);
             options?: (google.protobuf.IEnumValueOptions|null);
+            $unknowns?: Uint8Array[];
         }
 
         class EnumValueDescriptorProto implements IEnumValueDescriptorProto {
             constructor(properties?: google.protobuf.IEnumValueDescriptorProto);
+            public $unknowns?: Uint8Array[];
             public name: string;
             public number: number;
             public options?: (google.protobuf.IEnumValueOptions|null);
@@ -1248,10 +1342,12 @@ export namespace google {
             name?: (string|null);
             method?: (google.protobuf.IMethodDescriptorProto[]|null);
             options?: (google.protobuf.IServiceOptions|null);
+            $unknowns?: Uint8Array[];
         }
 
         class ServiceDescriptorProto implements IServiceDescriptorProto {
             constructor(properties?: google.protobuf.IServiceDescriptorProto);
+            public $unknowns?: Uint8Array[];
             public name: string;
             public method: google.protobuf.IMethodDescriptorProto[];
             public options?: (google.protobuf.IServiceOptions|null);
@@ -1274,10 +1370,12 @@ export namespace google {
             options?: (google.protobuf.IMethodOptions|null);
             clientStreaming?: (boolean|null);
             serverStreaming?: (boolean|null);
+            $unknowns?: Uint8Array[];
         }
 
         class MethodDescriptorProto implements IMethodDescriptorProto {
             constructor(properties?: google.protobuf.IMethodDescriptorProto);
+            public $unknowns?: Uint8Array[];
             public name: string;
             public inputType: string;
             public outputType: string;
@@ -1318,10 +1416,12 @@ export namespace google {
             rubyPackage?: (string|null);
             features?: (google.protobuf.IFeatureSet|null);
             uninterpretedOption?: (google.protobuf.IUninterpretedOption[]|null);
+            $unknowns?: Uint8Array[];
         }
 
         class FileOptions implements IFileOptions {
             constructor(properties?: google.protobuf.IFileOptions);
+            public $unknowns?: Uint8Array[];
             public javaPackage: string;
             public javaOuterClassname: string;
             public javaMultipleFiles: boolean;
@@ -1372,10 +1472,12 @@ export namespace google {
             deprecatedLegacyJsonFieldConflicts?: (boolean|null);
             features?: (google.protobuf.IFeatureSet|null);
             uninterpretedOption?: (google.protobuf.IUninterpretedOption[]|null);
+            $unknowns?: Uint8Array[];
         }
 
         class MessageOptions implements IMessageOptions {
             constructor(properties?: google.protobuf.IMessageOptions);
+            public $unknowns?: Uint8Array[];
             public messageSetWireFormat: boolean;
             public noStandardDescriptorAccessor: boolean;
             public deprecated: boolean;
@@ -1410,10 +1512,12 @@ export namespace google {
             features?: (google.protobuf.IFeatureSet|null);
             featureSupport?: (google.protobuf.FieldOptions.IFeatureSupport|null);
             uninterpretedOption?: (google.protobuf.IUninterpretedOption[]|null);
+            $unknowns?: Uint8Array[];
         }
 
         class FieldOptions implements IFieldOptions {
             constructor(properties?: google.protobuf.IFieldOptions);
+            public $unknowns?: Uint8Array[];
             public ctype: google.protobuf.FieldOptions.CType;
             public packed: boolean;
             public jstype: google.protobuf.FieldOptions.JSType;
@@ -1476,10 +1580,12 @@ export namespace google {
             interface IEditionDefault {
                 edition?: (google.protobuf.Edition|null);
                 value?: (string|null);
+                $unknowns?: Uint8Array[];
             }
 
             class EditionDefault implements IEditionDefault {
                 constructor(properties?: google.protobuf.FieldOptions.IEditionDefault);
+                public $unknowns?: Uint8Array[];
                 public edition: google.protobuf.Edition;
                 public value: string;
                 public static create(properties?: google.protobuf.FieldOptions.IEditionDefault): google.protobuf.FieldOptions.EditionDefault;
@@ -1499,10 +1605,12 @@ export namespace google {
                 editionDeprecated?: (google.protobuf.Edition|null);
                 deprecationWarning?: (string|null);
                 editionRemoved?: (google.protobuf.Edition|null);
+                $unknowns?: Uint8Array[];
             }
 
             class FeatureSupport implements IFeatureSupport {
                 constructor(properties?: google.protobuf.FieldOptions.IFeatureSupport);
+                public $unknowns?: Uint8Array[];
                 public editionIntroduced: google.protobuf.Edition;
                 public editionDeprecated: google.protobuf.Edition;
                 public deprecationWarning: string;
@@ -1523,10 +1631,12 @@ export namespace google {
         interface IOneofOptions {
             features?: (google.protobuf.IFeatureSet|null);
             uninterpretedOption?: (google.protobuf.IUninterpretedOption[]|null);
+            $unknowns?: Uint8Array[];
         }
 
         class OneofOptions implements IOneofOptions {
             constructor(properties?: google.protobuf.IOneofOptions);
+            public $unknowns?: Uint8Array[];
             public features?: (google.protobuf.IFeatureSet|null);
             public uninterpretedOption: google.protobuf.IUninterpretedOption[];
             public static create(properties?: google.protobuf.IOneofOptions): google.protobuf.OneofOptions;
@@ -1548,11 +1658,13 @@ export namespace google {
             features?: (google.protobuf.IFeatureSet|null);
             uninterpretedOption?: (google.protobuf.IUninterpretedOption[]|null);
             ".jspb.test.IsExtension.simpleOption"?: (string|null);
+            $unknowns?: Uint8Array[];
         }
 
         class EnumOptions implements IEnumOptions {
             constructor(properties?: google.protobuf.IEnumOptions);
             public ".jspb.test.IsExtension.simpleOption": string;
+            public $unknowns?: Uint8Array[];
             public allowAlias: boolean;
             public deprecated: boolean;
             public deprecatedLegacyJsonFieldConflicts: boolean;
@@ -1576,10 +1688,12 @@ export namespace google {
             debugRedact?: (boolean|null);
             featureSupport?: (google.protobuf.FieldOptions.IFeatureSupport|null);
             uninterpretedOption?: (google.protobuf.IUninterpretedOption[]|null);
+            $unknowns?: Uint8Array[];
         }
 
         class EnumValueOptions implements IEnumValueOptions {
             constructor(properties?: google.protobuf.IEnumValueOptions);
+            public $unknowns?: Uint8Array[];
             public deprecated: boolean;
             public features?: (google.protobuf.IFeatureSet|null);
             public debugRedact: boolean;
@@ -1601,10 +1715,12 @@ export namespace google {
             features?: (google.protobuf.IFeatureSet|null);
             deprecated?: (boolean|null);
             uninterpretedOption?: (google.protobuf.IUninterpretedOption[]|null);
+            $unknowns?: Uint8Array[];
         }
 
         class ServiceOptions implements IServiceOptions {
             constructor(properties?: google.protobuf.IServiceOptions);
+            public $unknowns?: Uint8Array[];
             public features?: (google.protobuf.IFeatureSet|null);
             public deprecated: boolean;
             public uninterpretedOption: google.protobuf.IUninterpretedOption[];
@@ -1625,10 +1741,12 @@ export namespace google {
             idempotencyLevel?: (google.protobuf.MethodOptions.IdempotencyLevel|null);
             features?: (google.protobuf.IFeatureSet|null);
             uninterpretedOption?: (google.protobuf.IUninterpretedOption[]|null);
+            $unknowns?: Uint8Array[];
         }
 
         class MethodOptions implements IMethodOptions {
             constructor(properties?: google.protobuf.IMethodOptions);
+            public $unknowns?: Uint8Array[];
             public deprecated: boolean;
             public idempotencyLevel: google.protobuf.MethodOptions.IdempotencyLevel;
             public features?: (google.protobuf.IFeatureSet|null);
@@ -1662,10 +1780,12 @@ export namespace google {
             doubleValue?: (number|null);
             stringValue?: (Uint8Array|null);
             aggregateValue?: (string|null);
+            $unknowns?: Uint8Array[];
         }
 
         class UninterpretedOption implements IUninterpretedOption {
             constructor(properties?: google.protobuf.IUninterpretedOption);
+            public $unknowns?: Uint8Array[];
             public name: google.protobuf.UninterpretedOption.INamePart[];
             public identifierValue: string;
             public positiveIntValue: (number|Long);
@@ -1690,10 +1810,12 @@ export namespace google {
             interface INamePart {
                 namePart: string;
                 isExtension: boolean;
+                $unknowns?: Uint8Array[];
             }
 
             class NamePart implements INamePart {
                 constructor(properties?: google.protobuf.UninterpretedOption.INamePart);
+                public $unknowns?: Uint8Array[];
                 public namePart: string;
                 public isExtension: boolean;
                 public static create(properties?: google.protobuf.UninterpretedOption.INamePart): google.protobuf.UninterpretedOption.NamePart;
@@ -1718,10 +1840,12 @@ export namespace google {
             jsonFormat?: (google.protobuf.FeatureSet.JsonFormat|null);
             enforceNamingStyle?: (google.protobuf.FeatureSet.EnforceNamingStyle|null);
             defaultSymbolVisibility?: (google.protobuf.FeatureSet.VisibilityFeature.DefaultSymbolVisibility|null);
+            $unknowns?: Uint8Array[];
         }
 
         class FeatureSet implements IFeatureSet {
             constructor(properties?: google.protobuf.IFeatureSet);
+            public $unknowns?: Uint8Array[];
             public fieldPresence: google.protobuf.FeatureSet.FieldPresence;
             public enumType: google.protobuf.FeatureSet.EnumType;
             public repeatedFieldEncoding: google.protobuf.FeatureSet.RepeatedFieldEncoding;
@@ -1788,10 +1912,12 @@ export namespace google {
             }
 
             interface IVisibilityFeature {
+                $unknowns?: Uint8Array[];
             }
 
             class VisibilityFeature implements IVisibilityFeature {
                 constructor(properties?: google.protobuf.FeatureSet.IVisibilityFeature);
+                public $unknowns?: Uint8Array[];
                 public static create(properties?: google.protobuf.FeatureSet.IVisibilityFeature): google.protobuf.FeatureSet.VisibilityFeature;
                 public static encode(message: google.protobuf.FeatureSet.IVisibilityFeature, writer?: $protobuf.Writer): $protobuf.Writer;
                 public static encodeDelimited(message: google.protobuf.FeatureSet.IVisibilityFeature, writer?: $protobuf.Writer): $protobuf.Writer;
@@ -1820,10 +1946,12 @@ export namespace google {
             defaults?: (google.protobuf.FeatureSetDefaults.IFeatureSetEditionDefault[]|null);
             minimumEdition?: (google.protobuf.Edition|null);
             maximumEdition?: (google.protobuf.Edition|null);
+            $unknowns?: Uint8Array[];
         }
 
         class FeatureSetDefaults implements IFeatureSetDefaults {
             constructor(properties?: google.protobuf.IFeatureSetDefaults);
+            public $unknowns?: Uint8Array[];
             public defaults: google.protobuf.FeatureSetDefaults.IFeatureSetEditionDefault[];
             public minimumEdition: google.protobuf.Edition;
             public maximumEdition: google.protobuf.Edition;
@@ -1845,10 +1973,12 @@ export namespace google {
                 edition?: (google.protobuf.Edition|null);
                 overridableFeatures?: (google.protobuf.IFeatureSet|null);
                 fixedFeatures?: (google.protobuf.IFeatureSet|null);
+                $unknowns?: Uint8Array[];
             }
 
             class FeatureSetEditionDefault implements IFeatureSetEditionDefault {
                 constructor(properties?: google.protobuf.FeatureSetDefaults.IFeatureSetEditionDefault);
+                public $unknowns?: Uint8Array[];
                 public edition: google.protobuf.Edition;
                 public overridableFeatures?: (google.protobuf.IFeatureSet|null);
                 public fixedFeatures?: (google.protobuf.IFeatureSet|null);
@@ -1867,10 +1997,12 @@ export namespace google {
 
         interface ISourceCodeInfo {
             location?: (google.protobuf.SourceCodeInfo.ILocation[]|null);
+            $unknowns?: Uint8Array[];
         }
 
         class SourceCodeInfo implements ISourceCodeInfo {
             constructor(properties?: google.protobuf.ISourceCodeInfo);
+            public $unknowns?: Uint8Array[];
             public location: google.protobuf.SourceCodeInfo.ILocation[];
             public static create(properties?: google.protobuf.ISourceCodeInfo): google.protobuf.SourceCodeInfo;
             public static encode(message: google.protobuf.ISourceCodeInfo, writer?: $protobuf.Writer): $protobuf.Writer;
@@ -1892,10 +2024,12 @@ export namespace google {
                 leadingComments?: (string|null);
                 trailingComments?: (string|null);
                 leadingDetachedComments?: (string[]|null);
+                $unknowns?: Uint8Array[];
             }
 
             class Location implements ILocation {
                 constructor(properties?: google.protobuf.SourceCodeInfo.ILocation);
+                public $unknowns?: Uint8Array[];
                 public path: number[];
                 public span: number[];
                 public leadingComments: string;
@@ -1916,10 +2050,12 @@ export namespace google {
 
         interface IGeneratedCodeInfo {
             annotation?: (google.protobuf.GeneratedCodeInfo.IAnnotation[]|null);
+            $unknowns?: Uint8Array[];
         }
 
         class GeneratedCodeInfo implements IGeneratedCodeInfo {
             constructor(properties?: google.protobuf.IGeneratedCodeInfo);
+            public $unknowns?: Uint8Array[];
             public annotation: google.protobuf.GeneratedCodeInfo.IAnnotation[];
             public static create(properties?: google.protobuf.IGeneratedCodeInfo): google.protobuf.GeneratedCodeInfo;
             public static encode(message: google.protobuf.IGeneratedCodeInfo, writer?: $protobuf.Writer): $protobuf.Writer;
@@ -1941,10 +2077,12 @@ export namespace google {
                 begin?: (number|null);
                 end?: (number|null);
                 semantic?: (google.protobuf.GeneratedCodeInfo.Annotation.Semantic|null);
+                $unknowns?: Uint8Array[];
             }
 
             class Annotation implements IAnnotation {
                 constructor(properties?: google.protobuf.GeneratedCodeInfo.IAnnotation);
+                public $unknowns?: Uint8Array[];
                 public path: number[];
                 public sourceFile: string;
                 public begin: number;

--- a/tests/data/test.js
+++ b/tests/data/test.js
@@ -33,6 +33,7 @@ $root.jspb = (function() {
              * Properties of an Empty.
              * @memberof jspb.test
              * @interface IEmpty
+             * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
              */
 
             /**
@@ -42,6 +43,7 @@ $root.jspb = (function() {
              * @implements IEmpty
              * @constructor
              * @param {jspb.test.IEmpty=} [properties] Properties to set
+             * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
              */
             function Empty(properties) {
                 if (properties)
@@ -74,6 +76,9 @@ $root.jspb = (function() {
             Empty.encode = function encode(message, writer) {
                 if (!writer)
                     writer = $Writer.create();
+                if (message.$unknowns != null && Object.hasOwnProperty.call(message, "$unknowns"))
+                    for (var i = 0; i < message.$unknowns.length; ++i)
+                        writer.raw(message.$unknowns[i]);
                 return writer;
             };
 
@@ -110,6 +115,7 @@ $root.jspb = (function() {
                     throw Error("max depth exceeded");
                 var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.jspb.test.Empty();
                 while (reader.pos < end) {
+                    var start = reader.pos;
                     var tag = reader.uint32();
                     if (tag === _end) {
                         _end = undefined;
@@ -118,6 +124,8 @@ $root.jspb = (function() {
                     switch (tag) {
                     default:
                         reader.skipType(tag & 7, _depth, tag >>> 3);
+                        $util.makeProp(message, "$unknowns", false);
+                        (message.$unknowns || (message.$unknowns = [])).push(reader.raw(start, reader.pos));
                         break;
                     }
                 }
@@ -241,6 +249,7 @@ $root.jspb = (function() {
              * @memberof jspb.test
              * @interface IEnumContainer
              * @property {jspb.test.OuterEnum|null} [outerEnum] EnumContainer outerEnum
+             * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
              */
 
             /**
@@ -250,6 +259,7 @@ $root.jspb = (function() {
              * @implements IEnumContainer
              * @constructor
              * @param {jspb.test.IEnumContainer=} [properties] Properties to set
+             * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
              */
             function EnumContainer(properties) {
                 if (properties)
@@ -292,6 +302,9 @@ $root.jspb = (function() {
                     writer = $Writer.create();
                 if (message.outerEnum != null && Object.hasOwnProperty.call(message, "outerEnum"))
                     writer.uint32(/* id 1, wireType 0 =*/8).int32(message.outerEnum);
+                if (message.$unknowns != null && Object.hasOwnProperty.call(message, "$unknowns"))
+                    for (var i = 0; i < message.$unknowns.length; ++i)
+                        writer.raw(message.$unknowns[i]);
                 return writer;
             };
 
@@ -328,6 +341,7 @@ $root.jspb = (function() {
                     throw Error("max depth exceeded");
                 var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.jspb.test.EnumContainer();
                 while (reader.pos < end) {
+                    var start = reader.pos;
                     var tag = reader.uint32();
                     if (tag === _end) {
                         _end = undefined;
@@ -340,6 +354,8 @@ $root.jspb = (function() {
                         }
                     default:
                         reader.skipType(tag & 7, _depth, tag >>> 3);
+                        $util.makeProp(message, "$unknowns", false);
+                        (message.$unknowns || (message.$unknowns = [])).push(reader.raw(start, reader.pos));
                         break;
                     }
                 }
@@ -483,6 +499,7 @@ $root.jspb = (function() {
              * @property {string} aString Simple1 aString
              * @property {Array.<string>|null} [aRepeatedString] Simple1 aRepeatedString
              * @property {boolean|null} [aBoolean] Simple1 aBoolean
+             * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
              */
 
             /**
@@ -492,6 +509,7 @@ $root.jspb = (function() {
              * @implements ISimple1
              * @constructor
              * @param {jspb.test.ISimple1=} [properties] Properties to set
+             * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
              */
             function Simple1(properties) {
                 this.aRepeatedString = [];
@@ -555,6 +573,9 @@ $root.jspb = (function() {
                         writer.uint32(/* id 2, wireType 2 =*/18).string(message.aRepeatedString[i]);
                 if (message.aBoolean != null && Object.hasOwnProperty.call(message, "aBoolean"))
                     writer.uint32(/* id 3, wireType 0 =*/24).bool(message.aBoolean);
+                if (message.$unknowns != null && Object.hasOwnProperty.call(message, "$unknowns"))
+                    for (var i = 0; i < message.$unknowns.length; ++i)
+                        writer.raw(message.$unknowns[i]);
                 return writer;
             };
 
@@ -591,6 +612,7 @@ $root.jspb = (function() {
                     throw Error("max depth exceeded");
                 var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.jspb.test.Simple1();
                 while (reader.pos < end) {
+                    var start = reader.pos;
                     var tag = reader.uint32();
                     if (tag === _end) {
                         _end = undefined;
@@ -613,6 +635,8 @@ $root.jspb = (function() {
                         }
                     default:
                         reader.skipType(tag & 7, _depth, tag >>> 3);
+                        $util.makeProp(message, "$unknowns", false);
+                        (message.$unknowns || (message.$unknowns = [])).push(reader.raw(start, reader.pos));
                         break;
                     }
                 }
@@ -767,6 +791,7 @@ $root.jspb = (function() {
              * @interface ISimple2
              * @property {string} aString Simple2 aString
              * @property {Array.<string>|null} [aRepeatedString] Simple2 aRepeatedString
+             * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
              */
 
             /**
@@ -776,6 +801,7 @@ $root.jspb = (function() {
              * @implements ISimple2
              * @constructor
              * @param {jspb.test.ISimple2=} [properties] Properties to set
+             * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
              */
             function Simple2(properties) {
                 this.aRepeatedString = [];
@@ -829,6 +855,9 @@ $root.jspb = (function() {
                 if (message.aRepeatedString != null && message.aRepeatedString.length)
                     for (var i = 0; i < message.aRepeatedString.length; ++i)
                         writer.uint32(/* id 2, wireType 2 =*/18).string(message.aRepeatedString[i]);
+                if (message.$unknowns != null && Object.hasOwnProperty.call(message, "$unknowns"))
+                    for (var i = 0; i < message.$unknowns.length; ++i)
+                        writer.raw(message.$unknowns[i]);
                 return writer;
             };
 
@@ -865,6 +894,7 @@ $root.jspb = (function() {
                     throw Error("max depth exceeded");
                 var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.jspb.test.Simple2();
                 while (reader.pos < end) {
+                    var start = reader.pos;
                     var tag = reader.uint32();
                     if (tag === _end) {
                         _end = undefined;
@@ -883,6 +913,8 @@ $root.jspb = (function() {
                         }
                     default:
                         reader.skipType(tag & 7, _depth, tag >>> 3);
+                        $util.makeProp(message, "$unknowns", false);
+                        (message.$unknowns || (message.$unknowns = [])).push(reader.raw(start, reader.pos));
                         break;
                     }
                 }
@@ -1030,6 +1062,7 @@ $root.jspb = (function() {
              * @property {string} "default" SpecialCases default
              * @property {string} "function" SpecialCases function
              * @property {string} "var" SpecialCases var
+             * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
              */
 
             /**
@@ -1039,6 +1072,7 @@ $root.jspb = (function() {
              * @implements ISpecialCases
              * @constructor
              * @param {jspb.test.ISpecialCases=} [properties] Properties to set
+             * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
              */
             function SpecialCases(properties) {
                 if (properties)
@@ -1107,6 +1141,9 @@ $root.jspb = (function() {
                 writer.uint32(/* id 2, wireType 2 =*/18).string(message["default"]);
                 writer.uint32(/* id 3, wireType 2 =*/26).string(message["function"]);
                 writer.uint32(/* id 4, wireType 2 =*/34).string(message["var"]);
+                if (message.$unknowns != null && Object.hasOwnProperty.call(message, "$unknowns"))
+                    for (var i = 0; i < message.$unknowns.length; ++i)
+                        writer.raw(message.$unknowns[i]);
                 return writer;
             };
 
@@ -1143,6 +1180,7 @@ $root.jspb = (function() {
                     throw Error("max depth exceeded");
                 var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.jspb.test.SpecialCases();
                 while (reader.pos < end) {
+                    var start = reader.pos;
                     var tag = reader.uint32();
                     if (tag === _end) {
                         _end = undefined;
@@ -1167,6 +1205,8 @@ $root.jspb = (function() {
                         }
                     default:
                         reader.skipType(tag & 7, _depth, tag >>> 3);
+                        $util.makeProp(message, "$unknowns", false);
+                        (message.$unknowns || (message.$unknowns = [])).push(reader.raw(start, reader.pos));
                         break;
                     }
                 }
@@ -1322,6 +1362,7 @@ $root.jspb = (function() {
              * @property {jspb.test.OptionalFields.INested|null} [aNestedMessage] OptionalFields aNestedMessage
              * @property {Array.<jspb.test.OptionalFields.INested>|null} [aRepeatedMessage] OptionalFields aRepeatedMessage
              * @property {Array.<string>|null} [aRepeatedString] OptionalFields aRepeatedString
+             * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
              */
 
             /**
@@ -1331,6 +1372,7 @@ $root.jspb = (function() {
              * @implements IOptionalFields
              * @constructor
              * @param {jspb.test.IOptionalFields=} [properties] Properties to set
+             * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
              */
             function OptionalFields(properties) {
                 this.aRepeatedMessage = [];
@@ -1416,6 +1458,9 @@ $root.jspb = (function() {
                 if (message.aRepeatedString != null && message.aRepeatedString.length)
                     for (var i = 0; i < message.aRepeatedString.length; ++i)
                         writer.uint32(/* id 5, wireType 2 =*/42).string(message.aRepeatedString[i]);
+                if (message.$unknowns != null && Object.hasOwnProperty.call(message, "$unknowns"))
+                    for (var i = 0; i < message.$unknowns.length; ++i)
+                        writer.raw(message.$unknowns[i]);
                 return writer;
             };
 
@@ -1452,6 +1497,7 @@ $root.jspb = (function() {
                     throw Error("max depth exceeded");
                 var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.jspb.test.OptionalFields();
                 while (reader.pos < end) {
+                    var start = reader.pos;
                     var tag = reader.uint32();
                     if (tag === _end) {
                         _end = undefined;
@@ -1484,6 +1530,8 @@ $root.jspb = (function() {
                         }
                     default:
                         reader.skipType(tag & 7, _depth, tag >>> 3);
+                        $util.makeProp(message, "$unknowns", false);
+                        (message.$unknowns || (message.$unknowns = [])).push(reader.raw(start, reader.pos));
                         break;
                     }
                 }
@@ -1673,6 +1721,7 @@ $root.jspb = (function() {
                  * @memberof jspb.test.OptionalFields
                  * @interface INested
                  * @property {number|null} [anInt] Nested anInt
+                 * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
                  */
 
                 /**
@@ -1682,6 +1731,7 @@ $root.jspb = (function() {
                  * @implements INested
                  * @constructor
                  * @param {jspb.test.OptionalFields.INested=} [properties] Properties to set
+                 * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
                  */
                 function Nested(properties) {
                     if (properties)
@@ -1724,6 +1774,9 @@ $root.jspb = (function() {
                         writer = $Writer.create();
                     if (message.anInt != null && Object.hasOwnProperty.call(message, "anInt"))
                         writer.uint32(/* id 1, wireType 0 =*/8).int32(message.anInt);
+                    if (message.$unknowns != null && Object.hasOwnProperty.call(message, "$unknowns"))
+                        for (var i = 0; i < message.$unknowns.length; ++i)
+                            writer.raw(message.$unknowns[i]);
                     return writer;
                 };
 
@@ -1760,6 +1813,7 @@ $root.jspb = (function() {
                         throw Error("max depth exceeded");
                     var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.jspb.test.OptionalFields.Nested();
                     while (reader.pos < end) {
+                        var start = reader.pos;
                         var tag = reader.uint32();
                         if (tag === _end) {
                             _end = undefined;
@@ -1772,6 +1826,8 @@ $root.jspb = (function() {
                             }
                         default:
                             reader.skipType(tag & 7, _depth, tag >>> 3);
+                            $util.makeProp(message, "$unknowns", false);
+                            (message.$unknowns || (message.$unknowns = [])).push(reader.raw(start, reader.pos));
                             break;
                         }
                     }
@@ -1905,6 +1961,7 @@ $root.jspb = (function() {
              * @property {Array.<string>|null} [".jspb.test.IndirectExtension.repeatedStr"] HasExtensions .jspb.test.IndirectExtension.repeatedStr
              * @property {Array.<jspb.test.ISimple1>|null} [".jspb.test.IndirectExtension.repeatedSimple"] HasExtensions .jspb.test.IndirectExtension.repeatedSimple
              * @property {jspb.test.ISimple1|null} [".jspb.test.simple1"] HasExtensions .jspb.test.simple1
+             * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
              */
 
             /**
@@ -1920,6 +1977,7 @@ $root.jspb = (function() {
              * @property {Array.<string>} ".jspb.test.IndirectExtension.repeatedStr" HasExtensions .jspb.test.IndirectExtension.repeatedStr
              * @property {Array.<jspb.test.ISimple1>} ".jspb.test.IndirectExtension.repeatedSimple" HasExtensions .jspb.test.IndirectExtension.repeatedSimple
              * @property {jspb.test.ISimple1|null} [".jspb.test.simple1"] HasExtensions .jspb.test.simple1
+             * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
              */
             function HasExtensions(properties) {
                 this[".jspb.test.IndirectExtension.repeatedStr"] = [];
@@ -2005,6 +2063,9 @@ $root.jspb = (function() {
                         $root.jspb.test.Simple1.encode(message[".jspb.test.IndirectExtension.repeatedSimple"][i], writer.uint32(/* id 104, wireType 2 =*/834).fork()).ldelim();
                 if (message[".jspb.test.simple1"] != null && Object.hasOwnProperty.call(message, ".jspb.test.simple1"))
                     $root.jspb.test.Simple1.encode(message[".jspb.test.simple1"], writer.uint32(/* id 105, wireType 2 =*/842).fork()).ldelim();
+                if (message.$unknowns != null && Object.hasOwnProperty.call(message, "$unknowns"))
+                    for (var i = 0; i < message.$unknowns.length; ++i)
+                        writer.raw(message.$unknowns[i]);
                 return writer;
             };
 
@@ -2041,6 +2102,7 @@ $root.jspb = (function() {
                     throw Error("max depth exceeded");
                 var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.jspb.test.HasExtensions();
                 while (reader.pos < end) {
+                    var start = reader.pos;
                     var tag = reader.uint32();
                     if (tag === _end) {
                         _end = undefined;
@@ -2089,6 +2151,8 @@ $root.jspb = (function() {
                         }
                     default:
                         reader.skipType(tag & 7, _depth, tag >>> 3);
+                        $util.makeProp(message, "$unknowns", false);
+                        (message.$unknowns || (message.$unknowns = [])).push(reader.raw(start, reader.pos));
                         break;
                     }
                 }
@@ -2326,6 +2390,7 @@ $root.jspb = (function() {
              * @property {jspb.test.Complex.INested|null} [aNestedMessage] Complex aNestedMessage
              * @property {Array.<jspb.test.Complex.INested>|null} [aRepeatedMessage] Complex aRepeatedMessage
              * @property {Array.<string>|null} [aRepeatedString] Complex aRepeatedString
+             * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
              */
 
             /**
@@ -2335,6 +2400,7 @@ $root.jspb = (function() {
              * @implements IComplex
              * @constructor
              * @param {jspb.test.IComplex=} [properties] Properties to set
+             * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
              */
             function Complex(properties) {
                 this.aRepeatedMessage = [];
@@ -2419,6 +2485,9 @@ $root.jspb = (function() {
                     for (var i = 0; i < message.aRepeatedString.length; ++i)
                         writer.uint32(/* id 7, wireType 2 =*/58).string(message.aRepeatedString[i]);
                 writer.uint32(/* id 9, wireType 0 =*/72).bool(message.anOutOfOrderBool);
+                if (message.$unknowns != null && Object.hasOwnProperty.call(message, "$unknowns"))
+                    for (var i = 0; i < message.$unknowns.length; ++i)
+                        writer.raw(message.$unknowns[i]);
                 return writer;
             };
 
@@ -2455,6 +2524,7 @@ $root.jspb = (function() {
                     throw Error("max depth exceeded");
                 var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.jspb.test.Complex();
                 while (reader.pos < end) {
+                    var start = reader.pos;
                     var tag = reader.uint32();
                     if (tag === _end) {
                         _end = undefined;
@@ -2487,6 +2557,8 @@ $root.jspb = (function() {
                         }
                     default:
                         reader.skipType(tag & 7, _depth, tag >>> 3);
+                        $util.makeProp(message, "$unknowns", false);
+                        (message.$unknowns || (message.$unknowns = [])).push(reader.raw(start, reader.pos));
                         break;
                     }
                 }
@@ -2677,6 +2749,7 @@ $root.jspb = (function() {
                  * @memberof jspb.test.Complex
                  * @interface INested
                  * @property {number} anInt Nested anInt
+                 * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
                  */
 
                 /**
@@ -2686,6 +2759,7 @@ $root.jspb = (function() {
                  * @implements INested
                  * @constructor
                  * @param {jspb.test.Complex.INested=} [properties] Properties to set
+                 * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
                  */
                 function Nested(properties) {
                     if (properties)
@@ -2727,6 +2801,9 @@ $root.jspb = (function() {
                     if (!writer)
                         writer = $Writer.create();
                     writer.uint32(/* id 2, wireType 0 =*/16).int32(message.anInt);
+                    if (message.$unknowns != null && Object.hasOwnProperty.call(message, "$unknowns"))
+                        for (var i = 0; i < message.$unknowns.length; ++i)
+                            writer.raw(message.$unknowns[i]);
                     return writer;
                 };
 
@@ -2763,6 +2840,7 @@ $root.jspb = (function() {
                         throw Error("max depth exceeded");
                     var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.jspb.test.Complex.Nested();
                     while (reader.pos < end) {
+                        var start = reader.pos;
                         var tag = reader.uint32();
                         if (tag === _end) {
                             _end = undefined;
@@ -2775,6 +2853,8 @@ $root.jspb = (function() {
                             }
                         default:
                             reader.skipType(tag & 7, _depth, tag >>> 3);
+                            $util.makeProp(message, "$unknowns", false);
+                            (message.$unknowns || (message.$unknowns = [])).push(reader.raw(start, reader.pos));
                             break;
                         }
                     }
@@ -2900,6 +2980,7 @@ $root.jspb = (function() {
              * Properties of an OuterMessage.
              * @memberof jspb.test
              * @interface IOuterMessage
+             * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
              */
 
             /**
@@ -2909,6 +2990,7 @@ $root.jspb = (function() {
              * @implements IOuterMessage
              * @constructor
              * @param {jspb.test.IOuterMessage=} [properties] Properties to set
+             * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
              */
             function OuterMessage(properties) {
                 if (properties)
@@ -2941,6 +3023,9 @@ $root.jspb = (function() {
             OuterMessage.encode = function encode(message, writer) {
                 if (!writer)
                     writer = $Writer.create();
+                if (message.$unknowns != null && Object.hasOwnProperty.call(message, "$unknowns"))
+                    for (var i = 0; i < message.$unknowns.length; ++i)
+                        writer.raw(message.$unknowns[i]);
                 return writer;
             };
 
@@ -2977,6 +3062,7 @@ $root.jspb = (function() {
                     throw Error("max depth exceeded");
                 var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.jspb.test.OuterMessage();
                 while (reader.pos < end) {
+                    var start = reader.pos;
                     var tag = reader.uint32();
                     if (tag === _end) {
                         _end = undefined;
@@ -2985,6 +3071,8 @@ $root.jspb = (function() {
                     switch (tag) {
                     default:
                         reader.skipType(tag & 7, _depth, tag >>> 3);
+                        $util.makeProp(message, "$unknowns", false);
+                        (message.$unknowns || (message.$unknowns = [])).push(reader.raw(start, reader.pos));
                         break;
                     }
                 }
@@ -3091,6 +3179,7 @@ $root.jspb = (function() {
                  * @memberof jspb.test.OuterMessage
                  * @interface IComplex
                  * @property {number|null} [innerComplexField] Complex innerComplexField
+                 * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
                  */
 
                 /**
@@ -3100,6 +3189,7 @@ $root.jspb = (function() {
                  * @implements IComplex
                  * @constructor
                  * @param {jspb.test.OuterMessage.IComplex=} [properties] Properties to set
+                 * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
                  */
                 function Complex(properties) {
                     if (properties)
@@ -3142,6 +3232,9 @@ $root.jspb = (function() {
                         writer = $Writer.create();
                     if (message.innerComplexField != null && Object.hasOwnProperty.call(message, "innerComplexField"))
                         writer.uint32(/* id 1, wireType 0 =*/8).int32(message.innerComplexField);
+                    if (message.$unknowns != null && Object.hasOwnProperty.call(message, "$unknowns"))
+                        for (var i = 0; i < message.$unknowns.length; ++i)
+                            writer.raw(message.$unknowns[i]);
                     return writer;
                 };
 
@@ -3178,6 +3271,7 @@ $root.jspb = (function() {
                         throw Error("max depth exceeded");
                     var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.jspb.test.OuterMessage.Complex();
                     while (reader.pos < end) {
+                        var start = reader.pos;
                         var tag = reader.uint32();
                         if (tag === _end) {
                             _end = undefined;
@@ -3190,6 +3284,8 @@ $root.jspb = (function() {
                             }
                         default:
                             reader.skipType(tag & 7, _depth, tag >>> 3);
+                            $util.makeProp(message, "$unknowns", false);
+                            (message.$unknowns || (message.$unknowns = [])).push(reader.raw(start, reader.pos));
                             break;
                         }
                     }
@@ -3315,6 +3411,7 @@ $root.jspb = (function() {
              * @memberof jspb.test
              * @interface IIsExtension
              * @property {string|null} [ext1] IsExtension ext1
+             * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
              */
 
             /**
@@ -3324,6 +3421,7 @@ $root.jspb = (function() {
              * @implements IIsExtension
              * @constructor
              * @param {jspb.test.IIsExtension=} [properties] Properties to set
+             * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
              */
             function IsExtension(properties) {
                 if (properties)
@@ -3366,6 +3464,9 @@ $root.jspb = (function() {
                     writer = $Writer.create();
                 if (message.ext1 != null && Object.hasOwnProperty.call(message, "ext1"))
                     writer.uint32(/* id 1, wireType 2 =*/10).string(message.ext1);
+                if (message.$unknowns != null && Object.hasOwnProperty.call(message, "$unknowns"))
+                    for (var i = 0; i < message.$unknowns.length; ++i)
+                        writer.raw(message.$unknowns[i]);
                 return writer;
             };
 
@@ -3402,6 +3503,7 @@ $root.jspb = (function() {
                     throw Error("max depth exceeded");
                 var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.jspb.test.IsExtension();
                 while (reader.pos < end) {
+                    var start = reader.pos;
                     var tag = reader.uint32();
                     if (tag === _end) {
                         _end = undefined;
@@ -3414,6 +3516,8 @@ $root.jspb = (function() {
                         }
                     default:
                         reader.skipType(tag & 7, _depth, tag >>> 3);
+                        $util.makeProp(message, "$unknowns", false);
+                        (message.$unknowns || (message.$unknowns = [])).push(reader.raw(start, reader.pos));
                         break;
                     }
                 }
@@ -3535,6 +3639,7 @@ $root.jspb = (function() {
              * Properties of an IndirectExtension.
              * @memberof jspb.test
              * @interface IIndirectExtension
+             * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
              */
 
             /**
@@ -3544,6 +3649,7 @@ $root.jspb = (function() {
              * @implements IIndirectExtension
              * @constructor
              * @param {jspb.test.IIndirectExtension=} [properties] Properties to set
+             * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
              */
             function IndirectExtension(properties) {
                 if (properties)
@@ -3576,6 +3682,9 @@ $root.jspb = (function() {
             IndirectExtension.encode = function encode(message, writer) {
                 if (!writer)
                     writer = $Writer.create();
+                if (message.$unknowns != null && Object.hasOwnProperty.call(message, "$unknowns"))
+                    for (var i = 0; i < message.$unknowns.length; ++i)
+                        writer.raw(message.$unknowns[i]);
                 return writer;
             };
 
@@ -3612,6 +3721,7 @@ $root.jspb = (function() {
                     throw Error("max depth exceeded");
                 var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.jspb.test.IndirectExtension();
                 while (reader.pos < end) {
+                    var start = reader.pos;
                     var tag = reader.uint32();
                     if (tag === _end) {
                         _end = undefined;
@@ -3620,6 +3730,8 @@ $root.jspb = (function() {
                     switch (tag) {
                     default:
                         reader.skipType(tag & 7, _depth, tag >>> 3);
+                        $util.makeProp(message, "$unknowns", false);
+                        (message.$unknowns || (message.$unknowns = [])).push(reader.raw(start, reader.pos));
                         break;
                     }
                 }
@@ -3734,6 +3846,7 @@ $root.jspb = (function() {
              * @property {jspb.test.DefaultValues.Enum|null} [enumField] DefaultValues enumField
              * @property {string|null} [emptyField] DefaultValues emptyField
              * @property {Uint8Array|null} [bytesField] DefaultValues bytesField
+             * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
              */
 
             /**
@@ -3743,6 +3856,7 @@ $root.jspb = (function() {
              * @implements IDefaultValues
              * @constructor
              * @param {jspb.test.IDefaultValues=} [properties] Properties to set
+             * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
              */
             function DefaultValues(properties) {
                 if (properties)
@@ -3835,6 +3949,9 @@ $root.jspb = (function() {
                     writer.uint32(/* id 6, wireType 2 =*/50).string(message.emptyField);
                 if (message.bytesField != null && Object.hasOwnProperty.call(message, "bytesField"))
                     writer.uint32(/* id 8, wireType 2 =*/66).bytes(message.bytesField);
+                if (message.$unknowns != null && Object.hasOwnProperty.call(message, "$unknowns"))
+                    for (var i = 0; i < message.$unknowns.length; ++i)
+                        writer.raw(message.$unknowns[i]);
                 return writer;
             };
 
@@ -3871,6 +3988,7 @@ $root.jspb = (function() {
                     throw Error("max depth exceeded");
                 var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.jspb.test.DefaultValues();
                 while (reader.pos < end) {
+                    var start = reader.pos;
                     var tag = reader.uint32();
                     if (tag === _end) {
                         _end = undefined;
@@ -3903,6 +4021,8 @@ $root.jspb = (function() {
                         }
                     default:
                         reader.skipType(tag & 7, _depth, tag >>> 3);
+                        $util.makeProp(message, "$unknowns", false);
+                        (message.$unknowns || (message.$unknowns = [])).push(reader.raw(start, reader.pos));
                         break;
                     }
                 }
@@ -4133,6 +4253,7 @@ $root.jspb = (function() {
              * @property {number} requiredDoubleField FloatingPointFields requiredDoubleField
              * @property {Array.<number>|null} [repeatedDoubleField] FloatingPointFields repeatedDoubleField
              * @property {number|null} [defaultDoubleField] FloatingPointFields defaultDoubleField
+             * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
              */
 
             /**
@@ -4142,6 +4263,7 @@ $root.jspb = (function() {
              * @implements IFloatingPointFields
              * @constructor
              * @param {jspb.test.IFloatingPointFields=} [properties] Properties to set
+             * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
              */
             function FloatingPointFields(properties) {
                 this.repeatedFloatField = [];
@@ -4256,6 +4378,9 @@ $root.jspb = (function() {
                         writer.uint32(/* id 7, wireType 1 =*/57).double(message.repeatedDoubleField[i]);
                 if (message.defaultDoubleField != null && Object.hasOwnProperty.call(message, "defaultDoubleField"))
                     writer.uint32(/* id 8, wireType 1 =*/65).double(message.defaultDoubleField);
+                if (message.$unknowns != null && Object.hasOwnProperty.call(message, "$unknowns"))
+                    for (var i = 0; i < message.$unknowns.length; ++i)
+                        writer.raw(message.$unknowns[i]);
                 return writer;
             };
 
@@ -4292,6 +4417,7 @@ $root.jspb = (function() {
                     throw Error("max depth exceeded");
                 var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.jspb.test.FloatingPointFields();
                 while (reader.pos < end) {
+                    var start = reader.pos;
                     var tag = reader.uint32();
                     if (tag === _end) {
                         _end = undefined;
@@ -4348,6 +4474,8 @@ $root.jspb = (function() {
                         }
                     default:
                         reader.skipType(tag & 7, _depth, tag >>> 3);
+                        $util.makeProp(message, "$unknowns", false);
+                        (message.$unknowns || (message.$unknowns = [])).push(reader.raw(start, reader.pos));
                         break;
                     }
                 }
@@ -4560,6 +4688,7 @@ $root.jspb = (function() {
              * @property {Uint8Array|null} [bytesField] TestClone bytesField
              * @property {string|null} [unused] TestClone unused
              * @property {jspb.test.ICloneExtension|null} [".jspb.test.CloneExtension.extField"] TestClone .jspb.test.CloneExtension.extField
+             * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
              */
 
             /**
@@ -4570,6 +4699,7 @@ $root.jspb = (function() {
              * @constructor
              * @param {jspb.test.ITestClone=} [properties] Properties to set
              * @property {jspb.test.ICloneExtension|null} [".jspb.test.CloneExtension.extField"] TestClone .jspb.test.CloneExtension.extField
+             * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
              */
             function TestClone(properties) {
                 this.simple2 = [];
@@ -4658,6 +4788,9 @@ $root.jspb = (function() {
                     writer.uint32(/* id 7, wireType 2 =*/58).string(message.unused);
                 if (message[".jspb.test.CloneExtension.extField"] != null && Object.hasOwnProperty.call(message, ".jspb.test.CloneExtension.extField"))
                     $root.jspb.test.CloneExtension.encode(message[".jspb.test.CloneExtension.extField"], writer.uint32(/* id 100, wireType 2 =*/802).fork()).ldelim();
+                if (message.$unknowns != null && Object.hasOwnProperty.call(message, "$unknowns"))
+                    for (var i = 0; i < message.$unknowns.length; ++i)
+                        writer.raw(message.$unknowns[i]);
                 return writer;
             };
 
@@ -4694,6 +4827,7 @@ $root.jspb = (function() {
                     throw Error("max depth exceeded");
                 var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.jspb.test.TestClone();
                 while (reader.pos < end) {
+                    var start = reader.pos;
                     var tag = reader.uint32();
                     if (tag === _end) {
                         _end = undefined;
@@ -4728,6 +4862,8 @@ $root.jspb = (function() {
                         }
                     default:
                         reader.skipType(tag & 7, _depth, tag >>> 3);
+                        $util.makeProp(message, "$unknowns", false);
+                        (message.$unknowns || (message.$unknowns = [])).push(reader.raw(start, reader.pos));
                         break;
                     }
                 }
@@ -4928,6 +5064,7 @@ $root.jspb = (function() {
              * @memberof jspb.test
              * @interface ICloneExtension
              * @property {string|null} [ext] CloneExtension ext
+             * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
              */
 
             /**
@@ -4937,6 +5074,7 @@ $root.jspb = (function() {
              * @implements ICloneExtension
              * @constructor
              * @param {jspb.test.ICloneExtension=} [properties] Properties to set
+             * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
              */
             function CloneExtension(properties) {
                 if (properties)
@@ -4979,6 +5117,9 @@ $root.jspb = (function() {
                     writer = $Writer.create();
                 if (message.ext != null && Object.hasOwnProperty.call(message, "ext"))
                     writer.uint32(/* id 2, wireType 2 =*/18).string(message.ext);
+                if (message.$unknowns != null && Object.hasOwnProperty.call(message, "$unknowns"))
+                    for (var i = 0; i < message.$unknowns.length; ++i)
+                        writer.raw(message.$unknowns[i]);
                 return writer;
             };
 
@@ -5015,6 +5156,7 @@ $root.jspb = (function() {
                     throw Error("max depth exceeded");
                 var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.jspb.test.CloneExtension();
                 while (reader.pos < end) {
+                    var start = reader.pos;
                     var tag = reader.uint32();
                     if (tag === _end) {
                         _end = undefined;
@@ -5027,6 +5169,8 @@ $root.jspb = (function() {
                         }
                     default:
                         reader.skipType(tag & 7, _depth, tag >>> 3);
+                        $util.makeProp(message, "$unknowns", false);
+                        (message.$unknowns || (message.$unknowns = [])).push(reader.raw(start, reader.pos));
                         break;
                     }
                 }
@@ -5156,6 +5300,7 @@ $root.jspb = (function() {
              * @property {string|null} [id] TestGroup id
              * @property {jspb.test.ISimple2} requiredSimple TestGroup requiredSimple
              * @property {jspb.test.ISimple2|null} [optionalSimple] TestGroup optionalSimple
+             * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
              */
 
             /**
@@ -5165,6 +5310,7 @@ $root.jspb = (function() {
              * @implements ITestGroup
              * @constructor
              * @param {jspb.test.ITestGroup=} [properties] Properties to set
+             * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
              */
             function TestGroup(properties) {
                 this.repeatedGroup = [];
@@ -5277,6 +5423,9 @@ $root.jspb = (function() {
                 $root.jspb.test.Simple2.encode(message.requiredSimple, writer.uint32(/* id 7, wireType 2 =*/58).fork()).ldelim();
                 if (message.optionalSimple != null && Object.hasOwnProperty.call(message, "optionalSimple"))
                     $root.jspb.test.Simple2.encode(message.optionalSimple, writer.uint32(/* id 8, wireType 2 =*/66).fork()).ldelim();
+                if (message.$unknowns != null && Object.hasOwnProperty.call(message, "$unknowns"))
+                    for (var i = 0; i < message.$unknowns.length; ++i)
+                        writer.raw(message.$unknowns[i]);
                 return writer;
             };
 
@@ -5313,6 +5462,7 @@ $root.jspb = (function() {
                     throw Error("max depth exceeded");
                 var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.jspb.test.TestGroup();
                 while (reader.pos < end) {
+                    var start = reader.pos;
                     var tag = reader.uint32();
                     if (tag === _end) {
                         _end = undefined;
@@ -5355,6 +5505,8 @@ $root.jspb = (function() {
                         }
                     default:
                         reader.skipType(tag & 7, _depth, tag >>> 3);
+                        $util.makeProp(message, "$unknowns", false);
+                        (message.$unknowns || (message.$unknowns = [])).push(reader.raw(start, reader.pos));
                         break;
                     }
                 }
@@ -5584,6 +5736,7 @@ $root.jspb = (function() {
                  * @interface IRepeatedGroup
                  * @property {string} id RepeatedGroup id
                  * @property {Array.<boolean>|null} [someBool] RepeatedGroup someBool
+                 * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
                  */
 
                 /**
@@ -5593,6 +5746,7 @@ $root.jspb = (function() {
                  * @implements IRepeatedGroup
                  * @constructor
                  * @param {jspb.test.TestGroup.IRepeatedGroup=} [properties] Properties to set
+                 * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
                  */
                 function RepeatedGroup(properties) {
                     this.someBool = [];
@@ -5646,6 +5800,9 @@ $root.jspb = (function() {
                     if (message.someBool != null && message.someBool.length)
                         for (var i = 0; i < message.someBool.length; ++i)
                             writer.uint32(/* id 2, wireType 0 =*/16).bool(message.someBool[i]);
+                    if (message.$unknowns != null && Object.hasOwnProperty.call(message, "$unknowns"))
+                        for (var i = 0; i < message.$unknowns.length; ++i)
+                            writer.raw(message.$unknowns[i]);
                     return writer;
                 };
 
@@ -5682,6 +5839,7 @@ $root.jspb = (function() {
                         throw Error("max depth exceeded");
                     var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.jspb.test.TestGroup.RepeatedGroup();
                     while (reader.pos < end) {
+                        var start = reader.pos;
                         var tag = reader.uint32();
                         if (tag === _end) {
                             _end = undefined;
@@ -5706,6 +5864,8 @@ $root.jspb = (function() {
                             }
                         default:
                             reader.skipType(tag & 7, _depth, tag >>> 3);
+                            $util.makeProp(message, "$unknowns", false);
+                            (message.$unknowns || (message.$unknowns = [])).push(reader.raw(start, reader.pos));
                             break;
                         }
                     }
@@ -5850,6 +6010,7 @@ $root.jspb = (function() {
                  * @memberof jspb.test.TestGroup
                  * @interface IRequiredGroup
                  * @property {string} id RequiredGroup id
+                 * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
                  */
 
                 /**
@@ -5859,6 +6020,7 @@ $root.jspb = (function() {
                  * @implements IRequiredGroup
                  * @constructor
                  * @param {jspb.test.TestGroup.IRequiredGroup=} [properties] Properties to set
+                 * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
                  */
                 function RequiredGroup(properties) {
                     if (properties)
@@ -5900,6 +6062,9 @@ $root.jspb = (function() {
                     if (!writer)
                         writer = $Writer.create();
                     writer.uint32(/* id 1, wireType 2 =*/10).string(message.id);
+                    if (message.$unknowns != null && Object.hasOwnProperty.call(message, "$unknowns"))
+                        for (var i = 0; i < message.$unknowns.length; ++i)
+                            writer.raw(message.$unknowns[i]);
                     return writer;
                 };
 
@@ -5936,6 +6101,7 @@ $root.jspb = (function() {
                         throw Error("max depth exceeded");
                     var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.jspb.test.TestGroup.RequiredGroup();
                     while (reader.pos < end) {
+                        var start = reader.pos;
                         var tag = reader.uint32();
                         if (tag === _end) {
                             _end = undefined;
@@ -5948,6 +6114,8 @@ $root.jspb = (function() {
                             }
                         default:
                             reader.skipType(tag & 7, _depth, tag >>> 3);
+                            $util.makeProp(message, "$unknowns", false);
+                            (message.$unknowns || (message.$unknowns = [])).push(reader.raw(start, reader.pos));
                             break;
                         }
                     }
@@ -6071,6 +6239,7 @@ $root.jspb = (function() {
                  * @memberof jspb.test.TestGroup
                  * @interface IOptionalGroup
                  * @property {string} id OptionalGroup id
+                 * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
                  */
 
                 /**
@@ -6080,6 +6249,7 @@ $root.jspb = (function() {
                  * @implements IOptionalGroup
                  * @constructor
                  * @param {jspb.test.TestGroup.IOptionalGroup=} [properties] Properties to set
+                 * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
                  */
                 function OptionalGroup(properties) {
                     if (properties)
@@ -6121,6 +6291,9 @@ $root.jspb = (function() {
                     if (!writer)
                         writer = $Writer.create();
                     writer.uint32(/* id 1, wireType 2 =*/10).string(message.id);
+                    if (message.$unknowns != null && Object.hasOwnProperty.call(message, "$unknowns"))
+                        for (var i = 0; i < message.$unknowns.length; ++i)
+                            writer.raw(message.$unknowns[i]);
                     return writer;
                 };
 
@@ -6157,6 +6330,7 @@ $root.jspb = (function() {
                         throw Error("max depth exceeded");
                     var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.jspb.test.TestGroup.OptionalGroup();
                     while (reader.pos < end) {
+                        var start = reader.pos;
                         var tag = reader.uint32();
                         if (tag === _end) {
                             _end = undefined;
@@ -6169,6 +6343,8 @@ $root.jspb = (function() {
                             }
                         default:
                             reader.skipType(tag & 7, _depth, tag >>> 3);
+                            $util.makeProp(message, "$unknowns", false);
+                            (message.$unknowns || (message.$unknowns = [])).push(reader.raw(start, reader.pos));
                             break;
                         }
                     }
@@ -6292,6 +6468,7 @@ $root.jspb = (function() {
                  * @memberof jspb.test.TestGroup
                  * @interface IMessageInGroup
                  * @property {jspb.test.TestGroup.MessageInGroup.INestedMessage} id MessageInGroup id
+                 * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
                  */
 
                 /**
@@ -6301,6 +6478,7 @@ $root.jspb = (function() {
                  * @implements IMessageInGroup
                  * @constructor
                  * @param {jspb.test.TestGroup.IMessageInGroup=} [properties] Properties to set
+                 * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
                  */
                 function MessageInGroup(properties) {
                     if (properties)
@@ -6342,6 +6520,9 @@ $root.jspb = (function() {
                     if (!writer)
                         writer = $Writer.create();
                     $root.jspb.test.TestGroup.MessageInGroup.NestedMessage.encode(message.id, writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
+                    if (message.$unknowns != null && Object.hasOwnProperty.call(message, "$unknowns"))
+                        for (var i = 0; i < message.$unknowns.length; ++i)
+                            writer.raw(message.$unknowns[i]);
                     return writer;
                 };
 
@@ -6378,6 +6559,7 @@ $root.jspb = (function() {
                         throw Error("max depth exceeded");
                     var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.jspb.test.TestGroup.MessageInGroup();
                     while (reader.pos < end) {
+                        var start = reader.pos;
                         var tag = reader.uint32();
                         if (tag === _end) {
                             _end = undefined;
@@ -6390,6 +6572,8 @@ $root.jspb = (function() {
                             }
                         default:
                             reader.skipType(tag & 7, _depth, tag >>> 3);
+                            $util.makeProp(message, "$unknowns", false);
+                            (message.$unknowns || (message.$unknowns = [])).push(reader.raw(start, reader.pos));
                             break;
                         }
                     }
@@ -6516,6 +6700,7 @@ $root.jspb = (function() {
                      * @memberof jspb.test.TestGroup.MessageInGroup
                      * @interface INestedMessage
                      * @property {string|null} [id] NestedMessage id
+                     * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
                      */
 
                     /**
@@ -6525,6 +6710,7 @@ $root.jspb = (function() {
                      * @implements INestedMessage
                      * @constructor
                      * @param {jspb.test.TestGroup.MessageInGroup.INestedMessage=} [properties] Properties to set
+                     * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
                      */
                     function NestedMessage(properties) {
                         if (properties)
@@ -6567,6 +6753,9 @@ $root.jspb = (function() {
                             writer = $Writer.create();
                         if (message.id != null && Object.hasOwnProperty.call(message, "id"))
                             writer.uint32(/* id 1, wireType 2 =*/10).string(message.id);
+                        if (message.$unknowns != null && Object.hasOwnProperty.call(message, "$unknowns"))
+                            for (var i = 0; i < message.$unknowns.length; ++i)
+                                writer.raw(message.$unknowns[i]);
                         return writer;
                     };
 
@@ -6603,6 +6792,7 @@ $root.jspb = (function() {
                             throw Error("max depth exceeded");
                         var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.jspb.test.TestGroup.MessageInGroup.NestedMessage();
                         while (reader.pos < end) {
+                            var start = reader.pos;
                             var tag = reader.uint32();
                             if (tag === _end) {
                                 _end = undefined;
@@ -6615,6 +6805,8 @@ $root.jspb = (function() {
                                 }
                             default:
                                 reader.skipType(tag & 7, _depth, tag >>> 3);
+                                $util.makeProp(message, "$unknowns", false);
+                                (message.$unknowns || (message.$unknowns = [])).push(reader.raw(start, reader.pos));
                                 break;
                             }
                         }
@@ -6740,6 +6932,7 @@ $root.jspb = (function() {
                  * @memberof jspb.test.TestGroup
                  * @interface IEnumInGroup
                  * @property {jspb.test.TestGroup.EnumInGroup.NestedEnum} id EnumInGroup id
+                 * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
                  */
 
                 /**
@@ -6749,6 +6942,7 @@ $root.jspb = (function() {
                  * @implements IEnumInGroup
                  * @constructor
                  * @param {jspb.test.TestGroup.IEnumInGroup=} [properties] Properties to set
+                 * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
                  */
                 function EnumInGroup(properties) {
                     if (properties)
@@ -6790,6 +6984,9 @@ $root.jspb = (function() {
                     if (!writer)
                         writer = $Writer.create();
                     writer.uint32(/* id 1, wireType 0 =*/8).int32(message.id);
+                    if (message.$unknowns != null && Object.hasOwnProperty.call(message, "$unknowns"))
+                        for (var i = 0; i < message.$unknowns.length; ++i)
+                            writer.raw(message.$unknowns[i]);
                     return writer;
                 };
 
@@ -6826,6 +7023,7 @@ $root.jspb = (function() {
                         throw Error("max depth exceeded");
                     var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.jspb.test.TestGroup.EnumInGroup();
                     while (reader.pos < end) {
+                        var start = reader.pos;
                         var tag = reader.uint32();
                         if (tag === _end) {
                             _end = undefined;
@@ -6838,6 +7036,8 @@ $root.jspb = (function() {
                             }
                         default:
                             reader.skipType(tag & 7, _depth, tag >>> 3);
+                            $util.makeProp(message, "$unknowns", false);
+                            (message.$unknowns || (message.$unknowns = [])).push(reader.raw(start, reader.pos));
                             break;
                         }
                     }
@@ -6997,6 +7197,7 @@ $root.jspb = (function() {
              * @memberof jspb.test
              * @interface ITestGroup1
              * @property {jspb.test.TestGroup.IRepeatedGroup|null} [group] TestGroup1 group
+             * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
              */
 
             /**
@@ -7006,6 +7207,7 @@ $root.jspb = (function() {
              * @implements ITestGroup1
              * @constructor
              * @param {jspb.test.ITestGroup1=} [properties] Properties to set
+             * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
              */
             function TestGroup1(properties) {
                 if (properties)
@@ -7048,6 +7250,9 @@ $root.jspb = (function() {
                     writer = $Writer.create();
                 if (message.group != null && Object.hasOwnProperty.call(message, "group"))
                     $root.jspb.test.TestGroup.RepeatedGroup.encode(message.group, writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
+                if (message.$unknowns != null && Object.hasOwnProperty.call(message, "$unknowns"))
+                    for (var i = 0; i < message.$unknowns.length; ++i)
+                        writer.raw(message.$unknowns[i]);
                 return writer;
             };
 
@@ -7084,6 +7289,7 @@ $root.jspb = (function() {
                     throw Error("max depth exceeded");
                 var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.jspb.test.TestGroup1();
                 while (reader.pos < end) {
+                    var start = reader.pos;
                     var tag = reader.uint32();
                     if (tag === _end) {
                         _end = undefined;
@@ -7096,6 +7302,8 @@ $root.jspb = (function() {
                         }
                     default:
                         reader.skipType(tag & 7, _depth, tag >>> 3);
+                        $util.makeProp(message, "$unknowns", false);
+                        (message.$unknowns || (message.$unknowns = [])).push(reader.raw(start, reader.pos));
                         break;
                     }
                 }
@@ -7224,6 +7432,7 @@ $root.jspb = (function() {
              * @interface ITestReservedNames
              * @property {number|null} [extension] TestReservedNames extension
              * @property {number|null} [".jspb.test.TestReservedNamesExtension.foo"] TestReservedNames .jspb.test.TestReservedNamesExtension.foo
+             * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
              */
 
             /**
@@ -7234,6 +7443,7 @@ $root.jspb = (function() {
              * @constructor
              * @param {jspb.test.ITestReservedNames=} [properties] Properties to set
              * @property {number} ".jspb.test.TestReservedNamesExtension.foo" TestReservedNames .jspb.test.TestReservedNamesExtension.foo
+             * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
              */
             function TestReservedNames(properties) {
                 if (properties)
@@ -7280,6 +7490,9 @@ $root.jspb = (function() {
                     writer.uint32(/* id 1, wireType 0 =*/8).int32(message.extension);
                 if (message[".jspb.test.TestReservedNamesExtension.foo"] != null && Object.hasOwnProperty.call(message, ".jspb.test.TestReservedNamesExtension.foo"))
                     writer.uint32(/* id 10, wireType 0 =*/80).int32(message[".jspb.test.TestReservedNamesExtension.foo"]);
+                if (message.$unknowns != null && Object.hasOwnProperty.call(message, "$unknowns"))
+                    for (var i = 0; i < message.$unknowns.length; ++i)
+                        writer.raw(message.$unknowns[i]);
                 return writer;
             };
 
@@ -7316,6 +7529,7 @@ $root.jspb = (function() {
                     throw Error("max depth exceeded");
                 var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.jspb.test.TestReservedNames();
                 while (reader.pos < end) {
+                    var start = reader.pos;
                     var tag = reader.uint32();
                     if (tag === _end) {
                         _end = undefined;
@@ -7332,6 +7546,8 @@ $root.jspb = (function() {
                         }
                     default:
                         reader.skipType(tag & 7, _depth, tag >>> 3);
+                        $util.makeProp(message, "$unknowns", false);
+                        (message.$unknowns || (message.$unknowns = [])).push(reader.raw(start, reader.pos));
                         break;
                     }
                 }
@@ -7462,6 +7678,7 @@ $root.jspb = (function() {
              * Properties of a TestReservedNamesExtension.
              * @memberof jspb.test
              * @interface ITestReservedNamesExtension
+             * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
              */
 
             /**
@@ -7471,6 +7688,7 @@ $root.jspb = (function() {
              * @implements ITestReservedNamesExtension
              * @constructor
              * @param {jspb.test.ITestReservedNamesExtension=} [properties] Properties to set
+             * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
              */
             function TestReservedNamesExtension(properties) {
                 if (properties)
@@ -7503,6 +7721,9 @@ $root.jspb = (function() {
             TestReservedNamesExtension.encode = function encode(message, writer) {
                 if (!writer)
                     writer = $Writer.create();
+                if (message.$unknowns != null && Object.hasOwnProperty.call(message, "$unknowns"))
+                    for (var i = 0; i < message.$unknowns.length; ++i)
+                        writer.raw(message.$unknowns[i]);
                 return writer;
             };
 
@@ -7539,6 +7760,7 @@ $root.jspb = (function() {
                     throw Error("max depth exceeded");
                 var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.jspb.test.TestReservedNamesExtension();
                 while (reader.pos < end) {
+                    var start = reader.pos;
                     var tag = reader.uint32();
                     if (tag === _end) {
                         _end = undefined;
@@ -7547,6 +7769,8 @@ $root.jspb = (function() {
                     switch (tag) {
                     default:
                         reader.skipType(tag & 7, _depth, tag >>> 3);
+                        $util.makeProp(message, "$unknowns", false);
+                        (message.$unknowns || (message.$unknowns = [])).push(reader.raw(start, reader.pos));
                         break;
                     }
                 }
@@ -7665,6 +7889,7 @@ $root.jspb = (function() {
              * @property {number|null} [atwo] TestMessageWithOneof atwo
              * @property {number|null} [bone] TestMessageWithOneof bone
              * @property {number|null} [btwo] TestMessageWithOneof btwo
+             * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
              */
 
             /**
@@ -7674,6 +7899,7 @@ $root.jspb = (function() {
              * @implements ITestMessageWithOneof
              * @constructor
              * @param {jspb.test.ITestMessageWithOneof=} [properties] Properties to set
+             * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
              */
             function TestMessageWithOneof(properties) {
                 this.repeatedField = [];
@@ -7855,6 +8081,9 @@ $root.jspb = (function() {
                     writer.uint32(/* id 12, wireType 0 =*/96).int32(message.bone);
                 if (message.btwo != null && Object.hasOwnProperty.call(message, "btwo"))
                     writer.uint32(/* id 13, wireType 0 =*/104).int32(message.btwo);
+                if (message.$unknowns != null && Object.hasOwnProperty.call(message, "$unknowns"))
+                    for (var i = 0; i < message.$unknowns.length; ++i)
+                        writer.raw(message.$unknowns[i]);
                 return writer;
             };
 
@@ -7891,6 +8120,7 @@ $root.jspb = (function() {
                     throw Error("max depth exceeded");
                 var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.jspb.test.TestMessageWithOneof();
                 while (reader.pos < end) {
+                    var start = reader.pos;
                     var tag = reader.uint32();
                     if (tag === _end) {
                         _end = undefined;
@@ -7949,6 +8179,8 @@ $root.jspb = (function() {
                         }
                     default:
                         reader.skipType(tag & 7, _depth, tag >>> 3);
+                        $util.makeProp(message, "$unknowns", false);
+                        (message.$unknowns || (message.$unknowns = [])).push(reader.raw(start, reader.pos));
                         break;
                     }
                 }
@@ -8204,6 +8436,7 @@ $root.jspb = (function() {
              * @interface ITestEndsWithBytes
              * @property {number|null} [value] TestEndsWithBytes value
              * @property {Uint8Array|null} [data] TestEndsWithBytes data
+             * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
              */
 
             /**
@@ -8213,6 +8446,7 @@ $root.jspb = (function() {
              * @implements ITestEndsWithBytes
              * @constructor
              * @param {jspb.test.ITestEndsWithBytes=} [properties] Properties to set
+             * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
              */
             function TestEndsWithBytes(properties) {
                 if (properties)
@@ -8265,6 +8499,9 @@ $root.jspb = (function() {
                     writer.uint32(/* id 1, wireType 0 =*/8).int32(message.value);
                 if (message.data != null && Object.hasOwnProperty.call(message, "data"))
                     writer.uint32(/* id 2, wireType 2 =*/18).bytes(message.data);
+                if (message.$unknowns != null && Object.hasOwnProperty.call(message, "$unknowns"))
+                    for (var i = 0; i < message.$unknowns.length; ++i)
+                        writer.raw(message.$unknowns[i]);
                 return writer;
             };
 
@@ -8301,6 +8538,7 @@ $root.jspb = (function() {
                     throw Error("max depth exceeded");
                 var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.jspb.test.TestEndsWithBytes();
                 while (reader.pos < end) {
+                    var start = reader.pos;
                     var tag = reader.uint32();
                     if (tag === _end) {
                         _end = undefined;
@@ -8317,6 +8555,8 @@ $root.jspb = (function() {
                         }
                     default:
                         reader.skipType(tag & 7, _depth, tag >>> 3);
+                        $util.makeProp(message, "$unknowns", false);
+                        (message.$unknowns || (message.$unknowns = [])).push(reader.raw(start, reader.pos));
                         break;
                     }
                 }
@@ -8468,6 +8708,7 @@ $root.jspb = (function() {
              * @property {Object.<string,string>|null} [mapBoolString] TestMapFieldsNoBinary mapBoolString
              * @property {jspb.test.ITestMapFieldsNoBinary|null} [testMapFields] TestMapFieldsNoBinary testMapFields
              * @property {Object.<string,jspb.test.ITestMapFieldsNoBinary>|null} [mapStringTestmapfields] TestMapFieldsNoBinary mapStringTestmapfields
+             * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
              */
 
             /**
@@ -8477,6 +8718,7 @@ $root.jspb = (function() {
              * @implements ITestMapFieldsNoBinary
              * @constructor
              * @param {jspb.test.ITestMapFieldsNoBinary=} [properties] Properties to set
+             * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
              */
             function TestMapFieldsNoBinary(properties) {
                 this.mapStringString = {};
@@ -8655,6 +8897,9 @@ $root.jspb = (function() {
                         writer.uint32(/* id 12, wireType 2 =*/98).fork().uint32(/* id 1, wireType 2 =*/10).string(keys[i]);
                         $root.jspb.test.TestMapFieldsNoBinary.encode(message.mapStringTestmapfields[keys[i]], writer.uint32(/* id 2, wireType 2 =*/18).fork()).ldelim().ldelim();
                     }
+                if (message.$unknowns != null && Object.hasOwnProperty.call(message, "$unknowns"))
+                    for (var i = 0; i < message.$unknowns.length; ++i)
+                        writer.raw(message.$unknowns[i]);
                 return writer;
             };
 
@@ -8691,6 +8936,7 @@ $root.jspb = (function() {
                     throw Error("max depth exceeded");
                 var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.jspb.test.TestMapFieldsNoBinary(), key, value;
                 while (reader.pos < end) {
+                    var start = reader.pos;
                     var tag = reader.uint32();
                     if (tag === _end) {
                         _end = undefined;
@@ -8972,6 +9218,8 @@ $root.jspb = (function() {
                         }
                     default:
                         reader.skipType(tag & 7, _depth, tag >>> 3);
+                        $util.makeProp(message, "$unknowns", false);
+                        (message.$unknowns || (message.$unknowns = [])).push(reader.raw(start, reader.pos));
                         break;
                     }
                 }
@@ -9468,6 +9716,7 @@ $root.jspb = (function() {
              * @memberof jspb.test
              * @interface IMapValueMessageNoBinary
              * @property {number|null} [foo] MapValueMessageNoBinary foo
+             * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
              */
 
             /**
@@ -9477,6 +9726,7 @@ $root.jspb = (function() {
              * @implements IMapValueMessageNoBinary
              * @constructor
              * @param {jspb.test.IMapValueMessageNoBinary=} [properties] Properties to set
+             * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
              */
             function MapValueMessageNoBinary(properties) {
                 if (properties)
@@ -9519,6 +9769,9 @@ $root.jspb = (function() {
                     writer = $Writer.create();
                 if (message.foo != null && Object.hasOwnProperty.call(message, "foo"))
                     writer.uint32(/* id 1, wireType 0 =*/8).int32(message.foo);
+                if (message.$unknowns != null && Object.hasOwnProperty.call(message, "$unknowns"))
+                    for (var i = 0; i < message.$unknowns.length; ++i)
+                        writer.raw(message.$unknowns[i]);
                 return writer;
             };
 
@@ -9555,6 +9808,7 @@ $root.jspb = (function() {
                     throw Error("max depth exceeded");
                 var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.jspb.test.MapValueMessageNoBinary();
                 while (reader.pos < end) {
+                    var start = reader.pos;
                     var tag = reader.uint32();
                     if (tag === _end) {
                         _end = undefined;
@@ -9567,6 +9821,8 @@ $root.jspb = (function() {
                         }
                     default:
                         reader.skipType(tag & 7, _depth, tag >>> 3);
+                        $util.makeProp(message, "$unknowns", false);
+                        (message.$unknowns || (message.$unknowns = [])).push(reader.raw(start, reader.pos));
                         break;
                     }
                 }
@@ -9688,6 +9944,7 @@ $root.jspb = (function() {
              * Properties of a Deeply.
              * @memberof jspb.test
              * @interface IDeeply
+             * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
              */
 
             /**
@@ -9697,6 +9954,7 @@ $root.jspb = (function() {
              * @implements IDeeply
              * @constructor
              * @param {jspb.test.IDeeply=} [properties] Properties to set
+             * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
              */
             function Deeply(properties) {
                 if (properties)
@@ -9729,6 +9987,9 @@ $root.jspb = (function() {
             Deeply.encode = function encode(message, writer) {
                 if (!writer)
                     writer = $Writer.create();
+                if (message.$unknowns != null && Object.hasOwnProperty.call(message, "$unknowns"))
+                    for (var i = 0; i < message.$unknowns.length; ++i)
+                        writer.raw(message.$unknowns[i]);
                 return writer;
             };
 
@@ -9765,6 +10026,7 @@ $root.jspb = (function() {
                     throw Error("max depth exceeded");
                 var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.jspb.test.Deeply();
                 while (reader.pos < end) {
+                    var start = reader.pos;
                     var tag = reader.uint32();
                     if (tag === _end) {
                         _end = undefined;
@@ -9773,6 +10035,8 @@ $root.jspb = (function() {
                     switch (tag) {
                     default:
                         reader.skipType(tag & 7, _depth, tag >>> 3);
+                        $util.makeProp(message, "$unknowns", false);
+                        (message.$unknowns || (message.$unknowns = [])).push(reader.raw(start, reader.pos));
                         break;
                     }
                 }
@@ -9878,6 +10142,7 @@ $root.jspb = (function() {
                  * Properties of a Nested.
                  * @memberof jspb.test.Deeply
                  * @interface INested
+                 * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
                  */
 
                 /**
@@ -9887,6 +10152,7 @@ $root.jspb = (function() {
                  * @implements INested
                  * @constructor
                  * @param {jspb.test.Deeply.INested=} [properties] Properties to set
+                 * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
                  */
                 function Nested(properties) {
                     if (properties)
@@ -9919,6 +10185,9 @@ $root.jspb = (function() {
                 Nested.encode = function encode(message, writer) {
                     if (!writer)
                         writer = $Writer.create();
+                    if (message.$unknowns != null && Object.hasOwnProperty.call(message, "$unknowns"))
+                        for (var i = 0; i < message.$unknowns.length; ++i)
+                            writer.raw(message.$unknowns[i]);
                     return writer;
                 };
 
@@ -9955,6 +10224,7 @@ $root.jspb = (function() {
                         throw Error("max depth exceeded");
                     var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.jspb.test.Deeply.Nested();
                     while (reader.pos < end) {
+                        var start = reader.pos;
                         var tag = reader.uint32();
                         if (tag === _end) {
                             _end = undefined;
@@ -9963,6 +10233,8 @@ $root.jspb = (function() {
                         switch (tag) {
                         default:
                             reader.skipType(tag & 7, _depth, tag >>> 3);
+                            $util.makeProp(message, "$unknowns", false);
+                            (message.$unknowns || (message.$unknowns = [])).push(reader.raw(start, reader.pos));
                             break;
                         }
                     }
@@ -10069,6 +10341,7 @@ $root.jspb = (function() {
                      * @memberof jspb.test.Deeply.Nested
                      * @interface IMessage
                      * @property {number|null} [count] Message count
+                     * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
                      */
 
                     /**
@@ -10078,6 +10351,7 @@ $root.jspb = (function() {
                      * @implements IMessage
                      * @constructor
                      * @param {jspb.test.Deeply.Nested.IMessage=} [properties] Properties to set
+                     * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
                      */
                     function Message(properties) {
                         if (properties)
@@ -10120,6 +10394,9 @@ $root.jspb = (function() {
                             writer = $Writer.create();
                         if (message.count != null && Object.hasOwnProperty.call(message, "count"))
                             writer.uint32(/* id 1, wireType 0 =*/8).int32(message.count);
+                        if (message.$unknowns != null && Object.hasOwnProperty.call(message, "$unknowns"))
+                            for (var i = 0; i < message.$unknowns.length; ++i)
+                                writer.raw(message.$unknowns[i]);
                         return writer;
                     };
 
@@ -10156,6 +10433,7 @@ $root.jspb = (function() {
                             throw Error("max depth exceeded");
                         var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.jspb.test.Deeply.Nested.Message();
                         while (reader.pos < end) {
+                            var start = reader.pos;
                             var tag = reader.uint32();
                             if (tag === _end) {
                                 _end = undefined;
@@ -10168,6 +10446,8 @@ $root.jspb = (function() {
                                 }
                             default:
                                 reader.skipType(tag & 7, _depth, tag >>> 3);
+                                $util.makeProp(message, "$unknowns", false);
+                                (message.$unknowns || (message.$unknowns = [])).push(reader.raw(start, reader.pos));
                                 break;
                             }
                         }
@@ -10320,6 +10600,7 @@ $root.google = (function() {
              * @memberof google.protobuf
              * @interface IFileDescriptorSet
              * @property {Array.<google.protobuf.IFileDescriptorProto>|null} [file] FileDescriptorSet file
+             * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
              */
 
             /**
@@ -10329,6 +10610,7 @@ $root.google = (function() {
              * @implements IFileDescriptorSet
              * @constructor
              * @param {google.protobuf.IFileDescriptorSet=} [properties] Properties to set
+             * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
              */
             function FileDescriptorSet(properties) {
                 this.file = [];
@@ -10373,6 +10655,9 @@ $root.google = (function() {
                 if (message.file != null && message.file.length)
                     for (var i = 0; i < message.file.length; ++i)
                         $root.google.protobuf.FileDescriptorProto.encode(message.file[i], writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
+                if (message.$unknowns != null && Object.hasOwnProperty.call(message, "$unknowns"))
+                    for (var i = 0; i < message.$unknowns.length; ++i)
+                        writer.raw(message.$unknowns[i]);
                 return writer;
             };
 
@@ -10409,6 +10694,7 @@ $root.google = (function() {
                     throw Error("max depth exceeded");
                 var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.google.protobuf.FileDescriptorSet();
                 while (reader.pos < end) {
+                    var start = reader.pos;
                     var tag = reader.uint32();
                     if (tag === _end) {
                         _end = undefined;
@@ -10423,6 +10709,8 @@ $root.google = (function() {
                         }
                     default:
                         reader.skipType(tag & 7, _depth, tag >>> 3);
+                        $util.makeProp(message, "$unknowns", false);
+                        (message.$unknowns || (message.$unknowns = [])).push(reader.raw(start, reader.pos));
                         break;
                     }
                 }
@@ -10609,6 +10897,7 @@ $root.google = (function() {
              * @property {google.protobuf.ISourceCodeInfo|null} [sourceCodeInfo] FileDescriptorProto sourceCodeInfo
              * @property {string|null} [syntax] FileDescriptorProto syntax
              * @property {google.protobuf.Edition|null} [edition] FileDescriptorProto edition
+             * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
              */
 
             /**
@@ -10618,6 +10907,7 @@ $root.google = (function() {
              * @implements IFileDescriptorProto
              * @constructor
              * @param {google.protobuf.IFileDescriptorProto=} [properties] Properties to set
+             * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
              */
             function FileDescriptorProto(properties) {
                 this.dependency = [];
@@ -10806,6 +11096,9 @@ $root.google = (function() {
                 if (message.optionDependency != null && message.optionDependency.length)
                     for (var i = 0; i < message.optionDependency.length; ++i)
                         writer.uint32(/* id 15, wireType 2 =*/122).string(message.optionDependency[i]);
+                if (message.$unknowns != null && Object.hasOwnProperty.call(message, "$unknowns"))
+                    for (var i = 0; i < message.$unknowns.length; ++i)
+                        writer.raw(message.$unknowns[i]);
                 return writer;
             };
 
@@ -10842,6 +11135,7 @@ $root.google = (function() {
                     throw Error("max depth exceeded");
                 var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.google.protobuf.FileDescriptorProto();
                 while (reader.pos < end) {
+                    var start = reader.pos;
                     var tag = reader.uint32();
                     if (tag === _end) {
                         _end = undefined;
@@ -10934,6 +11228,8 @@ $root.google = (function() {
                         }
                     default:
                         reader.skipType(tag & 7, _depth, tag >>> 3);
+                        $util.makeProp(message, "$unknowns", false);
+                        (message.$unknowns || (message.$unknowns = [])).push(reader.raw(start, reader.pos));
                         break;
                     }
                 }
@@ -11368,6 +11664,7 @@ $root.google = (function() {
              * @property {Array.<google.protobuf.DescriptorProto.IReservedRange>|null} [reservedRange] DescriptorProto reservedRange
              * @property {Array.<string>|null} [reservedName] DescriptorProto reservedName
              * @property {google.protobuf.SymbolVisibility|null} [visibility] DescriptorProto visibility
+             * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
              */
 
             /**
@@ -11377,6 +11674,7 @@ $root.google = (function() {
              * @implements IDescriptorProto
              * @constructor
              * @param {google.protobuf.IDescriptorProto=} [properties] Properties to set
+             * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
              */
             function DescriptorProto(properties) {
                 this.field = [];
@@ -11535,6 +11833,9 @@ $root.google = (function() {
                         writer.uint32(/* id 10, wireType 2 =*/82).string(message.reservedName[i]);
                 if (message.visibility != null && Object.hasOwnProperty.call(message, "visibility"))
                     writer.uint32(/* id 11, wireType 0 =*/88).int32(message.visibility);
+                if (message.$unknowns != null && Object.hasOwnProperty.call(message, "$unknowns"))
+                    for (var i = 0; i < message.$unknowns.length; ++i)
+                        writer.raw(message.$unknowns[i]);
                 return writer;
             };
 
@@ -11571,6 +11872,7 @@ $root.google = (function() {
                     throw Error("max depth exceeded");
                 var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.google.protobuf.DescriptorProto();
                 while (reader.pos < end) {
+                    var start = reader.pos;
                     var tag = reader.uint32();
                     if (tag === _end) {
                         _end = undefined;
@@ -11639,6 +11941,8 @@ $root.google = (function() {
                         }
                     default:
                         reader.skipType(tag & 7, _depth, tag >>> 3);
+                        $util.makeProp(message, "$unknowns", false);
+                        (message.$unknowns || (message.$unknowns = [])).push(reader.raw(start, reader.pos));
                         break;
                     }
                 }
@@ -12003,6 +12307,7 @@ $root.google = (function() {
                  * @property {number|null} [start] ExtensionRange start
                  * @property {number|null} [end] ExtensionRange end
                  * @property {google.protobuf.IExtensionRangeOptions|null} [options] ExtensionRange options
+                 * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
                  */
 
                 /**
@@ -12012,6 +12317,7 @@ $root.google = (function() {
                  * @implements IExtensionRange
                  * @constructor
                  * @param {google.protobuf.DescriptorProto.IExtensionRange=} [properties] Properties to set
+                 * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
                  */
                 function ExtensionRange(properties) {
                     if (properties)
@@ -12074,6 +12380,9 @@ $root.google = (function() {
                         writer.uint32(/* id 2, wireType 0 =*/16).int32(message.end);
                     if (message.options != null && Object.hasOwnProperty.call(message, "options"))
                         $root.google.protobuf.ExtensionRangeOptions.encode(message.options, writer.uint32(/* id 3, wireType 2 =*/26).fork()).ldelim();
+                    if (message.$unknowns != null && Object.hasOwnProperty.call(message, "$unknowns"))
+                        for (var i = 0; i < message.$unknowns.length; ++i)
+                            writer.raw(message.$unknowns[i]);
                     return writer;
                 };
 
@@ -12110,6 +12419,7 @@ $root.google = (function() {
                         throw Error("max depth exceeded");
                     var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.google.protobuf.DescriptorProto.ExtensionRange();
                     while (reader.pos < end) {
+                        var start = reader.pos;
                         var tag = reader.uint32();
                         if (tag === _end) {
                             _end = undefined;
@@ -12130,6 +12440,8 @@ $root.google = (function() {
                             }
                         default:
                             reader.skipType(tag & 7, _depth, tag >>> 3);
+                            $util.makeProp(message, "$unknowns", false);
+                            (message.$unknowns || (message.$unknowns = [])).push(reader.raw(start, reader.pos));
                             break;
                         }
                     }
@@ -12275,6 +12587,7 @@ $root.google = (function() {
                  * @interface IReservedRange
                  * @property {number|null} [start] ReservedRange start
                  * @property {number|null} [end] ReservedRange end
+                 * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
                  */
 
                 /**
@@ -12284,6 +12597,7 @@ $root.google = (function() {
                  * @implements IReservedRange
                  * @constructor
                  * @param {google.protobuf.DescriptorProto.IReservedRange=} [properties] Properties to set
+                 * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
                  */
                 function ReservedRange(properties) {
                     if (properties)
@@ -12336,6 +12650,9 @@ $root.google = (function() {
                         writer.uint32(/* id 1, wireType 0 =*/8).int32(message.start);
                     if (message.end != null && Object.hasOwnProperty.call(message, "end"))
                         writer.uint32(/* id 2, wireType 0 =*/16).int32(message.end);
+                    if (message.$unknowns != null && Object.hasOwnProperty.call(message, "$unknowns"))
+                        for (var i = 0; i < message.$unknowns.length; ++i)
+                            writer.raw(message.$unknowns[i]);
                     return writer;
                 };
 
@@ -12372,6 +12689,7 @@ $root.google = (function() {
                         throw Error("max depth exceeded");
                     var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.google.protobuf.DescriptorProto.ReservedRange();
                     while (reader.pos < end) {
+                        var start = reader.pos;
                         var tag = reader.uint32();
                         if (tag === _end) {
                             _end = undefined;
@@ -12388,6 +12706,8 @@ $root.google = (function() {
                             }
                         default:
                             reader.skipType(tag & 7, _depth, tag >>> 3);
+                            $util.makeProp(message, "$unknowns", false);
+                            (message.$unknowns || (message.$unknowns = [])).push(reader.raw(start, reader.pos));
                             break;
                         }
                     }
@@ -12525,6 +12845,7 @@ $root.google = (function() {
              * @property {Array.<google.protobuf.ExtensionRangeOptions.IDeclaration>|null} [declaration] ExtensionRangeOptions declaration
              * @property {google.protobuf.IFeatureSet|null} [features] ExtensionRangeOptions features
              * @property {google.protobuf.ExtensionRangeOptions.VerificationState|null} [verification] ExtensionRangeOptions verification
+             * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
              */
 
             /**
@@ -12534,6 +12855,7 @@ $root.google = (function() {
              * @implements IExtensionRangeOptions
              * @constructor
              * @param {google.protobuf.IExtensionRangeOptions=} [properties] Properties to set
+             * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
              */
             function ExtensionRangeOptions(properties) {
                 this.uninterpretedOption = [];
@@ -12610,6 +12932,9 @@ $root.google = (function() {
                 if (message.uninterpretedOption != null && message.uninterpretedOption.length)
                     for (var i = 0; i < message.uninterpretedOption.length; ++i)
                         $root.google.protobuf.UninterpretedOption.encode(message.uninterpretedOption[i], writer.uint32(/* id 999, wireType 2 =*/7994).fork()).ldelim();
+                if (message.$unknowns != null && Object.hasOwnProperty.call(message, "$unknowns"))
+                    for (var i = 0; i < message.$unknowns.length; ++i)
+                        writer.raw(message.$unknowns[i]);
                 return writer;
             };
 
@@ -12646,6 +12971,7 @@ $root.google = (function() {
                     throw Error("max depth exceeded");
                 var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.google.protobuf.ExtensionRangeOptions();
                 while (reader.pos < end) {
+                    var start = reader.pos;
                     var tag = reader.uint32();
                     if (tag === _end) {
                         _end = undefined;
@@ -12674,6 +13000,8 @@ $root.google = (function() {
                         }
                     default:
                         reader.skipType(tag & 7, _depth, tag >>> 3);
+                        $util.makeProp(message, "$unknowns", false);
+                        (message.$unknowns || (message.$unknowns = [])).push(reader.raw(start, reader.pos));
                         break;
                     }
                 }
@@ -12882,6 +13210,7 @@ $root.google = (function() {
                  * @property {string|null} [type] Declaration type
                  * @property {boolean|null} [reserved] Declaration reserved
                  * @property {boolean|null} [repeated] Declaration repeated
+                 * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
                  */
 
                 /**
@@ -12891,6 +13220,7 @@ $root.google = (function() {
                  * @implements IDeclaration
                  * @constructor
                  * @param {google.protobuf.ExtensionRangeOptions.IDeclaration=} [properties] Properties to set
+                 * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
                  */
                 function Declaration(properties) {
                     if (properties)
@@ -12973,6 +13303,9 @@ $root.google = (function() {
                         writer.uint32(/* id 5, wireType 0 =*/40).bool(message.reserved);
                     if (message.repeated != null && Object.hasOwnProperty.call(message, "repeated"))
                         writer.uint32(/* id 6, wireType 0 =*/48).bool(message.repeated);
+                    if (message.$unknowns != null && Object.hasOwnProperty.call(message, "$unknowns"))
+                        for (var i = 0; i < message.$unknowns.length; ++i)
+                            writer.raw(message.$unknowns[i]);
                     return writer;
                 };
 
@@ -13009,6 +13342,7 @@ $root.google = (function() {
                         throw Error("max depth exceeded");
                     var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.google.protobuf.ExtensionRangeOptions.Declaration();
                     while (reader.pos < end) {
+                        var start = reader.pos;
                         var tag = reader.uint32();
                         if (tag === _end) {
                             _end = undefined;
@@ -13037,6 +13371,8 @@ $root.google = (function() {
                             }
                         default:
                             reader.skipType(tag & 7, _depth, tag >>> 3);
+                            $util.makeProp(message, "$unknowns", false);
+                            (message.$unknowns || (message.$unknowns = [])).push(reader.raw(start, reader.pos));
                             break;
                         }
                     }
@@ -13219,6 +13555,7 @@ $root.google = (function() {
              * @property {string|null} [jsonName] FieldDescriptorProto jsonName
              * @property {google.protobuf.IFieldOptions|null} [options] FieldDescriptorProto options
              * @property {boolean|null} [proto3Optional] FieldDescriptorProto proto3Optional
+             * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
              */
 
             /**
@@ -13228,6 +13565,7 @@ $root.google = (function() {
              * @implements IFieldDescriptorProto
              * @constructor
              * @param {google.protobuf.IFieldDescriptorProto=} [properties] Properties to set
+             * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
              */
             function FieldDescriptorProto(properties) {
                 if (properties)
@@ -13370,6 +13708,9 @@ $root.google = (function() {
                     writer.uint32(/* id 10, wireType 2 =*/82).string(message.jsonName);
                 if (message.proto3Optional != null && Object.hasOwnProperty.call(message, "proto3Optional"))
                     writer.uint32(/* id 17, wireType 0 =*/136).bool(message.proto3Optional);
+                if (message.$unknowns != null && Object.hasOwnProperty.call(message, "$unknowns"))
+                    for (var i = 0; i < message.$unknowns.length; ++i)
+                        writer.raw(message.$unknowns[i]);
                 return writer;
             };
 
@@ -13406,6 +13747,7 @@ $root.google = (function() {
                     throw Error("max depth exceeded");
                 var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.google.protobuf.FieldDescriptorProto();
                 while (reader.pos < end) {
+                    var start = reader.pos;
                     var tag = reader.uint32();
                     if (tag === _end) {
                         _end = undefined;
@@ -13458,6 +13800,8 @@ $root.google = (function() {
                         }
                     default:
                         reader.skipType(tag & 7, _depth, tag >>> 3);
+                        $util.makeProp(message, "$unknowns", false);
+                        (message.$unknowns || (message.$unknowns = [])).push(reader.raw(start, reader.pos));
                         break;
                     }
                 }
@@ -13852,6 +14196,7 @@ $root.google = (function() {
              * @interface IOneofDescriptorProto
              * @property {string|null} [name] OneofDescriptorProto name
              * @property {google.protobuf.IOneofOptions|null} [options] OneofDescriptorProto options
+             * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
              */
 
             /**
@@ -13861,6 +14206,7 @@ $root.google = (function() {
              * @implements IOneofDescriptorProto
              * @constructor
              * @param {google.protobuf.IOneofDescriptorProto=} [properties] Properties to set
+             * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
              */
             function OneofDescriptorProto(properties) {
                 if (properties)
@@ -13913,6 +14259,9 @@ $root.google = (function() {
                     writer.uint32(/* id 1, wireType 2 =*/10).string(message.name);
                 if (message.options != null && Object.hasOwnProperty.call(message, "options"))
                     $root.google.protobuf.OneofOptions.encode(message.options, writer.uint32(/* id 2, wireType 2 =*/18).fork()).ldelim();
+                if (message.$unknowns != null && Object.hasOwnProperty.call(message, "$unknowns"))
+                    for (var i = 0; i < message.$unknowns.length; ++i)
+                        writer.raw(message.$unknowns[i]);
                 return writer;
             };
 
@@ -13949,6 +14298,7 @@ $root.google = (function() {
                     throw Error("max depth exceeded");
                 var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.google.protobuf.OneofDescriptorProto();
                 while (reader.pos < end) {
+                    var start = reader.pos;
                     var tag = reader.uint32();
                     if (tag === _end) {
                         _end = undefined;
@@ -13965,6 +14315,8 @@ $root.google = (function() {
                         }
                     default:
                         reader.skipType(tag & 7, _depth, tag >>> 3);
+                        $util.makeProp(message, "$unknowns", false);
+                        (message.$unknowns || (message.$unknowns = [])).push(reader.raw(start, reader.pos));
                         break;
                     }
                 }
@@ -14106,6 +14458,7 @@ $root.google = (function() {
              * @property {Array.<google.protobuf.EnumDescriptorProto.IEnumReservedRange>|null} [reservedRange] EnumDescriptorProto reservedRange
              * @property {Array.<string>|null} [reservedName] EnumDescriptorProto reservedName
              * @property {google.protobuf.SymbolVisibility|null} [visibility] EnumDescriptorProto visibility
+             * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
              */
 
             /**
@@ -14115,6 +14468,7 @@ $root.google = (function() {
              * @implements IEnumDescriptorProto
              * @constructor
              * @param {google.protobuf.IEnumDescriptorProto=} [properties] Properties to set
+             * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
              */
             function EnumDescriptorProto(properties) {
                 this.value = [];
@@ -14213,6 +14567,9 @@ $root.google = (function() {
                         writer.uint32(/* id 5, wireType 2 =*/42).string(message.reservedName[i]);
                 if (message.visibility != null && Object.hasOwnProperty.call(message, "visibility"))
                     writer.uint32(/* id 6, wireType 0 =*/48).int32(message.visibility);
+                if (message.$unknowns != null && Object.hasOwnProperty.call(message, "$unknowns"))
+                    for (var i = 0; i < message.$unknowns.length; ++i)
+                        writer.raw(message.$unknowns[i]);
                 return writer;
             };
 
@@ -14249,6 +14606,7 @@ $root.google = (function() {
                     throw Error("max depth exceeded");
                 var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.google.protobuf.EnumDescriptorProto();
                 while (reader.pos < end) {
+                    var start = reader.pos;
                     var tag = reader.uint32();
                     if (tag === _end) {
                         _end = undefined;
@@ -14287,6 +14645,8 @@ $root.google = (function() {
                         }
                     default:
                         reader.skipType(tag & 7, _depth, tag >>> 3);
+                        $util.makeProp(message, "$unknowns", false);
+                        (message.$unknowns || (message.$unknowns = [])).push(reader.raw(start, reader.pos));
                         break;
                     }
                 }
@@ -14525,6 +14885,7 @@ $root.google = (function() {
                  * @interface IEnumReservedRange
                  * @property {number|null} [start] EnumReservedRange start
                  * @property {number|null} [end] EnumReservedRange end
+                 * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
                  */
 
                 /**
@@ -14534,6 +14895,7 @@ $root.google = (function() {
                  * @implements IEnumReservedRange
                  * @constructor
                  * @param {google.protobuf.EnumDescriptorProto.IEnumReservedRange=} [properties] Properties to set
+                 * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
                  */
                 function EnumReservedRange(properties) {
                     if (properties)
@@ -14586,6 +14948,9 @@ $root.google = (function() {
                         writer.uint32(/* id 1, wireType 0 =*/8).int32(message.start);
                     if (message.end != null && Object.hasOwnProperty.call(message, "end"))
                         writer.uint32(/* id 2, wireType 0 =*/16).int32(message.end);
+                    if (message.$unknowns != null && Object.hasOwnProperty.call(message, "$unknowns"))
+                        for (var i = 0; i < message.$unknowns.length; ++i)
+                            writer.raw(message.$unknowns[i]);
                     return writer;
                 };
 
@@ -14622,6 +14987,7 @@ $root.google = (function() {
                         throw Error("max depth exceeded");
                     var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.google.protobuf.EnumDescriptorProto.EnumReservedRange();
                     while (reader.pos < end) {
+                        var start = reader.pos;
                         var tag = reader.uint32();
                         if (tag === _end) {
                             _end = undefined;
@@ -14638,6 +15004,8 @@ $root.google = (function() {
                             }
                         default:
                             reader.skipType(tag & 7, _depth, tag >>> 3);
+                            $util.makeProp(message, "$unknowns", false);
+                            (message.$unknowns || (message.$unknowns = [])).push(reader.raw(start, reader.pos));
                             break;
                         }
                     }
@@ -14774,6 +15142,7 @@ $root.google = (function() {
              * @property {string|null} [name] EnumValueDescriptorProto name
              * @property {number|null} [number] EnumValueDescriptorProto number
              * @property {google.protobuf.IEnumValueOptions|null} [options] EnumValueDescriptorProto options
+             * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
              */
 
             /**
@@ -14783,6 +15152,7 @@ $root.google = (function() {
              * @implements IEnumValueDescriptorProto
              * @constructor
              * @param {google.protobuf.IEnumValueDescriptorProto=} [properties] Properties to set
+             * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
              */
             function EnumValueDescriptorProto(properties) {
                 if (properties)
@@ -14845,6 +15215,9 @@ $root.google = (function() {
                     writer.uint32(/* id 2, wireType 0 =*/16).int32(message.number);
                 if (message.options != null && Object.hasOwnProperty.call(message, "options"))
                     $root.google.protobuf.EnumValueOptions.encode(message.options, writer.uint32(/* id 3, wireType 2 =*/26).fork()).ldelim();
+                if (message.$unknowns != null && Object.hasOwnProperty.call(message, "$unknowns"))
+                    for (var i = 0; i < message.$unknowns.length; ++i)
+                        writer.raw(message.$unknowns[i]);
                 return writer;
             };
 
@@ -14881,6 +15254,7 @@ $root.google = (function() {
                     throw Error("max depth exceeded");
                 var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.google.protobuf.EnumValueDescriptorProto();
                 while (reader.pos < end) {
+                    var start = reader.pos;
                     var tag = reader.uint32();
                     if (tag === _end) {
                         _end = undefined;
@@ -14901,6 +15275,8 @@ $root.google = (function() {
                         }
                     default:
                         reader.skipType(tag & 7, _depth, tag >>> 3);
+                        $util.makeProp(message, "$unknowns", false);
+                        (message.$unknowns || (message.$unknowns = [])).push(reader.raw(start, reader.pos));
                         break;
                     }
                 }
@@ -15047,6 +15423,7 @@ $root.google = (function() {
              * @property {string|null} [name] ServiceDescriptorProto name
              * @property {Array.<google.protobuf.IMethodDescriptorProto>|null} [method] ServiceDescriptorProto method
              * @property {google.protobuf.IServiceOptions|null} [options] ServiceDescriptorProto options
+             * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
              */
 
             /**
@@ -15056,6 +15433,7 @@ $root.google = (function() {
              * @implements IServiceDescriptorProto
              * @constructor
              * @param {google.protobuf.IServiceDescriptorProto=} [properties] Properties to set
+             * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
              */
             function ServiceDescriptorProto(properties) {
                 this.method = [];
@@ -15120,6 +15498,9 @@ $root.google = (function() {
                         $root.google.protobuf.MethodDescriptorProto.encode(message.method[i], writer.uint32(/* id 2, wireType 2 =*/18).fork()).ldelim();
                 if (message.options != null && Object.hasOwnProperty.call(message, "options"))
                     $root.google.protobuf.ServiceOptions.encode(message.options, writer.uint32(/* id 3, wireType 2 =*/26).fork()).ldelim();
+                if (message.$unknowns != null && Object.hasOwnProperty.call(message, "$unknowns"))
+                    for (var i = 0; i < message.$unknowns.length; ++i)
+                        writer.raw(message.$unknowns[i]);
                 return writer;
             };
 
@@ -15156,6 +15537,7 @@ $root.google = (function() {
                     throw Error("max depth exceeded");
                 var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.google.protobuf.ServiceDescriptorProto();
                 while (reader.pos < end) {
+                    var start = reader.pos;
                     var tag = reader.uint32();
                     if (tag === _end) {
                         _end = undefined;
@@ -15178,6 +15560,8 @@ $root.google = (function() {
                         }
                     default:
                         reader.skipType(tag & 7, _depth, tag >>> 3);
+                        $util.makeProp(message, "$unknowns", false);
+                        (message.$unknowns || (message.$unknowns = [])).push(reader.raw(start, reader.pos));
                         break;
                     }
                 }
@@ -15345,6 +15729,7 @@ $root.google = (function() {
              * @property {google.protobuf.IMethodOptions|null} [options] MethodDescriptorProto options
              * @property {boolean|null} [clientStreaming] MethodDescriptorProto clientStreaming
              * @property {boolean|null} [serverStreaming] MethodDescriptorProto serverStreaming
+             * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
              */
 
             /**
@@ -15354,6 +15739,7 @@ $root.google = (function() {
              * @implements IMethodDescriptorProto
              * @constructor
              * @param {google.protobuf.IMethodDescriptorProto=} [properties] Properties to set
+             * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
              */
             function MethodDescriptorProto(properties) {
                 if (properties)
@@ -15446,6 +15832,9 @@ $root.google = (function() {
                     writer.uint32(/* id 5, wireType 0 =*/40).bool(message.clientStreaming);
                 if (message.serverStreaming != null && Object.hasOwnProperty.call(message, "serverStreaming"))
                     writer.uint32(/* id 6, wireType 0 =*/48).bool(message.serverStreaming);
+                if (message.$unknowns != null && Object.hasOwnProperty.call(message, "$unknowns"))
+                    for (var i = 0; i < message.$unknowns.length; ++i)
+                        writer.raw(message.$unknowns[i]);
                 return writer;
             };
 
@@ -15482,6 +15871,7 @@ $root.google = (function() {
                     throw Error("max depth exceeded");
                 var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.google.protobuf.MethodDescriptorProto();
                 while (reader.pos < end) {
+                    var start = reader.pos;
                     var tag = reader.uint32();
                     if (tag === _end) {
                         _end = undefined;
@@ -15514,6 +15904,8 @@ $root.google = (function() {
                         }
                     default:
                         reader.skipType(tag & 7, _depth, tag >>> 3);
+                        $util.makeProp(message, "$unknowns", false);
+                        (message.$unknowns || (message.$unknowns = [])).push(reader.raw(start, reader.pos));
                         break;
                     }
                 }
@@ -15702,6 +16094,7 @@ $root.google = (function() {
              * @property {string|null} [rubyPackage] FileOptions rubyPackage
              * @property {google.protobuf.IFeatureSet|null} [features] FileOptions features
              * @property {Array.<google.protobuf.IUninterpretedOption>|null} [uninterpretedOption] FileOptions uninterpretedOption
+             * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
              */
 
             /**
@@ -15711,6 +16104,7 @@ $root.google = (function() {
              * @implements IFileOptions
              * @constructor
              * @param {google.protobuf.IFileOptions=} [properties] Properties to set
+             * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
              */
             function FileOptions(properties) {
                 this.uninterpretedOption = [];
@@ -15955,6 +16349,9 @@ $root.google = (function() {
                 if (message.uninterpretedOption != null && message.uninterpretedOption.length)
                     for (var i = 0; i < message.uninterpretedOption.length; ++i)
                         $root.google.protobuf.UninterpretedOption.encode(message.uninterpretedOption[i], writer.uint32(/* id 999, wireType 2 =*/7994).fork()).ldelim();
+                if (message.$unknowns != null && Object.hasOwnProperty.call(message, "$unknowns"))
+                    for (var i = 0; i < message.$unknowns.length; ++i)
+                        writer.raw(message.$unknowns[i]);
                 return writer;
             };
 
@@ -15991,6 +16388,7 @@ $root.google = (function() {
                     throw Error("max depth exceeded");
                 var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.google.protobuf.FileOptions();
                 while (reader.pos < end) {
+                    var start = reader.pos;
                     var tag = reader.uint32();
                     if (tag === _end) {
                         _end = undefined;
@@ -16085,6 +16483,8 @@ $root.google = (function() {
                         }
                     default:
                         reader.skipType(tag & 7, _depth, tag >>> 3);
+                        $util.makeProp(message, "$unknowns", false);
+                        (message.$unknowns || (message.$unknowns = [])).push(reader.raw(start, reader.pos));
                         break;
                     }
                 }
@@ -16437,6 +16837,7 @@ $root.google = (function() {
              * @property {boolean|null} [deprecatedLegacyJsonFieldConflicts] MessageOptions deprecatedLegacyJsonFieldConflicts
              * @property {google.protobuf.IFeatureSet|null} [features] MessageOptions features
              * @property {Array.<google.protobuf.IUninterpretedOption>|null} [uninterpretedOption] MessageOptions uninterpretedOption
+             * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
              */
 
             /**
@@ -16446,6 +16847,7 @@ $root.google = (function() {
              * @implements IMessageOptions
              * @constructor
              * @param {google.protobuf.IMessageOptions=} [properties] Properties to set
+             * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
              */
             function MessageOptions(properties) {
                 this.uninterpretedOption = [];
@@ -16550,6 +16952,9 @@ $root.google = (function() {
                 if (message.uninterpretedOption != null && message.uninterpretedOption.length)
                     for (var i = 0; i < message.uninterpretedOption.length; ++i)
                         $root.google.protobuf.UninterpretedOption.encode(message.uninterpretedOption[i], writer.uint32(/* id 999, wireType 2 =*/7994).fork()).ldelim();
+                if (message.$unknowns != null && Object.hasOwnProperty.call(message, "$unknowns"))
+                    for (var i = 0; i < message.$unknowns.length; ++i)
+                        writer.raw(message.$unknowns[i]);
                 return writer;
             };
 
@@ -16586,6 +16991,7 @@ $root.google = (function() {
                     throw Error("max depth exceeded");
                 var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.google.protobuf.MessageOptions();
                 while (reader.pos < end) {
+                    var start = reader.pos;
                     var tag = reader.uint32();
                     if (tag === _end) {
                         _end = undefined;
@@ -16624,6 +17030,8 @@ $root.google = (function() {
                         }
                     default:
                         reader.skipType(tag & 7, _depth, tag >>> 3);
+                        $util.makeProp(message, "$unknowns", false);
+                        (message.$unknowns || (message.$unknowns = [])).push(reader.raw(start, reader.pos));
                         break;
                     }
                 }
@@ -16831,6 +17239,7 @@ $root.google = (function() {
              * @property {google.protobuf.IFeatureSet|null} [features] FieldOptions features
              * @property {google.protobuf.FieldOptions.IFeatureSupport|null} [featureSupport] FieldOptions featureSupport
              * @property {Array.<google.protobuf.IUninterpretedOption>|null} [uninterpretedOption] FieldOptions uninterpretedOption
+             * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
              */
 
             /**
@@ -16840,6 +17249,7 @@ $root.google = (function() {
              * @implements IFieldOptions
              * @constructor
              * @param {google.protobuf.IFieldOptions=} [properties] Properties to set
+             * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
              */
             function FieldOptions(properties) {
                 this.targets = [];
@@ -17018,6 +17428,9 @@ $root.google = (function() {
                 if (message.uninterpretedOption != null && message.uninterpretedOption.length)
                     for (var i = 0; i < message.uninterpretedOption.length; ++i)
                         $root.google.protobuf.UninterpretedOption.encode(message.uninterpretedOption[i], writer.uint32(/* id 999, wireType 2 =*/7994).fork()).ldelim();
+                if (message.$unknowns != null && Object.hasOwnProperty.call(message, "$unknowns"))
+                    for (var i = 0; i < message.$unknowns.length; ++i)
+                        writer.raw(message.$unknowns[i]);
                 return writer;
             };
 
@@ -17054,6 +17467,7 @@ $root.google = (function() {
                     throw Error("max depth exceeded");
                 var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.google.protobuf.FieldOptions();
                 while (reader.pos < end) {
+                    var start = reader.pos;
                     var tag = reader.uint32();
                     if (tag === _end) {
                         _end = undefined;
@@ -17130,6 +17544,8 @@ $root.google = (function() {
                         }
                     default:
                         reader.skipType(tag & 7, _depth, tag >>> 3);
+                        $util.makeProp(message, "$unknowns", false);
+                        (message.$unknowns || (message.$unknowns = [])).push(reader.raw(start, reader.pos));
                         break;
                     }
                 }
@@ -17622,6 +18038,7 @@ $root.google = (function() {
                  * @interface IEditionDefault
                  * @property {google.protobuf.Edition|null} [edition] EditionDefault edition
                  * @property {string|null} [value] EditionDefault value
+                 * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
                  */
 
                 /**
@@ -17631,6 +18048,7 @@ $root.google = (function() {
                  * @implements IEditionDefault
                  * @constructor
                  * @param {google.protobuf.FieldOptions.IEditionDefault=} [properties] Properties to set
+                 * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
                  */
                 function EditionDefault(properties) {
                     if (properties)
@@ -17683,6 +18101,9 @@ $root.google = (function() {
                         writer.uint32(/* id 2, wireType 2 =*/18).string(message.value);
                     if (message.edition != null && Object.hasOwnProperty.call(message, "edition"))
                         writer.uint32(/* id 3, wireType 0 =*/24).int32(message.edition);
+                    if (message.$unknowns != null && Object.hasOwnProperty.call(message, "$unknowns"))
+                        for (var i = 0; i < message.$unknowns.length; ++i)
+                            writer.raw(message.$unknowns[i]);
                     return writer;
                 };
 
@@ -17719,6 +18140,7 @@ $root.google = (function() {
                         throw Error("max depth exceeded");
                     var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.google.protobuf.FieldOptions.EditionDefault();
                     while (reader.pos < end) {
+                        var start = reader.pos;
                         var tag = reader.uint32();
                         if (tag === _end) {
                             _end = undefined;
@@ -17735,6 +18157,8 @@ $root.google = (function() {
                             }
                         default:
                             reader.skipType(tag & 7, _depth, tag >>> 3);
+                            $util.makeProp(message, "$unknowns", false);
+                            (message.$unknowns || (message.$unknowns = [])).push(reader.raw(start, reader.pos));
                             break;
                         }
                     }
@@ -17938,6 +18362,7 @@ $root.google = (function() {
                  * @property {google.protobuf.Edition|null} [editionDeprecated] FeatureSupport editionDeprecated
                  * @property {string|null} [deprecationWarning] FeatureSupport deprecationWarning
                  * @property {google.protobuf.Edition|null} [editionRemoved] FeatureSupport editionRemoved
+                 * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
                  */
 
                 /**
@@ -17947,6 +18372,7 @@ $root.google = (function() {
                  * @implements IFeatureSupport
                  * @constructor
                  * @param {google.protobuf.FieldOptions.IFeatureSupport=} [properties] Properties to set
+                 * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
                  */
                 function FeatureSupport(properties) {
                     if (properties)
@@ -18019,6 +18445,9 @@ $root.google = (function() {
                         writer.uint32(/* id 3, wireType 2 =*/26).string(message.deprecationWarning);
                     if (message.editionRemoved != null && Object.hasOwnProperty.call(message, "editionRemoved"))
                         writer.uint32(/* id 4, wireType 0 =*/32).int32(message.editionRemoved);
+                    if (message.$unknowns != null && Object.hasOwnProperty.call(message, "$unknowns"))
+                        for (var i = 0; i < message.$unknowns.length; ++i)
+                            writer.raw(message.$unknowns[i]);
                     return writer;
                 };
 
@@ -18055,6 +18484,7 @@ $root.google = (function() {
                         throw Error("max depth exceeded");
                     var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.google.protobuf.FieldOptions.FeatureSupport();
                     while (reader.pos < end) {
+                        var start = reader.pos;
                         var tag = reader.uint32();
                         if (tag === _end) {
                             _end = undefined;
@@ -18079,6 +18509,8 @@ $root.google = (function() {
                             }
                         default:
                             reader.skipType(tag & 7, _depth, tag >>> 3);
+                            $util.makeProp(message, "$unknowns", false);
+                            (message.$unknowns || (message.$unknowns = [])).push(reader.raw(start, reader.pos));
                             break;
                         }
                     }
@@ -18437,6 +18869,7 @@ $root.google = (function() {
              * @interface IOneofOptions
              * @property {google.protobuf.IFeatureSet|null} [features] OneofOptions features
              * @property {Array.<google.protobuf.IUninterpretedOption>|null} [uninterpretedOption] OneofOptions uninterpretedOption
+             * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
              */
 
             /**
@@ -18446,6 +18879,7 @@ $root.google = (function() {
              * @implements IOneofOptions
              * @constructor
              * @param {google.protobuf.IOneofOptions=} [properties] Properties to set
+             * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
              */
             function OneofOptions(properties) {
                 this.uninterpretedOption = [];
@@ -18500,6 +18934,9 @@ $root.google = (function() {
                 if (message.uninterpretedOption != null && message.uninterpretedOption.length)
                     for (var i = 0; i < message.uninterpretedOption.length; ++i)
                         $root.google.protobuf.UninterpretedOption.encode(message.uninterpretedOption[i], writer.uint32(/* id 999, wireType 2 =*/7994).fork()).ldelim();
+                if (message.$unknowns != null && Object.hasOwnProperty.call(message, "$unknowns"))
+                    for (var i = 0; i < message.$unknowns.length; ++i)
+                        writer.raw(message.$unknowns[i]);
                 return writer;
             };
 
@@ -18536,6 +18973,7 @@ $root.google = (function() {
                     throw Error("max depth exceeded");
                 var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.google.protobuf.OneofOptions();
                 while (reader.pos < end) {
+                    var start = reader.pos;
                     var tag = reader.uint32();
                     if (tag === _end) {
                         _end = undefined;
@@ -18554,6 +18992,8 @@ $root.google = (function() {
                         }
                     default:
                         reader.skipType(tag & 7, _depth, tag >>> 3);
+                        $util.makeProp(message, "$unknowns", false);
+                        (message.$unknowns || (message.$unknowns = [])).push(reader.raw(start, reader.pos));
                         break;
                     }
                 }
@@ -18712,6 +19152,7 @@ $root.google = (function() {
              * @property {google.protobuf.IFeatureSet|null} [features] EnumOptions features
              * @property {Array.<google.protobuf.IUninterpretedOption>|null} [uninterpretedOption] EnumOptions uninterpretedOption
              * @property {string|null} [".jspb.test.IsExtension.simpleOption"] EnumOptions .jspb.test.IsExtension.simpleOption
+             * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
              */
 
             /**
@@ -18722,6 +19163,7 @@ $root.google = (function() {
              * @constructor
              * @param {google.protobuf.IEnumOptions=} [properties] Properties to set
              * @property {string} ".jspb.test.IsExtension.simpleOption" EnumOptions .jspb.test.IsExtension.simpleOption
+             * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
              */
             function EnumOptions(properties) {
                 this.uninterpretedOption = [];
@@ -18810,6 +19252,9 @@ $root.google = (function() {
                         $root.google.protobuf.UninterpretedOption.encode(message.uninterpretedOption[i], writer.uint32(/* id 999, wireType 2 =*/7994).fork()).ldelim();
                 if (message[".jspb.test.IsExtension.simpleOption"] != null && Object.hasOwnProperty.call(message, ".jspb.test.IsExtension.simpleOption"))
                     writer.uint32(/* id 42113038, wireType 2 =*/336904306).string(message[".jspb.test.IsExtension.simpleOption"]);
+                if (message.$unknowns != null && Object.hasOwnProperty.call(message, "$unknowns"))
+                    for (var i = 0; i < message.$unknowns.length; ++i)
+                        writer.raw(message.$unknowns[i]);
                 return writer;
             };
 
@@ -18846,6 +19291,7 @@ $root.google = (function() {
                     throw Error("max depth exceeded");
                 var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.google.protobuf.EnumOptions();
                 while (reader.pos < end) {
+                    var start = reader.pos;
                     var tag = reader.uint32();
                     if (tag === _end) {
                         _end = undefined;
@@ -18880,6 +19326,8 @@ $root.google = (function() {
                         }
                     default:
                         reader.skipType(tag & 7, _depth, tag >>> 3);
+                        $util.makeProp(message, "$unknowns", false);
+                        (message.$unknowns || (message.$unknowns = [])).push(reader.raw(start, reader.pos));
                         break;
                     }
                 }
@@ -19070,6 +19518,7 @@ $root.google = (function() {
              * @property {boolean|null} [debugRedact] EnumValueOptions debugRedact
              * @property {google.protobuf.FieldOptions.IFeatureSupport|null} [featureSupport] EnumValueOptions featureSupport
              * @property {Array.<google.protobuf.IUninterpretedOption>|null} [uninterpretedOption] EnumValueOptions uninterpretedOption
+             * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
              */
 
             /**
@@ -19079,6 +19528,7 @@ $root.google = (function() {
              * @implements IEnumValueOptions
              * @constructor
              * @param {google.protobuf.IEnumValueOptions=} [properties] Properties to set
+             * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
              */
             function EnumValueOptions(properties) {
                 this.uninterpretedOption = [];
@@ -19163,6 +19613,9 @@ $root.google = (function() {
                 if (message.uninterpretedOption != null && message.uninterpretedOption.length)
                     for (var i = 0; i < message.uninterpretedOption.length; ++i)
                         $root.google.protobuf.UninterpretedOption.encode(message.uninterpretedOption[i], writer.uint32(/* id 999, wireType 2 =*/7994).fork()).ldelim();
+                if (message.$unknowns != null && Object.hasOwnProperty.call(message, "$unknowns"))
+                    for (var i = 0; i < message.$unknowns.length; ++i)
+                        writer.raw(message.$unknowns[i]);
                 return writer;
             };
 
@@ -19199,6 +19652,7 @@ $root.google = (function() {
                     throw Error("max depth exceeded");
                 var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.google.protobuf.EnumValueOptions();
                 while (reader.pos < end) {
+                    var start = reader.pos;
                     var tag = reader.uint32();
                     if (tag === _end) {
                         _end = undefined;
@@ -19229,6 +19683,8 @@ $root.google = (function() {
                         }
                     default:
                         reader.skipType(tag & 7, _depth, tag >>> 3);
+                        $util.makeProp(message, "$unknowns", false);
+                        (message.$unknowns || (message.$unknowns = [])).push(reader.raw(start, reader.pos));
                         break;
                     }
                 }
@@ -19414,6 +19870,7 @@ $root.google = (function() {
              * @property {google.protobuf.IFeatureSet|null} [features] ServiceOptions features
              * @property {boolean|null} [deprecated] ServiceOptions deprecated
              * @property {Array.<google.protobuf.IUninterpretedOption>|null} [uninterpretedOption] ServiceOptions uninterpretedOption
+             * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
              */
 
             /**
@@ -19423,6 +19880,7 @@ $root.google = (function() {
              * @implements IServiceOptions
              * @constructor
              * @param {google.protobuf.IServiceOptions=} [properties] Properties to set
+             * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
              */
             function ServiceOptions(properties) {
                 this.uninterpretedOption = [];
@@ -19487,6 +19945,9 @@ $root.google = (function() {
                 if (message.uninterpretedOption != null && message.uninterpretedOption.length)
                     for (var i = 0; i < message.uninterpretedOption.length; ++i)
                         $root.google.protobuf.UninterpretedOption.encode(message.uninterpretedOption[i], writer.uint32(/* id 999, wireType 2 =*/7994).fork()).ldelim();
+                if (message.$unknowns != null && Object.hasOwnProperty.call(message, "$unknowns"))
+                    for (var i = 0; i < message.$unknowns.length; ++i)
+                        writer.raw(message.$unknowns[i]);
                 return writer;
             };
 
@@ -19523,6 +19984,7 @@ $root.google = (function() {
                     throw Error("max depth exceeded");
                 var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.google.protobuf.ServiceOptions();
                 while (reader.pos < end) {
+                    var start = reader.pos;
                     var tag = reader.uint32();
                     if (tag === _end) {
                         _end = undefined;
@@ -19545,6 +20007,8 @@ $root.google = (function() {
                         }
                     default:
                         reader.skipType(tag & 7, _depth, tag >>> 3);
+                        $util.makeProp(message, "$unknowns", false);
+                        (message.$unknowns || (message.$unknowns = [])).push(reader.raw(start, reader.pos));
                         break;
                     }
                 }
@@ -19710,6 +20174,7 @@ $root.google = (function() {
              * @property {google.protobuf.MethodOptions.IdempotencyLevel|null} [idempotencyLevel] MethodOptions idempotencyLevel
              * @property {google.protobuf.IFeatureSet|null} [features] MethodOptions features
              * @property {Array.<google.protobuf.IUninterpretedOption>|null} [uninterpretedOption] MethodOptions uninterpretedOption
+             * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
              */
 
             /**
@@ -19719,6 +20184,7 @@ $root.google = (function() {
              * @implements IMethodOptions
              * @constructor
              * @param {google.protobuf.IMethodOptions=} [properties] Properties to set
+             * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
              */
             function MethodOptions(properties) {
                 this.uninterpretedOption = [];
@@ -19793,6 +20259,9 @@ $root.google = (function() {
                 if (message.uninterpretedOption != null && message.uninterpretedOption.length)
                     for (var i = 0; i < message.uninterpretedOption.length; ++i)
                         $root.google.protobuf.UninterpretedOption.encode(message.uninterpretedOption[i], writer.uint32(/* id 999, wireType 2 =*/7994).fork()).ldelim();
+                if (message.$unknowns != null && Object.hasOwnProperty.call(message, "$unknowns"))
+                    for (var i = 0; i < message.$unknowns.length; ++i)
+                        writer.raw(message.$unknowns[i]);
                 return writer;
             };
 
@@ -19829,6 +20298,7 @@ $root.google = (function() {
                     throw Error("max depth exceeded");
                 var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.google.protobuf.MethodOptions();
                 while (reader.pos < end) {
+                    var start = reader.pos;
                     var tag = reader.uint32();
                     if (tag === _end) {
                         _end = undefined;
@@ -19855,6 +20325,8 @@ $root.google = (function() {
                         }
                     default:
                         reader.skipType(tag & 7, _depth, tag >>> 3);
+                        $util.makeProp(message, "$unknowns", false);
+                        (message.$unknowns || (message.$unknowns = [])).push(reader.raw(start, reader.pos));
                         break;
                     }
                 }
@@ -20071,6 +20543,7 @@ $root.google = (function() {
              * @property {number|null} [doubleValue] UninterpretedOption doubleValue
              * @property {Uint8Array|null} [stringValue] UninterpretedOption stringValue
              * @property {string|null} [aggregateValue] UninterpretedOption aggregateValue
+             * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
              */
 
             /**
@@ -20080,6 +20553,7 @@ $root.google = (function() {
              * @implements IUninterpretedOption
              * @constructor
              * @param {google.protobuf.IUninterpretedOption=} [properties] Properties to set
+             * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
              */
             function UninterpretedOption(properties) {
                 this.name = [];
@@ -20184,6 +20658,9 @@ $root.google = (function() {
                     writer.uint32(/* id 7, wireType 2 =*/58).bytes(message.stringValue);
                 if (message.aggregateValue != null && Object.hasOwnProperty.call(message, "aggregateValue"))
                     writer.uint32(/* id 8, wireType 2 =*/66).string(message.aggregateValue);
+                if (message.$unknowns != null && Object.hasOwnProperty.call(message, "$unknowns"))
+                    for (var i = 0; i < message.$unknowns.length; ++i)
+                        writer.raw(message.$unknowns[i]);
                 return writer;
             };
 
@@ -20220,6 +20697,7 @@ $root.google = (function() {
                     throw Error("max depth exceeded");
                 var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.google.protobuf.UninterpretedOption();
                 while (reader.pos < end) {
+                    var start = reader.pos;
                     var tag = reader.uint32();
                     if (tag === _end) {
                         _end = undefined;
@@ -20258,6 +20736,8 @@ $root.google = (function() {
                         }
                     default:
                         reader.skipType(tag & 7, _depth, tag >>> 3);
+                        $util.makeProp(message, "$unknowns", false);
+                        (message.$unknowns || (message.$unknowns = [])).push(reader.raw(start, reader.pos));
                         break;
                     }
                 }
@@ -20482,6 +20962,7 @@ $root.google = (function() {
                  * @interface INamePart
                  * @property {string} namePart NamePart namePart
                  * @property {boolean} isExtension NamePart isExtension
+                 * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
                  */
 
                 /**
@@ -20491,6 +20972,7 @@ $root.google = (function() {
                  * @implements INamePart
                  * @constructor
                  * @param {google.protobuf.UninterpretedOption.INamePart=} [properties] Properties to set
+                 * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
                  */
                 function NamePart(properties) {
                     if (properties)
@@ -20541,6 +21023,9 @@ $root.google = (function() {
                         writer = $Writer.create();
                     writer.uint32(/* id 1, wireType 2 =*/10).string(message.namePart);
                     writer.uint32(/* id 2, wireType 0 =*/16).bool(message.isExtension);
+                    if (message.$unknowns != null && Object.hasOwnProperty.call(message, "$unknowns"))
+                        for (var i = 0; i < message.$unknowns.length; ++i)
+                            writer.raw(message.$unknowns[i]);
                     return writer;
                 };
 
@@ -20577,6 +21062,7 @@ $root.google = (function() {
                         throw Error("max depth exceeded");
                     var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.google.protobuf.UninterpretedOption.NamePart();
                     while (reader.pos < end) {
+                        var start = reader.pos;
                         var tag = reader.uint32();
                         if (tag === _end) {
                             _end = undefined;
@@ -20593,6 +21079,8 @@ $root.google = (function() {
                             }
                         default:
                             reader.skipType(tag & 7, _depth, tag >>> 3);
+                            $util.makeProp(message, "$unknowns", false);
+                            (message.$unknowns || (message.$unknowns = [])).push(reader.raw(start, reader.pos));
                             break;
                         }
                     }
@@ -20736,6 +21224,7 @@ $root.google = (function() {
              * @property {google.protobuf.FeatureSet.JsonFormat|null} [jsonFormat] FeatureSet jsonFormat
              * @property {google.protobuf.FeatureSet.EnforceNamingStyle|null} [enforceNamingStyle] FeatureSet enforceNamingStyle
              * @property {google.protobuf.FeatureSet.VisibilityFeature.DefaultSymbolVisibility|null} [defaultSymbolVisibility] FeatureSet defaultSymbolVisibility
+             * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
              */
 
             /**
@@ -20745,6 +21234,7 @@ $root.google = (function() {
              * @implements IFeatureSet
              * @constructor
              * @param {google.protobuf.IFeatureSet=} [properties] Properties to set
+             * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
              */
             function FeatureSet(properties) {
                 if (properties)
@@ -20857,6 +21347,9 @@ $root.google = (function() {
                     writer.uint32(/* id 7, wireType 0 =*/56).int32(message.enforceNamingStyle);
                 if (message.defaultSymbolVisibility != null && Object.hasOwnProperty.call(message, "defaultSymbolVisibility"))
                     writer.uint32(/* id 8, wireType 0 =*/64).int32(message.defaultSymbolVisibility);
+                if (message.$unknowns != null && Object.hasOwnProperty.call(message, "$unknowns"))
+                    for (var i = 0; i < message.$unknowns.length; ++i)
+                        writer.raw(message.$unknowns[i]);
                 return writer;
             };
 
@@ -20893,6 +21386,7 @@ $root.google = (function() {
                     throw Error("max depth exceeded");
                 var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.google.protobuf.FeatureSet();
                 while (reader.pos < end) {
+                    var start = reader.pos;
                     var tag = reader.uint32();
                     if (tag === _end) {
                         _end = undefined;
@@ -20933,6 +21427,8 @@ $root.google = (function() {
                         }
                     default:
                         reader.skipType(tag & 7, _depth, tag >>> 3);
+                        $util.makeProp(message, "$unknowns", false);
+                        (message.$unknowns || (message.$unknowns = [])).push(reader.raw(start, reader.pos));
                         break;
                     }
                 }
@@ -21429,6 +21925,7 @@ $root.google = (function() {
                  * Properties of a VisibilityFeature.
                  * @memberof google.protobuf.FeatureSet
                  * @interface IVisibilityFeature
+                 * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
                  */
 
                 /**
@@ -21438,6 +21935,7 @@ $root.google = (function() {
                  * @implements IVisibilityFeature
                  * @constructor
                  * @param {google.protobuf.FeatureSet.IVisibilityFeature=} [properties] Properties to set
+                 * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
                  */
                 function VisibilityFeature(properties) {
                     if (properties)
@@ -21470,6 +21968,9 @@ $root.google = (function() {
                 VisibilityFeature.encode = function encode(message, writer) {
                     if (!writer)
                         writer = $Writer.create();
+                    if (message.$unknowns != null && Object.hasOwnProperty.call(message, "$unknowns"))
+                        for (var i = 0; i < message.$unknowns.length; ++i)
+                            writer.raw(message.$unknowns[i]);
                     return writer;
                 };
 
@@ -21506,6 +22007,7 @@ $root.google = (function() {
                         throw Error("max depth exceeded");
                     var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.google.protobuf.FeatureSet.VisibilityFeature();
                     while (reader.pos < end) {
+                        var start = reader.pos;
                         var tag = reader.uint32();
                         if (tag === _end) {
                             _end = undefined;
@@ -21514,6 +22016,8 @@ $root.google = (function() {
                         switch (tag) {
                         default:
                             reader.skipType(tag & 7, _depth, tag >>> 3);
+                            $util.makeProp(message, "$unknowns", false);
+                            (message.$unknowns || (message.$unknowns = [])).push(reader.raw(start, reader.pos));
                             break;
                         }
                     }
@@ -21648,6 +22152,7 @@ $root.google = (function() {
              * @property {Array.<google.protobuf.FeatureSetDefaults.IFeatureSetEditionDefault>|null} [defaults] FeatureSetDefaults defaults
              * @property {google.protobuf.Edition|null} [minimumEdition] FeatureSetDefaults minimumEdition
              * @property {google.protobuf.Edition|null} [maximumEdition] FeatureSetDefaults maximumEdition
+             * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
              */
 
             /**
@@ -21657,6 +22162,7 @@ $root.google = (function() {
              * @implements IFeatureSetDefaults
              * @constructor
              * @param {google.protobuf.IFeatureSetDefaults=} [properties] Properties to set
+             * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
              */
             function FeatureSetDefaults(properties) {
                 this.defaults = [];
@@ -21721,6 +22227,9 @@ $root.google = (function() {
                     writer.uint32(/* id 4, wireType 0 =*/32).int32(message.minimumEdition);
                 if (message.maximumEdition != null && Object.hasOwnProperty.call(message, "maximumEdition"))
                     writer.uint32(/* id 5, wireType 0 =*/40).int32(message.maximumEdition);
+                if (message.$unknowns != null && Object.hasOwnProperty.call(message, "$unknowns"))
+                    for (var i = 0; i < message.$unknowns.length; ++i)
+                        writer.raw(message.$unknowns[i]);
                 return writer;
             };
 
@@ -21757,6 +22266,7 @@ $root.google = (function() {
                     throw Error("max depth exceeded");
                 var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.google.protobuf.FeatureSetDefaults();
                 while (reader.pos < end) {
+                    var start = reader.pos;
                     var tag = reader.uint32();
                     if (tag === _end) {
                         _end = undefined;
@@ -21779,6 +22289,8 @@ $root.google = (function() {
                         }
                     default:
                         reader.skipType(tag & 7, _depth, tag >>> 3);
+                        $util.makeProp(message, "$unknowns", false);
+                        (message.$unknowns || (message.$unknowns = [])).push(reader.raw(start, reader.pos));
                         break;
                     }
                 }
@@ -22073,6 +22585,7 @@ $root.google = (function() {
                  * @property {google.protobuf.Edition|null} [edition] FeatureSetEditionDefault edition
                  * @property {google.protobuf.IFeatureSet|null} [overridableFeatures] FeatureSetEditionDefault overridableFeatures
                  * @property {google.protobuf.IFeatureSet|null} [fixedFeatures] FeatureSetEditionDefault fixedFeatures
+                 * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
                  */
 
                 /**
@@ -22082,6 +22595,7 @@ $root.google = (function() {
                  * @implements IFeatureSetEditionDefault
                  * @constructor
                  * @param {google.protobuf.FeatureSetDefaults.IFeatureSetEditionDefault=} [properties] Properties to set
+                 * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
                  */
                 function FeatureSetEditionDefault(properties) {
                     if (properties)
@@ -22144,6 +22658,9 @@ $root.google = (function() {
                         $root.google.protobuf.FeatureSet.encode(message.overridableFeatures, writer.uint32(/* id 4, wireType 2 =*/34).fork()).ldelim();
                     if (message.fixedFeatures != null && Object.hasOwnProperty.call(message, "fixedFeatures"))
                         $root.google.protobuf.FeatureSet.encode(message.fixedFeatures, writer.uint32(/* id 5, wireType 2 =*/42).fork()).ldelim();
+                    if (message.$unknowns != null && Object.hasOwnProperty.call(message, "$unknowns"))
+                        for (var i = 0; i < message.$unknowns.length; ++i)
+                            writer.raw(message.$unknowns[i]);
                     return writer;
                 };
 
@@ -22180,6 +22697,7 @@ $root.google = (function() {
                         throw Error("max depth exceeded");
                     var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.google.protobuf.FeatureSetDefaults.FeatureSetEditionDefault();
                     while (reader.pos < end) {
+                        var start = reader.pos;
                         var tag = reader.uint32();
                         if (tag === _end) {
                             _end = undefined;
@@ -22200,6 +22718,8 @@ $root.google = (function() {
                             }
                         default:
                             reader.skipType(tag & 7, _depth, tag >>> 3);
+                            $util.makeProp(message, "$unknowns", false);
+                            (message.$unknowns || (message.$unknowns = [])).push(reader.raw(start, reader.pos));
                             break;
                         }
                     }
@@ -22421,6 +22941,7 @@ $root.google = (function() {
              * @memberof google.protobuf
              * @interface ISourceCodeInfo
              * @property {Array.<google.protobuf.SourceCodeInfo.ILocation>|null} [location] SourceCodeInfo location
+             * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
              */
 
             /**
@@ -22430,6 +22951,7 @@ $root.google = (function() {
              * @implements ISourceCodeInfo
              * @constructor
              * @param {google.protobuf.ISourceCodeInfo=} [properties] Properties to set
+             * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
              */
             function SourceCodeInfo(properties) {
                 this.location = [];
@@ -22474,6 +22996,9 @@ $root.google = (function() {
                 if (message.location != null && message.location.length)
                     for (var i = 0; i < message.location.length; ++i)
                         $root.google.protobuf.SourceCodeInfo.Location.encode(message.location[i], writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
+                if (message.$unknowns != null && Object.hasOwnProperty.call(message, "$unknowns"))
+                    for (var i = 0; i < message.$unknowns.length; ++i)
+                        writer.raw(message.$unknowns[i]);
                 return writer;
             };
 
@@ -22510,6 +23035,7 @@ $root.google = (function() {
                     throw Error("max depth exceeded");
                 var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.google.protobuf.SourceCodeInfo();
                 while (reader.pos < end) {
+                    var start = reader.pos;
                     var tag = reader.uint32();
                     if (tag === _end) {
                         _end = undefined;
@@ -22524,6 +23050,8 @@ $root.google = (function() {
                         }
                     default:
                         reader.skipType(tag & 7, _depth, tag >>> 3);
+                        $util.makeProp(message, "$unknowns", false);
+                        (message.$unknowns || (message.$unknowns = [])).push(reader.raw(start, reader.pos));
                         break;
                     }
                 }
@@ -22664,6 +23192,7 @@ $root.google = (function() {
                  * @property {string|null} [leadingComments] Location leadingComments
                  * @property {string|null} [trailingComments] Location trailingComments
                  * @property {Array.<string>|null} [leadingDetachedComments] Location leadingDetachedComments
+                 * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
                  */
 
                 /**
@@ -22673,6 +23202,7 @@ $root.google = (function() {
                  * @implements ILocation
                  * @constructor
                  * @param {google.protobuf.SourceCodeInfo.ILocation=} [properties] Properties to set
+                 * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
                  */
                 function Location(properties) {
                     this.path = [];
@@ -22767,6 +23297,9 @@ $root.google = (function() {
                     if (message.leadingDetachedComments != null && message.leadingDetachedComments.length)
                         for (var i = 0; i < message.leadingDetachedComments.length; ++i)
                             writer.uint32(/* id 6, wireType 2 =*/50).string(message.leadingDetachedComments[i]);
+                    if (message.$unknowns != null && Object.hasOwnProperty.call(message, "$unknowns"))
+                        for (var i = 0; i < message.$unknowns.length; ++i)
+                            writer.raw(message.$unknowns[i]);
                     return writer;
                 };
 
@@ -22803,6 +23336,7 @@ $root.google = (function() {
                         throw Error("max depth exceeded");
                     var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.google.protobuf.SourceCodeInfo.Location();
                     while (reader.pos < end) {
+                        var start = reader.pos;
                         var tag = reader.uint32();
                         if (tag === _end) {
                             _end = undefined;
@@ -22849,6 +23383,8 @@ $root.google = (function() {
                             }
                         default:
                             reader.skipType(tag & 7, _depth, tag >>> 3);
+                            $util.makeProp(message, "$unknowns", false);
+                            (message.$unknowns || (message.$unknowns = [])).push(reader.raw(start, reader.pos));
                             break;
                         }
                     }
@@ -23045,6 +23581,7 @@ $root.google = (function() {
              * @memberof google.protobuf
              * @interface IGeneratedCodeInfo
              * @property {Array.<google.protobuf.GeneratedCodeInfo.IAnnotation>|null} [annotation] GeneratedCodeInfo annotation
+             * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
              */
 
             /**
@@ -23054,6 +23591,7 @@ $root.google = (function() {
              * @implements IGeneratedCodeInfo
              * @constructor
              * @param {google.protobuf.IGeneratedCodeInfo=} [properties] Properties to set
+             * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
              */
             function GeneratedCodeInfo(properties) {
                 this.annotation = [];
@@ -23098,6 +23636,9 @@ $root.google = (function() {
                 if (message.annotation != null && message.annotation.length)
                     for (var i = 0; i < message.annotation.length; ++i)
                         $root.google.protobuf.GeneratedCodeInfo.Annotation.encode(message.annotation[i], writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
+                if (message.$unknowns != null && Object.hasOwnProperty.call(message, "$unknowns"))
+                    for (var i = 0; i < message.$unknowns.length; ++i)
+                        writer.raw(message.$unknowns[i]);
                 return writer;
             };
 
@@ -23134,6 +23675,7 @@ $root.google = (function() {
                     throw Error("max depth exceeded");
                 var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.google.protobuf.GeneratedCodeInfo();
                 while (reader.pos < end) {
+                    var start = reader.pos;
                     var tag = reader.uint32();
                     if (tag === _end) {
                         _end = undefined;
@@ -23148,6 +23690,8 @@ $root.google = (function() {
                         }
                     default:
                         reader.skipType(tag & 7, _depth, tag >>> 3);
+                        $util.makeProp(message, "$unknowns", false);
+                        (message.$unknowns || (message.$unknowns = [])).push(reader.raw(start, reader.pos));
                         break;
                     }
                 }
@@ -23288,6 +23832,7 @@ $root.google = (function() {
                  * @property {number|null} [begin] Annotation begin
                  * @property {number|null} [end] Annotation end
                  * @property {google.protobuf.GeneratedCodeInfo.Annotation.Semantic|null} [semantic] Annotation semantic
+                 * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
                  */
 
                 /**
@@ -23297,6 +23842,7 @@ $root.google = (function() {
                  * @implements IAnnotation
                  * @constructor
                  * @param {google.protobuf.GeneratedCodeInfo.IAnnotation=} [properties] Properties to set
+                 * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
                  */
                 function Annotation(properties) {
                     this.path = [];
@@ -23384,6 +23930,9 @@ $root.google = (function() {
                         writer.uint32(/* id 4, wireType 0 =*/32).int32(message.end);
                     if (message.semantic != null && Object.hasOwnProperty.call(message, "semantic"))
                         writer.uint32(/* id 5, wireType 0 =*/40).int32(message.semantic);
+                    if (message.$unknowns != null && Object.hasOwnProperty.call(message, "$unknowns"))
+                        for (var i = 0; i < message.$unknowns.length; ++i)
+                            writer.raw(message.$unknowns[i]);
                     return writer;
                 };
 
@@ -23420,6 +23969,7 @@ $root.google = (function() {
                         throw Error("max depth exceeded");
                     var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.google.protobuf.GeneratedCodeInfo.Annotation();
                     while (reader.pos < end) {
+                        var start = reader.pos;
                         var tag = reader.uint32();
                         if (tag === _end) {
                             _end = undefined;
@@ -23456,6 +24006,8 @@ $root.google = (function() {
                             }
                         default:
                             reader.skipType(tag & 7, _depth, tag >>> 3);
+                            $util.makeProp(message, "$unknowns", false);
+                            (message.$unknowns || (message.$unknowns = [])).push(reader.raw(start, reader.pos));
                             break;
                         }
                     }

--- a/tests/data/type_url.js
+++ b/tests/data/type_url.js
@@ -16,6 +16,7 @@ $root.TypeUrlTest = (function() {
      * @exports ITypeUrlTest
      * @interface ITypeUrlTest
      * @property {TypeUrlTest.INested|null} [nested] TypeUrlTest nested
+     * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
      */
 
     /**
@@ -25,6 +26,7 @@ $root.TypeUrlTest = (function() {
      * @implements ITypeUrlTest
      * @constructor
      * @param {ITypeUrlTest=} [properties] Properties to set
+     * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
      */
     function TypeUrlTest(properties) {
         if (properties)
@@ -67,6 +69,9 @@ $root.TypeUrlTest = (function() {
             writer = $Writer.create();
         if (message.nested != null && Object.hasOwnProperty.call(message, "nested"))
             $root.TypeUrlTest.Nested.encode(message.nested, writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
+        if (message.$unknowns != null && Object.hasOwnProperty.call(message, "$unknowns"))
+            for (var i = 0; i < message.$unknowns.length; ++i)
+                writer.raw(message.$unknowns[i]);
         return writer;
     };
 
@@ -103,6 +108,7 @@ $root.TypeUrlTest = (function() {
             throw Error("max depth exceeded");
         var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.TypeUrlTest();
         while (reader.pos < end) {
+            var start = reader.pos;
             var tag = reader.uint32();
             if (tag === _end) {
                 _end = undefined;
@@ -115,6 +121,8 @@ $root.TypeUrlTest = (function() {
                 }
             default:
                 reader.skipType(tag & 7, _depth, tag >>> 3);
+                $util.makeProp(message, "$unknowns", false);
+                (message.$unknowns || (message.$unknowns = [])).push(reader.raw(start, reader.pos));
                 break;
             }
         }
@@ -239,6 +247,7 @@ $root.TypeUrlTest = (function() {
          * @memberof TypeUrlTest
          * @interface INested
          * @property {string|null} [a] Nested a
+         * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
          */
 
         /**
@@ -248,6 +257,7 @@ $root.TypeUrlTest = (function() {
          * @implements INested
          * @constructor
          * @param {TypeUrlTest.INested=} [properties] Properties to set
+         * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding
          */
         function Nested(properties) {
             if (properties)
@@ -290,6 +300,9 @@ $root.TypeUrlTest = (function() {
                 writer = $Writer.create();
             if (message.a != null && Object.hasOwnProperty.call(message, "a"))
                 writer.uint32(/* id 1, wireType 2 =*/10).string(message.a);
+            if (message.$unknowns != null && Object.hasOwnProperty.call(message, "$unknowns"))
+                for (var i = 0; i < message.$unknowns.length; ++i)
+                    writer.raw(message.$unknowns[i]);
             return writer;
         };
 
@@ -326,6 +339,7 @@ $root.TypeUrlTest = (function() {
                 throw Error("max depth exceeded");
             var end = length === undefined ? reader.len : reader.pos + length, message = _target || new $root.TypeUrlTest.Nested();
             while (reader.pos < end) {
+                var start = reader.pos;
                 var tag = reader.uint32();
                 if (tag === _end) {
                     _end = undefined;
@@ -338,6 +352,8 @@ $root.TypeUrlTest = (function() {
                     }
                 default:
                     reader.skipType(tag & 7, _depth, tag >>> 3);
+                    $util.makeProp(message, "$unknowns", false);
+                    (message.$unknowns || (message.$unknowns = [])).push(reader.raw(start, reader.pos));
                     break;
                 }
             }


### PR DESCRIPTION
Preserves unknown fields encountered during binary decoding and writes them back during encoding, enabling forward-compatible binary roundtrips.

Unknown field data is stored on messages as a non-enumerable, user-accessible `$unknowns` property. Deleting `$unknowns` discards preserved unknown fields explicitly. Also adds `Reader#raw` and `Writer#raw` helpers for reading and writing raw wire bytes directly.

Fixes #775
Fixes #1619 via `Writer#raw`

Supersedes #779
Supersedes #1912

Related: #296