### PR TITLE
perf: Preallocate arrays in converters

### DIFF
--- a/src/converter.js
+++ b/src/converter.js
@@ -141,7 +141,7 @@ converter.fromObject = function fromObject(mtype) {
     ("if(d%s){", prop)
         ("if(!Array.isArray(d%s))", prop)
             ("throw TypeError(%j)", field.fullName + ": array expected")
-        ("m%s=[]", prop)
+        ("m%s=Array(d%s.length)", prop, prop)
         ("for(var i=0;i<d%s.length;++i){", prop);
             genValuePartial_fromObject(gen, field, /* not sorted */ i, prop + "[i]")
         ("}")
@@ -317,7 +317,7 @@ converter.toObject = function toObject(mtype) {
         ("}");
         } else if (field.repeated) { gen
     ("if(m%s&&m%s.length){", prop, prop)
-        ("d%s=[]", prop)
+        ("d%s=Array(m%s.length)", prop, prop)
         ("for(var j=0;j<m%s.length;++j){", prop);
             genValuePartial_toObject(gen, field, /* sorted */ index, prop + "[j]")
         ("}");


### PR DESCRIPTION
Preallocates repeated-field arrays in generated `fromObject` and `toObject` converters when the source array length is already known.

This improves converter-heavy usage, but does not affect wire decoding as originally implied in the superseded PR.

Supersedes #2033