### PR TITLE
fix: Improve Deno and Bun compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,6 +300,10 @@ For protobuf descriptor interoperability, see [ext/descriptor](./ext/descriptor)
 
 In [CSP](https://w3c.github.io/webappsec-csp/)-restricted environments that disallow unsafe-eval, use generated static code instead of runtime code generation.
 
+## Compatibility
+
+Supported runtimes are browsers, Node.js v12+, Deno (`deno add npm:protobufjs`) and Bun (`bun add protobufjs`). When using the CLI with Bun, Node.js must also be installed.
+
 ## Conformance
 
 protobuf.js targets full binary wire-format conformance for **Proto2**, **Proto3** and **Editions**. CI runs the official Protocol Buffers conformance suite, with logs uploaded as artifacts.

--- a/cli/package.json
+++ b/cli/package.json
@@ -12,6 +12,7 @@
   },
   "license": "BSD-3-Clause",
   "main": "index.js",
+  "type": "commonjs",
   "types": "index.d.ts",
   "bin": {
     "pbjs": "bin/pbjs",

--- a/cli/pbts.js
+++ b/cli/pbts.js
@@ -97,7 +97,10 @@ exports.main = function(args, callback) {
         // There is no proper API for jsdoc, so this executes the CLI and pipes the output
         var basedir = path.join(__dirname, ".");
         var moduleName = argv.name || "null";
-        var nodePath = process.execPath;
+        // JSDoc 4 uses requizzle, which depends on Node's CommonJS loader internals.
+        var nodePath = typeof Bun === "undefined"
+            ? process.execPath
+            : process.env.npm_node_execpath || "node"; // eslint-disable-line no-process-env
         var jsdocArgs = [
             require.resolve("jsdoc/jsdoc.js"),
             "-c",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "typescript"
   ],
   "main": "index.js",
+  "type": "commonjs",
   "types": "index.d.ts",
   "scripts": {
     "bench": "node bench",

--- a/tests/cli.js
+++ b/tests/cli.js
@@ -144,8 +144,11 @@ tape.test("pbts passes jsdoc arguments without a shell", function(test) {
         var child = new EventEmitter();
         child.stdout = new EventEmitter();
         child.stderr = { pipe: function() {} };
+        var nodePath = typeof Bun !== "undefined"
+            ? process.env.npm_node_execpath || "node"
+            : process.execPath;
 
-        test.equal(cmd, process.execPath, "should execute node directly");
+        test.equal(cmd, nodePath, "should execute node directly");
         test.ok(/jsdoc[\\/]jsdoc\.js$/.test(args[0]), "should execute jsdoc directly");
         test.equal(args[args.length - 1], file, "should pass file path as a single argument");
         test.equal(options.stdio, "pipe", "should pipe jsdoc output");


### PR DESCRIPTION
For Deno, the main and CLI packages are explicitly marked as CommonJS, so Deno does not need CommonJS detection to load them. For Bun, `pbts` now runs the JSDoc subprocess with Node.js because JSDoc still depends on Node.js loader internals that Bun does not mirror.

Also adds compatibility notes to README.