### PR TITLE
deps: Bump CLI peer dependency

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -18,7 +18,7 @@
     "pbts": "bin/pbts"
   },
   "peerDependencies": {
-    "protobufjs": ">=8.0.4 <9"
+    "protobufjs": ">=8.1.0 <9"
   },
   "dependencies": {
     "chalk": "^4.0.0",


### PR DESCRIPTION
Bumps the protobufjs-cli peer dependency to require the expected protobufjs 8.1.0 feature release triggered by #2209.