### PR TITLE
fix: Correct parsedOptions TypeScript types

### DIFF
--- a/cli/lib/tsd-jsdoc/publish.js
+++ b/cli/lib/tsd-jsdoc/publish.js
@@ -276,19 +276,25 @@ function getTypeOf(element) {
     // Ensure upper case Object for map expressions below
     name = name.replace(/\bobject\b/g, "Object");
 
+    // Convert innermost generic types first so Array.<Object.<...>>
+    // and Object.<string,Array.<...>> are both handled correctly
+    var prevName;
+    do {
+        prevName = name;
+        name = name.replace(/\bObject\.?<([^,<>]*), *([^<>]*)>/gi, function($0, $1, $2) {
+            return "{ [k: " + $1 + "]: " + $2 + " }";
+        });
+        name = name.replace(/\bArray\.?<([^<>]*)>/gi, function($0, $1) {
+            return $1 + "[]";
+        });
+        name = name.replace(/\b(?!Object|Array)([\w$]+)\.<([^<>]*)>/gi, function($0, $1, $2) {
+            return $1 + "<" + $2 + ">";
+        });
+    } while (name !== prevName);
+
     // Correct Something.<Something> to Something<Something>
     name = replaceRecursive(name, /\b(?!Object|Array)([\w$]+)\.<([^>]*)>/gi, function($0, $1, $2) {
         return $1 + "<" + $2 + ">";
-    });
-
-    // Replace Array.<string> with string[]
-    name = replaceRecursive(name, /\bArray\.?<([^>]*)>/gi, function($0, $1) {
-        return $1 + "[]";
-    });
-
-    // Replace Object.<string,number> with { [k: string]: number }
-    name = replaceRecursive(name, /\bObject\.?<([^,]*), *([^>]*)>/gi, function($0, $1, $2) {
-        return "{ [k: " + $1 + "]: " + $2 + " }";
     });
 
     // Replace functions (there are no signatures) with Function

--- a/index.d.ts
+++ b/index.d.ts
@@ -262,6 +262,15 @@ export class Field extends FieldBase {
     constructor(name: string, id: number, type: string, rule?: (string|{ [k: string]: any }), extend?: (string|{ [k: string]: any }), options?: { [k: string]: any });
 
     /**
+     * Field decorator (TypeScript).
+     * @param fieldId Field id
+     * @param fieldType Field type
+     * @param [fieldRule="optional"] Field rule
+     * @returns Decorator function
+     */
+    public static d<T extends Message<T>>(fieldId: number, fieldType: (Constructor<T>|string), fieldRule?: ("optional"|"required"|"repeated")): FieldDecorator;
+
+    /**
      * Constructs a field from a field descriptor.
      * @param name Field name
      * @param json Field descriptor
@@ -297,15 +306,6 @@ export class Field extends FieldBase {
      * @returns Decorator function
      */
     public static d<T extends number | number[] | Long | Long[] | string | string[] | boolean | boolean[] | Uint8Array | Uint8Array[] | Buffer | Buffer[]>(fieldId: number, fieldType: ("double"|"float"|"int32"|"uint32"|"sint32"|"fixed32"|"sfixed32"|"int64"|"uint64"|"sint64"|"fixed64"|"sfixed64"|"string"|"bool"|"bytes"|object), fieldRule?: ("optional"|"required"|"repeated"), defaultValue?: T): FieldDecorator;
-
-    /**
-     * Field decorator (TypeScript).
-     * @param fieldId Field id
-     * @param fieldType Field type
-     * @param [fieldRule="optional"] Field rule
-     * @returns Decorator function
-     */
-    public static d<T extends Message<T>>(fieldId: number, fieldType: (Constructor<T>|string), fieldRule?: ("optional"|"required"|"repeated")): FieldDecorator;
 }
 
 /** Base class of all reflected message fields. This is not an actual class but here for the sake of having consistent type definitions. */
@@ -539,14 +539,14 @@ export class Message<T extends object = object> {
      */
     constructor(properties?: Properties<T>);
 
+    /** Unknown fields preserved while decoding */
+    public $unknowns?: Uint8Array[];
+
     /** Reference to the reflected type. */
     public static readonly $type: Type;
 
     /** Reference to the reflected type. */
     public readonly $type: Type;
-
-    /** Unknown fields preserved while decoding. */
-    public $unknowns?: Uint8Array[];
 
     /**
      * Creates a new message of this type using the specified properties.
@@ -627,9 +627,9 @@ export class Method extends ReflectionObject {
      * @param [responseStream] Whether the response is streamed
      * @param [options] Declared options
      * @param [comment] The comment for this method
-     * @param [parsedOptions] Declared options, properly parsed into an object
+     * @param [parsedOptions] Declared options, properly parsed into objects
      */
-    constructor(name: string, type: (string|undefined), requestType: string, responseType: string, requestStream?: (boolean|{ [k: string]: any }), responseStream?: (boolean|{ [k: string]: any }), options?: { [k: string]: any }, comment?: string, parsedOptions?: { [k: string]: any });
+    constructor(name: string, type: (string|undefined), requestType: string, responseType: string, requestStream?: (boolean|{ [k: string]: any }), responseStream?: (boolean|{ [k: string]: any }), options?: { [k: string]: any }, comment?: string, parsedOptions?: { [k: string]: any }[]);
 
     /** Method type. */
     public type: string;
@@ -655,8 +655,8 @@ export class Method extends ReflectionObject {
     /** Comment for this method */
     public comment: (string|null);
 
-    /** Options properly parsed into an object */
-    public parsedOptions: any;
+    /** Options properly parsed into objects */
+    public parsedOptions?: { [k: string]: any }[];
 
     /**
      * Constructs a method from a method descriptor.
@@ -699,8 +699,8 @@ export interface IMethod {
     /** Method comments */
     comment: string;
 
-    /** Method options properly parsed into an object */
-    parsedOptions?: { [k: string]: any };
+    /** Method options properly parsed into objects */
+    parsedOptions?: { [k: string]: any }[];
 }
 
 /** Reflected namespace. */
@@ -901,7 +901,7 @@ export abstract class ReflectionObject {
     public options?: { [k: string]: any };
 
     /** Parsed Options. */
-    public parsedOptions?: { [k: string]: any[] };
+    public parsedOptions?: { [k: string]: any }[];
 
     /** Unique name within its namespace. */
     public name: string;

--- a/src/method.js
+++ b/src/method.js
@@ -20,7 +20,7 @@ var util = require("./util");
  * @param {boolean|Object.<string,*>} [responseStream] Whether the response is streamed
  * @param {Object.<string,*>} [options] Declared options
  * @param {string} [comment] The comment for this method
- * @param {Object.<string,*>} [parsedOptions] Declared options, properly parsed into an object
+ * @param {Array.<Object.<string,*>>} [parsedOptions] Declared options, properly parsed into objects
  */
 function Method(name, type, requestType, responseType, requestStream, responseStream, options, comment, parsedOptions) {
 
@@ -96,7 +96,8 @@ function Method(name, type, requestType, responseType, requestStream, responseSt
     this.comment = comment;
 
     /**
-     * Options properly parsed into an object
+     * Options properly parsed into objects
+     * @type {Array.<Object.<string,*>>|undefined}
      */
     this.parsedOptions = parsedOptions;
 }
@@ -111,7 +112,7 @@ function Method(name, type, requestType, responseType, requestStream, responseSt
  * @property {boolean} [responseStream=false] Whether responses are streamed
  * @property {Object.<string,*>} [options] Method options
  * @property {string} comment Method comments
- * @property {Object.<string,*>} [parsedOptions] Method options properly parsed into an object
+ * @property {Array.<Object.<string,*>>} [parsedOptions] Method options properly parsed into objects
  */
 
 /**

--- a/tests/comp_typescript.js
+++ b/tests/comp_typescript.js
@@ -22,6 +22,7 @@ var __decorate = (this && this.__decorate) || function (decorators, target, key,
 var __metadata = (this && this.__metadata) || function (k, v) {
     if (typeof Reflect === "object" && typeof Reflect.metadata === "function") return Reflect.metadata(k, v);
 };
+var _a, _b;
 exports.__esModule = true;
 exports.AwesomeMessage = exports.AwesomeSubMessage = exports.AwesomeEnum = exports.Hello = void 0;
 var __1 = require("..");
@@ -41,6 +42,9 @@ var root = __1.Root.fromJSON({
 });
 var HelloReflected = root.lookupType("Hello");
 HelloReflected.create({ value: "hi" });
+var parsedOptionValue = (_a = HelloReflected.parsedOptions) === null || _a === void 0 ? void 0 : _a[0]["(custom_option)"];
+var reflectedMethod = new __1.Method("Call", undefined, "Hello", "Hello", false, false, undefined, undefined, [{ option: 1 }]);
+var parsedMethodOptionValue = (_b = reflectedMethod.parsedOptions) === null || _b === void 0 ? void 0 : _b[0].option;
 // Custom classes
 var Hello = /** @class */ (function (_super) {
     __extends(Hello, _super);

--- a/tests/comp_typescript.ts
+++ b/tests/comp_typescript.ts
@@ -1,6 +1,6 @@
 // test currently consists only of not throwing
 
-import { Root, Message, Type, Field, MapField, OneOf } from "..";
+import { Root, Message, Method, Type, Field, MapField, OneOf } from "..";
 
 // Reflection
 const root = Root.fromJSON({
@@ -19,6 +19,10 @@ const root = Root.fromJSON({
 const HelloReflected = root.lookupType("Hello");
 
 HelloReflected.create({ value: "hi" });
+
+const parsedOptionValue: number | undefined = HelloReflected.parsedOptions?.[0]["(custom_option)"];
+const reflectedMethod = new Method("Call", undefined, "Hello", "Hello", false, false, undefined, undefined, [{ option: 1 }]);
+const parsedMethodOptionValue: number | undefined = reflectedMethod.parsedOptions?.[0].option;
 
 // Custom classes
 


### PR DESCRIPTION
Fixes the generated TypeScript types for `parsedOptions`, which should use `{ [k: string]: any }[]`.

Required a small fix in the local `tsd-jsdoc` conversion for nested types.

Supersedes #2100