### PR TITLE
fix: Tighten key2Re regex with non-capturing group

### DIFF
--- a/src/util/minimal.js
+++ b/src/util/minimal.js
@@ -186,7 +186,7 @@ util.Long = /* istanbul ignore next */ util.global.dcodeIO && /* istanbul ignore
  * @type {RegExp}
  * @const
  */
-util.key2Re = /^true|false|0|1$/;
+util.key2Re = /^(?:true|false|0|1)$/;
 
 /**
  * Regular expression used to verify 32 bit (`int32` etc.) map keys.

--- a/tests/api_util.js
+++ b/tests/api_util.js
@@ -169,5 +169,21 @@ tape.test("util", function(test) {
         test.end();
     });
 
+    test.test(test.name + " - key2Re", function(test) {
+        [ "true", "false", "0", "1" ].forEach(function(k) {
+            test.ok(util.key2Re.test(k), "should accept canonical bool key " + JSON.stringify(k));
+        });
+        [
+            "TRUE", "FALSE", "True",
+            "yes", "no",
+            "trueblue", "true-yes", "blah-false-blah",
+            "x100x", "abc1", "100", "0x0", "01",
+            "true ", " true", "", "truefalse"
+        ].forEach(function(k) {
+            test.notOk(util.key2Re.test(k), "should reject non-canonical bool key " + JSON.stringify(k));
+        });
+        test.end();
+    });
+
     test.end();
 });


### PR DESCRIPTION
Add non-capturing group so verify() only matches canonical bool keys: "true", "false", "0", "1".