### PR TITLE
test: Fix up conformance tests

### DIFF
--- a/tests/comp_maps.js
+++ b/tests/comp_maps.js
@@ -168,19 +168,19 @@ tape.test("maps", function(test) {
 
         // 1 <chunk> = message(1 <varint> = 0, 2 <chunk> = empty chunk)
         dec = MapMessage.decode(Uint8Array.of(0x0a, 0x04, 0x08, 0x00, 0x12, 0x00));
-        test.deepEqual(MapMessage.toObject(dec), value, "should correct decode the buffer without omitted fields");
+        test.deepEqual(MapMessage.toObject(dec), value, "should correctly decode the buffer without omitted fields");
 
         // 1 <chunk> = message(1 <varint> = 0)
         dec = MapMessage.decode(Uint8Array.of(0x0a, 0x02, 0x08, 0x00));
-        test.deepEqual(MapMessage.toObject(dec), value, "should correct decode the buffer with omitted value");
+        test.deepEqual(MapMessage.toObject(dec), value, "should correctly decode the buffer with omitted value");
 
         // 1 <chunk> = message(2 <chunk> = empty chunk)
         dec = MapMessage.decode(Uint8Array.of(0x0a, 0x02, 0x12, 0x00));
-        test.deepEqual(MapMessage.toObject(dec), value, "should correct decode the buffer with omitted key");
+        test.deepEqual(MapMessage.toObject(dec), value, "should correctly decode the buffer with omitted key");
 
         // 1 <chunk> = empty chunk
         dec = MapMessage.decode(Uint8Array.of(0x0a, 0x00));
-        test.deepEqual(MapMessage.toObject(dec), value, "should correct decode the buffer with both key and value omitted");
+        test.deepEqual(MapMessage.toObject(dec), value, "should correctly decode the buffer with both key and value omitted");
 
         test.end();
     });
@@ -282,7 +282,7 @@ tape.test("maps", function(test) {
 
 function verifyEncode(test, buf) {
     test.test(test.name + " - should encode", function(test) {
-        test.equal(buf.length, 32, "a total of 30 bytes");
+        test.equal(buf.length, 32, "a total of 32 bytes");
 
         // first kv:
         /*

--- a/tests/comp_oneof.js
+++ b/tests/comp_oneof.js
@@ -50,7 +50,7 @@ tape.test("oneofs", function(test) {
     delete message.other;
     var buf = Message.encode(message).finish();
     test.equal(buf.length, 2, "should write a total of 2 bytes");
-    test.equal(buf[0], 16, "should write id 1, wireType 0");
+    test.equal(buf[0], 16, "should write id 2, wireType 0");
     test.equal(buf[1], 0, "should write a value of 0");
 
     message = Message.decode([ 10, 1, 97, 16, 1 ]);

--- a/tests/comp_optional.js
+++ b/tests/comp_optional.js
@@ -48,8 +48,8 @@ tape.test("proto3 implicit scalar defaults", function(test) {
     }
 
     test.same(reencode([8, 0]), [], "should omit default int32");
-    test.same(reencode([26, 0]), [], "should omit default string");
-    test.same(reencode([34, 0]), [], "should omit default bytes");
+    test.same(reencode([34, 0]), [], "should omit default string");
+    test.same(reencode([42, 0]), [], "should omit default bytes");
     test.same(reencode([48, 0]), [], "should omit default int64");
     test.same(reencode([56, 0]), [], "should omit default bool");
     test.same(reencode([16, 0]), [16, 0], "should preserve proto3 optional default");

--- a/tests/comp_packed-repeated.js
+++ b/tests/comp_packed-repeated.js
@@ -55,7 +55,7 @@ tape.test("packed repeated values encode", function(top) {
             var Test = root.lookup("Test");
 
             var buf = Test.encode(msg).finish();
-            test.equal(buf.length, 5, "a total of 4 bytes");
+            test.equal(buf.length, 5, "a total of 5 bytes");
             test.equal(buf[0], 1 << 3 | 2, "id 1, wireType 2");
             test.equal(buf[1], 3, "length 3");
             test.equal(buf[2], 1, "element 1");
@@ -69,7 +69,7 @@ tape.test("packed repeated values encode", function(top) {
     top.end()
 });
 
-tape.test("packed repeated values encode", function(top) {
+tape.test("unpacked repeated values encode", function(top) {
     [
         unpackedOption,
         regular,


### PR DESCRIPTION
Fixes the currently failing proto3 scalar presence test to use the correct wire tags for string and bytes fields, and cleans up a few adjacent test descriptions.

Discovered from the interaction between earlier changes when merging #2209.