### PR TITLE
perf: Avoid constructor setup during resolve

### DIFF
--- a/src/field.js
+++ b/src/field.js
@@ -352,8 +352,8 @@ Field.prototype.resolve = function resolve() {
         this.defaultValue = this.typeDefault;
 
     // ensure proper value on prototype
-    if (this.parent instanceof Type)
-        this.parent.ctor.prototype[this.name] = this.defaultValue;
+    if (this.parent instanceof Type && this.parent._ctor)
+        this.parent._ctor.prototype[this.name] = this.defaultValue;
 
     return ReflectionObject.prototype.resolve.call(this);
 };

--- a/src/namespace.js
+++ b/src/namespace.js
@@ -356,7 +356,8 @@ Namespace.prototype.define = function define(path, json) {
 Namespace.prototype.resolveAll = function resolveAll() {
     if (!this._needsRecursiveResolve) return this;
 
-    this._resolveFeaturesRecursive(this._edition);
+    if (this._needsRecursiveFeatureResolution)
+        this._resolveFeaturesRecursive(this._edition);
 
     var nested = this.nestedArray, i = 0;
     this.resolve();

--- a/src/type.js
+++ b/src/type.js
@@ -174,8 +174,10 @@ Object.defineProperties(Type.prototype, {
 
             // Messages have non-enumerable default values on their prototype
             var i = 0;
-            for (; i < /* initializes */ this.fieldsArray.length; ++i)
-                this._fieldsArray[i].resolve(); // ensures a proper value
+            for (var field; i < /* initializes */ this.fieldsArray.length; ++i) {
+                field = this._fieldsArray[i].resolve(); // ensures a proper value
+                ctor.prototype[field.name] = field.defaultValue;
+            }
 
             // Messages have non-enumerable getters and setters for each virtual oneof field
             var ctorProperties = {};
@@ -493,15 +495,13 @@ Type.prototype.setup = function setup() {
     // Inject custom wrappers for common types
     var wrapper = wrappers[fullName];
     if (wrapper) {
-        var originalThis = Object.create(this);
-        // if (wrapper.fromObject) {
-            originalThis.fromObject = this.fromObject;
-            this.fromObject = wrapper.fromObject.bind(originalThis);
-        // }
-        // if (wrapper.toObject) {
-            originalThis.toObject = this.toObject;
-            this.toObject = wrapper.toObject.bind(originalThis);
-        // }
+        var wrapperThis = Object.create(this);
+        // Reuse this type's runtime constructor in wrapper fromObject/toObject
+        wrapperThis._ctor = this.ctor;
+        wrapperThis.fromObject = this.fromObject;
+        this.fromObject = wrapper.fromObject.bind(wrapperThis);
+        wrapperThis.toObject = this.toObject;
+        this.toObject = wrapper.toObject.bind(wrapperThis);
     }
 
     return this;

--- a/tests/api_type.js
+++ b/tests/api_type.js
@@ -44,12 +44,14 @@ tape.test("reflected types", function(test) {
     type.ctor = MyMessageAuto;
     test.ok(MyMessageAuto.prototype instanceof protobuf.Message, "should properly register a constructor through assignment");
     test.ok(typeof MyMessageAuto.encode === "function", "should populate static methods on assigned constructors");
+    test.equal(new MyMessageAuto().a, 0, "should initialize prototype defaults on assigned constructors");
 
     function MyMessageManual() {}
     MyMessageManual.prototype = Object.create(protobuf.Message.prototype);
     type.ctor = MyMessageManual;
     test.ok(MyMessageManual.prototype instanceof protobuf.Message, "should properly register a constructor through assignment if already extending message");
     test.ok(typeof MyMessageManual.encode === "function", "should populate static methods on assigned constructors");
+    test.equal(new MyMessageManual().a, 0, "should initialize prototype defaults on assigned constructors if already extending message");
 
     type = protobuf.Type.fromJSON("My", {
         fields: {


### PR DESCRIPTION
Resolving fields currently reads `parent.ctor` to install prototype defaults. Since `ctor` is a lazy getter, this also generates a runtime message constructor for every resolved type. That constructor setup then resolves the same fields again.

This PR separates reflection resolution from runtime constructor initialization:

- `Field#resolve` updates prototype defaults only for constructors that already exist, avoiding the lazy `ctor` getter.
- `Type#ctor` initializes prototype defaults when a constructor is actually created or registered.
- wrapper setup reuses the type's runtime `ctor` instead of creating a second one.
- additionally, recursive feature resolution is skipped when the feature tree is already clean.

On a synthetic benchmark with many cross-type references, this removes one redundant field-resolution pass and avoids generating constructors during schema loading, improving `fromJSON` by roughly 40-50% depending on schema size.

For `1500 types x 4 refs`, the median local `fromJSON` time went from 9.150ms to 4.855ms. The relevant call counts changed from 12000 to 6000 `Field#resolve` calls and from 1500 generated constructors during load to 0.

So instead of rolling back eager resolution as proposed in #2157, this keeps the current eager semantics while reducing redundant work.

Follow-up to #2066 and #2068
Addresses #2123