### PR TITLE
fix: Also resolve common definitions by file name

### DIFF
--- a/src/root.js
+++ b/src/root.js
@@ -130,8 +130,9 @@ Root.prototype.load = function load(filename, options, callback) {
         var idx = filename.lastIndexOf("google/protobuf/");
         if (idx > -1) {
             var altname = filename.substring(idx);
-            if (altname in common) return altname;
+            if (Object.prototype.hasOwnProperty.call(common, altname)) return altname;
         }
+        if (Object.prototype.hasOwnProperty.call(common, filename)) return filename;
         return null;
     }
 
@@ -175,7 +176,7 @@ Root.prototype.load = function load(filename, options, callback) {
         self.files.push(filename);
 
         // Shortcut bundled definitions
-        if (filename in common) {
+        if (Object.prototype.hasOwnProperty.call(common, filename)) {
             if (sync) {
                 process(filename, common[filename]);
             } else {

--- a/tests/data/common-custom.proto
+++ b/tests/data/common-custom.proto
@@ -1,0 +1,7 @@
+syntax = "proto3";
+
+import "custom/common.proto";
+
+message UsesCustomCommon {
+  custom.CommonMessage value = 1;
+}

--- a/tests/node/api_load-sync.js
+++ b/tests/node/api_load-sync.js
@@ -46,3 +46,30 @@ tape.test("should load bundled definitions even if resolvePath method was overri
     test.ok(root.lookup("Something"), "should parse message Something");
     test.end();
 });
+
+tape.test("should load custom common definitions by full file name", function(test) {
+    protobuf.common("custom/common.proto", {
+        nested: {
+            custom: {
+                nested: {
+                    CommonMessage: {
+                        fields: {}
+                    }
+                }
+            }
+        }
+    });
+
+    try {
+        var root = protobuf.loadSync("tests/data/common-custom.proto");
+
+        test.ok(root.files.indexOf("custom/common.proto") > -1, "should track the custom common file name");
+        test.ok(root.lookup("custom.CommonMessage"), "should load the custom common type");
+        test.ok(root.lookup("UsesCustomCommon"), "should parse the importing message");
+    } catch (err) {
+        test.fail(err && err.message || err);
+    } finally {
+        delete protobuf.common["custom/common.proto"];
+        test.end();
+    }
+});


### PR DESCRIPTION
Fixes loading custom common definitions registered by full file name, before resolving imports relative to the importing file. This matches the existing `protobuf.common` documentation, which already describes passing a full file name for custom definitions.

Supersedes #2036