### PR TITLE
feat: Add textformat extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ protobuf.js favors transparent disclosure. Security-impacting reports are handle
 
 ## Conformance
 
-protobuf.js targets full binary wire-format conformance for **Proto2**, **Proto3** and **Editions**. CI runs the official Protocol Buffers conformance suite, with logs uploaded as artifacts.
+protobuf.js targets full binary wire-format conformance for **Proto2**, **Proto3** and **Editions**. **TextFormat** is supported via [ext/textformat](./ext/README.md#textformat). CI runs the official Protocol Buffers conformance suite, with logs uploaded as artifacts.
 
 ## Performance
 

--- a/README.md
+++ b/README.md
@@ -268,7 +268,11 @@ protobuf.js supports service clients built from reflected service definitions. T
 
 ### Descriptors
 
-For protobuf descriptor interoperability, see [ext/descriptor](./ext/README.md#descriptor). Note that because protobuf.js does not use `descriptor.proto` internally, options are parsed and presented literally.
+For `google/protobuf/descriptor.proto` interoperability, see [ext/descriptor](./ext/README.md#descriptor). Note that because protobuf.js does not use `descriptor.proto` internally, options are parsed and presented literally.
+
+### Text format
+
+Protocol Buffers [Text Format](https://protobuf.dev/reference/protobuf/textformat-spec/) is supported via [ext/textformat](./ext/README.md#textformat).
 
 ### Content Security Policy
 
@@ -291,8 +295,6 @@ protobuf.js targets full binary wire-format conformance for **Proto2**, **Proto3
 | Proto2   |   100.00% (694/694) | 100.00% (485/485) | 100.00% (209/209) |
 | Proto3   |   100.00% (689/689) | 100.00% (482/482) | 100.00% (207/207) |
 | Editions | 100.00% (1176/1176) | 100.00% (926/926) | 100.00% (250/250) |
-
-**TextFormat** is supported via [ext/textformat](./ext/README.md#textformat) and also passes required and recommended conformance tests.
 
 ## Performance
 

--- a/README.md
+++ b/README.md
@@ -284,7 +284,15 @@ protobuf.js favors transparent disclosure. Security-impacting reports are handle
 
 ## Conformance
 
-protobuf.js targets full binary wire-format conformance for **Proto2**, **Proto3** and **Editions**. **TextFormat** is supported via [ext/textformat](./ext/README.md#textformat). CI runs the official Protocol Buffers conformance suite, with logs uploaded as artifacts.
+protobuf.js targets full binary wire-format conformance for **Proto2**, **Proto3** and **Editions**. CI runs the official Protocol Buffers conformance suite, with logs uploaded as artifacts.
+
+| Syntax   |               Total |          Required |       Recommended |
+| -------- | ------------------: | ----------------: | ----------------: |
+| Proto2   |   100.00% (694/694) | 100.00% (485/485) | 100.00% (209/209) |
+| Proto3   |   100.00% (689/689) | 100.00% (482/482) | 100.00% (207/207) |
+| Editions | 100.00% (1176/1176) | 100.00% (926/926) | 100.00% (250/250) |
+
+**TextFormat** is supported via [ext/textformat](./ext/README.md#textformat) and also passes required and recommended conformance tests.
 
 ## Performance
 

--- a/ext/README.md
+++ b/ext/README.md
@@ -61,3 +61,21 @@ Importing the extension adds `.fromDescriptor(descriptor[, syntaxOrEdition])` an
 Not all `descriptor.proto` features translate perfectly to a protobuf.js root. A root has only limited knowledge of packages and individual files, for example, which is compensated by guessing and generating file names.
 
 The exported TypeScript interfaces can be used to reference specific descriptor message instances, for example `protobuf.Message<IDescriptorProto>`.
+
+## textformat
+
+Optional text format support for reflected message types.
+
+```js
+import protobuf from "protobufjs";
+import "protobufjs/ext/textformat.js";
+
+const root = protobuf.Root.fromJSON(bundle);
+const MyType = root.lookupType("MyType");
+const message = MyType.fromText("value: 1");
+const text = MyType.toText(message);
+```
+
+The extension patches `protobuf.Type` at runtime and requires reflection metadata. It works with `protobufjs/light.js` when schemas are loaded from JSON or otherwise provided as reflection objects. Static-only code using `protobufjs/minimal.js` is not supported.
+
+Text output is produced from the message object passed to `toText`. Unknown fields can be printed with numeric field names by passing `{ unknowns: true }` to `toText`.

--- a/ext/textformat.d.ts
+++ b/ext/textformat.d.ts
@@ -1,0 +1,30 @@
+import * as $protobuf from "..";
+
+export interface ITextFormatOptions {
+    /** Also includes and formats unknown fields`. */
+    unknowns?: boolean;
+}
+
+/** Maximum recursion depth for text format parsing and formatting. Defaults to util.recursionLimit. */
+export let recursionLimit: number;
+
+/** Maximum recursion depth for formatting length-delimited unknown fields. */
+export let unknownRecursionLimit: number;
+
+declare module ".." {
+    namespace textformat {
+        /** Maximum recursion depth for text format parsing and formatting. Defaults to util.recursionLimit. */
+        let recursionLimit: number;
+
+        /** Maximum recursion depth for formatting length-delimited unknown fields. */
+        let unknownRecursionLimit: number;
+    }
+
+    interface Type {
+        /** Parses this type from protobuf text format. */
+        fromText(text: string): $protobuf.Message<{}>;
+
+        /** Formats a message of this type as protobuf text format. */
+        toText(message: ($protobuf.Message<{}>|{ [k: string]: any }), options?: ITextFormatOptions): string;
+    }
+}

--- a/ext/textformat.d.ts
+++ b/ext/textformat.d.ts
@@ -1,7 +1,7 @@
 import * as $protobuf from "..";
 
 export interface ITextFormatOptions {
-    /** Also includes and formats unknown fields`. */
+    /** Also includes and formats unknown fields. */
     unknowns?: boolean;
 }
 

--- a/ext/textformat.js
+++ b/ext/textformat.js
@@ -1,0 +1,1249 @@
+"use strict";
+var protobuf = require("../light");
+
+var Type    = protobuf.Type,
+    Enum    = protobuf.Enum,
+    Field   = protobuf.Field,
+    Reader  = protobuf.Reader,
+    types   = protobuf.types,
+    util    = protobuf.util;
+
+var textformat = protobuf.textformat = module.exports = {};
+
+var recursionLimit;
+
+/**
+ * Maximum recursion depth for text format parsing and formatting. Defaults to util.recursionLimit.
+ * @type {number}
+ */
+Object.defineProperty(textformat, "recursionLimit", {
+    get: function get() {
+        return recursionLimit === undefined ? util.recursionLimit : recursionLimit;
+    },
+    set: function set(value) {
+        recursionLimit = value == null ? undefined : value;
+    }
+});
+
+/**
+ * Maximum recursion depth for formatting length-delimited unknown fields.
+ * @type {number}
+ */
+textformat.unknownRecursionLimit = 10;
+
+var punct = {
+    "{": true,
+    "}": true,
+    "<": true,
+    ">": true,
+    ":": true,
+    "[": true,
+    "]": true,
+    ",": true,
+    ";": true,
+    "-": true
+};
+
+var identRe = /^[A-Za-z_][A-Za-z0-9_]*$/,
+    numberStartRe = /[0-9]/,
+    wordCharRe = /[A-Za-z0-9_]/,
+    hexRe = /^[0-9A-Fa-f]$/,
+    octRe = /^[0-7]$/,
+    floatRe = /^(?:[0-9]+\.[0-9]*(?:[eE][+-]?[0-9]+)?[fF]?|\.[0-9]+(?:[eE][+-]?[0-9]+)?[fF]?|[0-9]+[eE][+-]?[0-9]+[fF]?|[0-9]+[fF])/,
+    hexIntRe = /^0[xX][0-9A-Fa-f]+/,
+    octIntRe = /^0[0-7]+/,
+    decIntRe = /^(?:0|[1-9][0-9]*)/;
+
+/**
+ * Parses protobuf text format using the specified reflected message type.
+ * @param {Type} type Reflected message type
+ * @param {string} text Text format input
+ * @returns {Message<{}>} Message instance
+ */
+function parseText(type, text) {
+    if (!(type instanceof Type))
+        throw TypeError("type must be a Type");
+    type.root.resolveAll();
+    var parser = new Parser(String(text));
+    var object = parser.parseMessage(type, null, 0);
+    parser.expectEnd();
+    var err = verifyTextMessage(type, object),
+        message;
+    if (err)
+        throw Error(err);
+    message = type.create(object);
+    return message;
+}
+
+/**
+ * Formats a message as protobuf text format using the specified reflected type.
+ * @param {Type} type Reflected message type
+ * @param {Message<{}>|Object.<string,*>} message Message instance or plain object
+ * @param {Object} [options] Text format options
+ * @param {boolean} [options.unknowns=false] Includes and formats unknown fields
+ * @returns {string} Text format output
+ */
+function formatText(type, message, options) {
+    if (!(type instanceof Type))
+        throw TypeError("type must be a Type");
+    type.root.resolveAll();
+    var lines = [];
+    writeMessage(type, message, lines, 0, options || {}, 0, textformat.recursionLimit);
+    return lines.join("\n");
+}
+
+/**
+ * Parses this type from protobuf text format.
+ * @param {string} text Text format input
+ * @returns {Message<{}>} Message instance
+ */
+Type.prototype.fromText = function fromText(text) {
+    return parseText(this, text);
+};
+
+/**
+ * Formats a message of this type as protobuf text format.
+ * @param {Message<{}>|Object.<string,*>} message Message instance or plain object
+ * @param {Object} [options] Text format options
+ * @returns {string} Text format output
+ */
+Type.prototype.toText = function toText(message, options) {
+    return formatText(this, message, options);
+};
+
+function Tokenizer(source) {
+    this.source = source;
+    this.pos = 0;
+    this.len = source.length;
+    this.line = 1;
+    this.stack = [];
+}
+
+Tokenizer.prototype.error = function error(message) {
+    return Error(message + " (line " + this.line + ")");
+};
+
+Tokenizer.prototype.peek = function peek() {
+    var token = this.next();
+    this.push(token);
+    return token;
+};
+
+Tokenizer.prototype.push = function push(token) {
+    if (token)
+        this.stack.unshift(token);
+};
+
+Tokenizer.prototype.next = function next() {
+    if (this.stack.length)
+        return this.stack.shift();
+    this.skipSpace();
+    if (this.pos >= this.len)
+        return null;
+
+    var ch = this.source.charAt(this.pos);
+    if (ch === "\"" || ch === "'")
+        return this.readString(ch);
+    if (ch === "." && numberStartRe.test(this.source.charAt(this.pos + 1)) || numberStartRe.test(ch))
+        return this.readNumber();
+    if (punct[ch]) {
+        ++this.pos;
+        return { type: "punct", value: ch, raw: ch, line: this.line };
+    }
+    return this.readWord();
+};
+
+Tokenizer.prototype.expect = function expect(value) {
+    var token = this.next();
+    if (!token || token.value !== value)
+        throw this.error("expected '" + value + "'");
+    return token;
+};
+
+Tokenizer.prototype.skip = function skip(value) {
+    var token = this.next();
+    if (token && token.value === value)
+        return true;
+    this.push(token);
+    return false;
+};
+
+Tokenizer.prototype.skipSpace = function skipSpace() {
+    var ch;
+    while (this.pos < this.len) {
+        ch = this.source.charAt(this.pos);
+        if (ch === "#") {
+            while (this.pos < this.len && this.source.charAt(this.pos) !== "\n")
+                ++this.pos;
+        } else if (ch === " " || ch === "\t" || ch === "\v" || ch === "\f" || ch === "\r") {
+            ++this.pos;
+        } else if (ch === "\n") {
+            ++this.pos;
+            ++this.line;
+        } else
+            break;
+    }
+};
+
+Tokenizer.prototype.readWord = function readWord() {
+    var start = this.pos,
+        ch;
+    while (this.pos < this.len) {
+        ch = this.source.charAt(this.pos);
+        if (ch === "#" || ch === "\"" || ch === "'" || punct[ch] || /\s/.test(ch))
+            break;
+        ++this.pos;
+    }
+    if (start === this.pos)
+        throw this.error("illegal character '" + this.source.charAt(this.pos) + "'");
+    var raw = this.source.substring(start, this.pos);
+    return { type: "word", value: raw, raw: raw, line: this.line };
+};
+
+Tokenizer.prototype.readNumber = function readNumber() {
+    var rest = this.source.substring(this.pos),
+        matches = [
+            floatRe.exec(rest),
+            hexIntRe.exec(rest),
+            octIntRe.exec(rest),
+            decIntRe.exec(rest)
+        ],
+        raw = null;
+    for (var i = 0; i < matches.length; ++i)
+        if (matches[i] && (!raw || matches[i][0].length > raw.length))
+            raw = matches[i][0];
+    if (!raw)
+        throw this.error("illegal number");
+    this.pos += raw.length;
+    if (this.pos < this.len && wordCharRe.test(this.source.charAt(this.pos)))
+        throw this.error("illegal number '" + raw + this.source.charAt(this.pos) + "'");
+    return { type: "number", value: raw, raw: raw, line: this.line };
+};
+
+Tokenizer.prototype.readString = function readString(quote) {
+    var bytes = [],
+        ch,
+        code;
+    ++this.pos;
+    while (this.pos < this.len) {
+        ch = this.source.charAt(this.pos++);
+        if (ch === quote)
+            return { type: "string", value: bytes, raw: quote, line: this.line };
+        if (ch === "\n")
+            throw this.error("illegal string");
+        if (ch !== "\\") {
+            code = ch.charCodeAt(0);
+            if ((code & 0xFC00) === 0xD800 && this.pos < this.len) {
+                var next = this.source.charCodeAt(this.pos);
+                if ((next & 0xFC00) === 0xDC00) {
+                    ++this.pos;
+                    code = 0x10000 + ((code & 0x03FF) << 10) + (next & 0x03FF);
+                }
+            }
+            pushUtf8(bytes, code);
+            continue;
+        }
+        if (this.pos >= this.len)
+            throw this.error("illegal string escape");
+        ch = this.source.charAt(this.pos++);
+        switch (ch) {
+            case "a": bytes.push(7); break;
+            case "b": bytes.push(8); break;
+            case "f": bytes.push(12); break;
+            case "n": bytes.push(10); break;
+            case "r": bytes.push(13); break;
+            case "t": bytes.push(9); break;
+            case "v": bytes.push(11); break;
+            case "?": bytes.push(63); break;
+            case "\\": bytes.push(92); break;
+            case "'": bytes.push(39); break;
+            case "\"": bytes.push(34); break;
+            case "x":
+            case "X":
+                bytes.push(this.readHexEscape());
+                break;
+            case "u":
+                pushUtf8(bytes, this.readCodePoint(4));
+                break;
+            case "U":
+                pushUtf8(bytes, this.readCodePoint(8));
+                break;
+            default:
+                if (octRe.test(ch)) {
+                    bytes.push(this.readOctEscape(ch));
+                    break;
+                }
+                throw this.error("illegal string escape '\\" + ch + "'");
+        }
+    }
+    throw this.error("unterminated string");
+};
+
+Tokenizer.prototype.readHexEscape = function readHexEscape() {
+    var value = 0,
+        count = 0,
+        ch;
+    while (count < 2 && this.pos < this.len && hexRe.test(ch = this.source.charAt(this.pos))) {
+        value = value * 16 + parseInt(ch, 16);
+        ++this.pos;
+        ++count;
+    }
+    if (!count)
+        throw this.error("illegal hex escape");
+    return value;
+};
+
+Tokenizer.prototype.readOctEscape = function readOctEscape(first) {
+    var value = parseInt(first, 8),
+        count = 1,
+        ch;
+    while (count < 3 && this.pos < this.len && octRe.test(ch = this.source.charAt(this.pos))) {
+        value = value * 8 + parseInt(ch, 8);
+        ++this.pos;
+        ++count;
+    }
+    return value & 255;
+};
+
+Tokenizer.prototype.readCodePoint = function readCodePoint(size) {
+    var raw = this.source.substring(this.pos, this.pos + size);
+    if (raw.length !== size || !/^[0-9A-Fa-f]+$/.test(raw))
+        throw this.error("illegal unicode escape");
+    this.pos += size;
+    var code = parseInt(raw, 16);
+    if (code > 0x10FFFF || code >= 0xD800 && code <= 0xDFFF)
+        throw this.error("illegal unicode escape");
+    return code;
+};
+
+function Parser(source) {
+    this.tn = new Tokenizer(source);
+    this.recursionLimit = textformat.recursionLimit;
+}
+
+Parser.prototype.error = function error(message) {
+    throw this.tn.error(message);
+};
+
+Parser.prototype.expectEnd = function expectEnd() {
+    var token = this.tn.next();
+    if (token)
+        this.error("unexpected token '" + token.value + "'");
+};
+
+Parser.prototype.checkRecursion = function checkRecursion(depth) {
+    if (depth > this.recursionLimit)
+        this.error("max depth exceeded");
+};
+
+Parser.prototype.parseMessage = function parseMessage(type, end, depth) {
+    this.checkRecursion(depth);
+    var object = {},
+        seen = {};
+    for (;;) {
+        var token = this.tn.peek();
+        if (!token) {
+            if (end)
+                this.error("expected '" + end + "'");
+            return object;
+        }
+        if (end && token.value === end) {
+            this.tn.next();
+            return object;
+        }
+        if (isSeparator(token))
+            this.error("unexpected separator");
+        this.parseField(type, object, seen, depth);
+        token = this.tn.peek();
+        if (token && isSeparator(token)) {
+            this.tn.next();
+            token = this.tn.peek();
+            if (token && isSeparator(token))
+                this.error("unexpected separator");
+        }
+    }
+};
+
+Parser.prototype.parseField = function parseField(type, object, seen, depth) {
+    var info = this.readFieldName(type);
+    if (info.any) {
+        this.parseAny(type, info.name, object, seen, depth);
+        return;
+    }
+    if (!info.field) {
+        this.skipReservedValue(depth);
+        return;
+    }
+
+    var field = info.field.resolve();
+    if (field.map) {
+        this.parseMessageFieldDelimiter();
+        this.parseMapField(field, object, depth);
+    } else if (field.resolvedType instanceof Type) {
+        this.parseMessageFieldDelimiter();
+        if (this.tn.skip("[")) {
+            if (!field.repeated)
+                this.error(field.fullName + ": list value specified for singular field");
+            if (!this.tn.skip("]")) {
+                do {
+                    addField(object, seen, field, this.parseMessageValue(field.resolvedType, depth));
+                } while (this.tn.skip(","));
+                this.tn.expect("]");
+            }
+        } else
+            addField(object, seen, field, this.parseMessageValue(field.resolvedType, depth));
+    } else {
+        this.tn.expect(":");
+        if (this.tn.skip("[")) {
+            if (!field.repeated)
+                this.error(field.fullName + ": list value specified for singular field");
+            if (!this.tn.skip("]")) {
+                do {
+                    addField(object, seen, field, this.parseScalar(field));
+                } while (this.tn.skip(","));
+                this.tn.expect("]");
+            }
+        } else
+            addField(object, seen, field, this.parseScalar(field));
+    }
+};
+
+Parser.prototype.readFieldName = function readFieldName(type) {
+    var token = this.tn.next();
+    if (!token)
+        this.error("expected field name");
+    if (token.value === "[") {
+        var bracketName = this.readBracketName();
+        if (type.fullName === ".google.protobuf.Any" && bracketName.indexOf("/") >= 0)
+            return { any: true, name: bracketName };
+        return { field: lookupExtension(type, bracketName), name: bracketName };
+    }
+    if (token.type !== "word" || !identRe.test(token.value))
+        this.error("illegal field name '" + token.value + "'");
+
+    var field = lookupField(type, token.value);
+    if (!field) {
+        if (type.isReservedName(token.value))
+            return { name: token.value };
+        this.error(type.fullName + ": unknown field '" + token.value + "'");
+    }
+    return { field: field, name: token.value };
+};
+
+Parser.prototype.readBracketName = function readBracketName() {
+    var parts = [],
+        token;
+    while (token = this.tn.next()) {
+        if (token.value === "]")
+            return parts.join("");
+        parts.push(token.raw || token.value);
+    }
+    this.error("unterminated bracketed field name");
+    return null;
+};
+
+Parser.prototype.parseAny = function parseAny(type, typeUrl, object, seen, depth) {
+    this.parseMessageFieldDelimiter();
+    validateTypeUrl(typeUrl);
+    var typeName = typeUrl.substring(typeUrl.lastIndexOf("/") + 1),
+        embeddedType = type.root.lookupType(typeName.charAt(0) === "." ? typeName : "." + typeName),
+        embedded = this.parseMessageValue(embeddedType, depth),
+        typeUrlField = lookupField(type, "type_url") || lookupField(type, "typeUrl"),
+        valueField = lookupField(type, "value");
+    addField(object, seen, typeUrlField, typeUrl);
+    addField(object, seen, valueField, embeddedType.encode(embedded).finish());
+};
+
+Parser.prototype.parseMapField = function parseMapField(field, object, depth) {
+    if (!object[field.name])
+        object[field.name] = {};
+    if (this.tn.skip("[")) {
+        if (!this.tn.skip("]")) {
+            do {
+                addMapEntry(field, object[field.name], this.parseMapEntry(field, depth + 1));
+            } while (this.tn.skip(","));
+            this.tn.expect("]");
+        }
+    } else
+        addMapEntry(field, object[field.name], this.parseMapEntry(field, depth + 1));
+};
+
+Parser.prototype.parseMessageFieldDelimiter = function parseMessageFieldDelimiter() {
+    this.tn.skip(":");
+};
+
+Parser.prototype.parseMapEntry = function parseMapEntry(field, depth) {
+    this.checkRecursion(depth);
+    var end;
+    if (this.tn.skip("{"))
+        end = "}";
+    else if (this.tn.skip("<"))
+        end = ">";
+    else
+        this.error("expected map entry");
+
+    var entry = {},
+        token,
+        valueField = mapValueField(field),
+        keyField = mapKeyField(field);
+    for (;;) {
+        token = this.tn.peek();
+        if (!token)
+            this.error("expected '" + end + "'");
+        if (token.value === end) {
+            this.tn.next();
+            return entry;
+        }
+        if (isSeparator(token))
+            this.error("unexpected separator");
+        token = this.tn.next();
+        if (token.type !== "word")
+            this.error("expected map field name");
+        if (token.value === "key") {
+            this.tn.expect(":");
+            entry.key = this.parseScalar(keyField);
+        } else if (token.value === "value") {
+            if (valueField.resolvedType instanceof Type) {
+                this.parseMessageFieldDelimiter();
+                entry.value = this.parseMessageValue(valueField.resolvedType, depth);
+            } else {
+                this.tn.expect(":");
+                entry.value = this.parseScalar(valueField);
+            }
+        } else
+            this.error("unknown map field '" + token.value + "'");
+        token = this.tn.peek();
+        if (token && isSeparator(token)) {
+            this.tn.next();
+            token = this.tn.peek();
+            if (token && isSeparator(token))
+                this.error("unexpected separator");
+        }
+    }
+};
+
+Parser.prototype.parseMessageValue = function parseMessageValue(type, depth) {
+    var end;
+    if (this.tn.skip("{"))
+        end = "}";
+    else if (this.tn.skip("<"))
+        end = ">";
+    else
+        this.error("expected message value");
+    return this.parseMessage(type, end, depth + 1);
+};
+
+Parser.prototype.parseScalar = function parseScalar(field) {
+    if (field.type === "string" || field.type === "bytes") {
+        var bytes = this.readStringBytes();
+        return field.type === "bytes" ? util.newBuffer(bytes) : utf8Read(bytes, true);
+    }
+
+    var sign = 1;
+    if (this.tn.skip("-"))
+        sign = -1;
+
+    var token = this.tn.next();
+    if (!token)
+        this.error("expected value");
+
+    if (field.resolvedType instanceof Enum)
+        return parseEnum(field, token, sign);
+
+    switch (field.type) {
+        case "double":
+        case "float":
+            return parseFloatValue(token, sign);
+        case "bool":
+            return parseBool(token, sign);
+        case "int32":
+        case "sint32":
+        case "sfixed32":
+            return parseInteger(token, sign, false, 32);
+        case "uint32":
+        case "fixed32":
+            return parseInteger(token, sign, true, 32);
+        case "int64":
+        case "sint64":
+        case "sfixed64":
+            return parseInteger(token, sign, false, 64);
+        case "uint64":
+        case "fixed64":
+            return parseInteger(token, sign, true, 64);
+        default:
+            this.error(field.fullName + ": unsupported scalar type");
+    }
+    return undefined;
+};
+
+Parser.prototype.readStringBytes = function readStringBytes() {
+    var token = this.tn.next(),
+        bytes = [];
+    if (!token || token.type !== "string")
+        this.error("expected string");
+    Array.prototype.push.apply(bytes, token.value);
+    while ((token = this.tn.peek()) && token.type === "string") {
+        token = this.tn.next();
+        Array.prototype.push.apply(bytes, token.value);
+    }
+    return bytes;
+};
+
+Parser.prototype.skipReservedValue = function skipReservedValue(depth) {
+    this.tn.skip(":");
+    var token = this.tn.peek();
+    if (!token)
+        return;
+    if (token.value === "{") {
+        this.skipBalanced("{", "}", depth);
+    } else if (token.value === "<") {
+        this.skipBalanced("<", ">", depth);
+    } else if (token.value === "[") {
+        this.skipBalanced("[", "]", depth);
+    } else if (token.type === "string") {
+        this.readStringBytes();
+    } else {
+        if (token.value === "-")
+            this.tn.next();
+        this.tn.next();
+    }
+};
+
+Parser.prototype.skipBalanced = function skipBalanced(open, close, depth) {
+    var balance = 0,
+        token;
+    do {
+        token = this.tn.next();
+        if (!token)
+            this.error("expected '" + close + "'");
+        if (token.value === open) {
+            if (depth + ++balance > this.recursionLimit)
+                this.error("max depth exceeded");
+        }
+        else if (token.value === close)
+            --balance;
+    } while (balance);
+};
+
+function addField(object, seen, field, value) {
+    if (field.repeated) {
+        (object[field.name] || (object[field.name] = [])).push(value);
+        return;
+    }
+    if (Object.prototype.hasOwnProperty.call(seen, field.name))
+        throw Error(field.fullName + ": multiple values");
+    if (field.partOf) {
+        var oneofName = "$oneof:" + field.partOf.name;
+        if (seen[oneofName])
+            throw Error(field.partOf.name + ": multiple values");
+        seen[oneofName] = true;
+    }
+    seen[field.name] = true;
+    object[field.name] = value;
+}
+
+function addMapEntry(field, map, entry) {
+    var keyField = mapKeyField(field),
+        valueField = mapValueField(field),
+        key = Object.prototype.hasOwnProperty.call(entry, "key")
+            ? entry.key
+            : defaultScalarValue(keyField),
+        value = Object.prototype.hasOwnProperty.call(entry, "value")
+            ? entry.value
+            : defaultMapValue(valueField);
+    map[mapKey(keyField, key)] = value;
+}
+
+function defaultMapValue(field) {
+    if (field.resolvedType instanceof Type)
+        return field.resolvedType.create();
+    if (field.resolvedType instanceof Enum)
+        return field.typeDefault;
+    return defaultScalarValue(field);
+}
+
+function defaultScalarValue(field) {
+    if (field.type === "string")
+        return "";
+    if (field.type === "bytes")
+        return util.newBuffer([]);
+    if (field.type === "bool")
+        return false;
+    return field.defaultValue;
+}
+
+function mapKeyField(field) {
+    return {
+        name: "key",
+        fullName: field.fullName + ".key",
+        type: field.keyType,
+        resolvedType: null,
+        defaultValue: field.keyType === "bool" ? false : field.keyType === "string" ? "" : 0
+    };
+}
+
+function mapValueField(field) {
+    return {
+        name: "value",
+        fullName: field.fullName + ".value",
+        type: field.type,
+        resolvedType: field.resolvedType,
+        defaultValue: field.resolvedType instanceof Enum ? field.resolvedType.values[Object.keys(field.resolvedType.values)[0]] : field.typeDefault
+    };
+}
+
+function mapKey(field, value) {
+    if (types.long[field.type] !== undefined)
+        return String(value);
+    if (field.type === "bool")
+        return value ? "true" : "false";
+    return String(value);
+}
+
+function lookupField(type, name) {
+    var fields = type.fieldsArray;
+    for (var i = 0; i < fields.length; ++i) {
+        var field = fields[i].resolve();
+        if (field.name === name || underScore(field.name) === name)
+            return field;
+        if (field.delimited && field.resolvedType instanceof Type) {
+            var groupName = field.resolvedType.name,
+                lowerName = name.toLowerCase(),
+                compactName = compact(name);
+            if (groupName === name || underScore(groupName) === name
+             || field.name.toLowerCase() === lowerName
+             || groupName.toLowerCase() === lowerName
+             || compact(field.name) === compactName
+             || compact(groupName) === compactName)
+                return field;
+        }
+    }
+    return null;
+}
+
+function lookupExtension(type, name) {
+    var fullName = name.charAt(0) === "." ? name : "." + name,
+        camelName = camelCaseLastPath(fullName),
+        field = type.get(fullName) || type.root.lookup(fullName, Field)
+             || type.get(camelName) || type.root.lookup(camelName, Field);
+    if (!field)
+        field = lookupExtensionField(type, fullName);
+    if (field && field.extend !== undefined && field.extensionField)
+        field = field.extensionField;
+    if (!field || field.parent !== type)
+        throw Error(type.fullName + ": unknown extension '" + name + "'");
+    return field;
+}
+
+function camelCaseLastPath(name) {
+    var dot = name.lastIndexOf(".");
+    return name.substring(0, dot + 1) + util.camelCase(name.substring(dot + 1));
+}
+
+function parseEnum(field, token, sign) {
+    if (sign < 0) {
+        if (token.type !== "number")
+            throw Error(field.fullName + ": enum value expected");
+        return checkEnumValue(field, parseInteger(token, sign, false, 32));
+    }
+    if (token.type === "word") {
+        var value = field.resolvedType.values[token.value];
+        if (value === undefined)
+            throw Error(field.fullName + ": enum value expected");
+        return value;
+    }
+    return checkEnumValue(field, parseInteger(token, sign, false, 32));
+}
+
+function parseBool(token, sign) {
+    if (sign < 0)
+        throw Error("bool value expected");
+    if (token.type === "word") {
+        switch (token.value) {
+            case "true":
+            case "True":
+            case "t":
+                return true;
+            case "false":
+            case "False":
+            case "f":
+                return false;
+        }
+    } else if (token.type === "number") {
+        var value = parseInteger(token, 1, true, 32);
+        if (value === 0)
+            return false;
+        if (value === 1)
+            return true;
+    }
+    throw Error("bool value expected");
+}
+
+function parseFloatValue(token, sign) {
+    if (token.type === "word") {
+        switch (token.value.toLowerCase()) {
+            case "inf":
+            case "infinity":
+                return sign * Infinity;
+            case "nan":
+                return NaN;
+        }
+        throw Error("float value expected");
+    }
+    if (token.type !== "number")
+        throw Error("float value expected");
+    var raw = token.value;
+    if (/^0[xX]/.test(raw) || /^0[0-7]/.test(raw) && raw.length > 1)
+        throw Error("float value expected");
+    if (/[fF]$/.test(raw))
+        raw = raw.substring(0, raw.length - 1);
+    return sign * Number(raw);
+}
+
+function parseInteger(token, sign, unsigned, bits) {
+    if (token.type !== "number")
+        throw Error("integer value expected");
+    if (sign < 0 && unsigned)
+        throw Error("unsigned integer value expected");
+
+    var raw = token.value,
+        radix = 10,
+        digits = raw;
+    if (/^0[xX]/.test(raw)) {
+        radix = 16;
+        digits = raw.substring(2);
+    } else if (/^0[0-7]/.test(raw) && raw.length > 1) {
+        radix = 8;
+        digits = raw.substring(1);
+    } else if (!/^(?:0|[1-9][0-9]*)$/.test(raw))
+        throw Error("integer value expected");
+
+    if (typeof util.global.BigInt === "function")
+        return parseIntegerBigInt(digits, radix, sign, unsigned, bits);
+
+    var value = parseInt(digits, radix) * sign;
+    if (bits === 64 && util.Long)
+        return util.Long.fromString(String(value), unsigned);
+    return value;
+}
+
+function parseIntegerBigInt(digits, radix, sign, unsigned, bits) {
+    var value,
+        BigInt = util.global.BigInt;
+    if (radix === 16)
+        value = BigInt("0x" + digits);
+    else if (radix === 8)
+        value = BigInt("0o" + digits);
+    else
+        value = BigInt(digits);
+    if (sign < 0)
+        value = -value;
+
+    var min,
+        max;
+    if (bits === 32) {
+        min = unsigned ? BigInt(0) : -BigInt(2147483648);
+        max = unsigned ? BigInt(4294967295) : BigInt(2147483647);
+    } else {
+        min = unsigned ? BigInt(0) : -BigInt("9223372036854775808");
+        max = unsigned ? BigInt("18446744073709551615") : BigInt("9223372036854775807");
+    }
+    if (value < min || value > max)
+        throw Error((unsigned ? "unsigned " : "") + "integer value out of range");
+    if (bits === 64 && util.Long)
+        return util.Long.fromString(value.toString(), unsigned, 10);
+    return Number(value);
+}
+
+function checkRecursion(depth, recursionLimit) {
+    if (depth > recursionLimit)
+        throw Error("max depth exceeded");
+}
+
+function writeMessage(type, message, lines, indent, options, depth, recursionLimit) {
+    checkRecursion(depth, recursionLimit);
+    var fields = type.fieldsArray.slice().sort(util.compareFieldsById);
+    for (var i = 0; i < fields.length; ++i) {
+        var field = fields[i].resolve(),
+            value = message[field.name];
+        if (value == null || !Object.prototype.hasOwnProperty.call(message, field.name))
+            continue;
+        if (field.map)
+            writeMapField(field, value, lines, indent, options, depth, recursionLimit);
+        else if (field.repeated)
+            for (var j = 0; j < value.length; ++j)
+                writeField(field, value[j], lines, indent, options, depth, recursionLimit);
+        else
+            writeField(field, value, lines, indent, options, depth, recursionLimit);
+    }
+    if (options.unknowns && message.$unknowns != null && Object.prototype.hasOwnProperty.call(message, "$unknowns"))
+        writeUnknowns(message.$unknowns, lines, indent);
+}
+
+function writeMapField(field, map, lines, indent, options, depth, recursionLimit) {
+    var keys = Object.keys(map).sort(),
+        keyField = mapKeyField(field),
+        valueField = mapValueField(field),
+        name = formatFieldName(field),
+        sp = spaces(indent);
+    for (var i = 0; i < keys.length; ++i) {
+        checkRecursion(depth + 1, recursionLimit);
+        var key = keyField.long ? util.longFromKey(keys[i], keyField.type === "uint64" || keyField.type === "fixed64") : keys[i];
+        if (keyField.type === "bool")
+            key = util.boolFromKey(keys[i]);
+        lines.push(sp + name + " {");
+        lines.push(spaces(indent + 2) + "key: " + formatScalar(keyField, key));
+        if (valueField.resolvedType instanceof Type) {
+            lines.push(spaces(indent + 2) + "value {");
+            writeMessage(valueField.resolvedType, map[keys[i]], lines, indent + 4, options, depth + 2, recursionLimit);
+            lines.push(spaces(indent + 2) + "}");
+        } else
+            lines.push(spaces(indent + 2) + "value: " + formatScalar(valueField, map[keys[i]]));
+        lines.push(sp + "}");
+    }
+}
+
+function writeField(field, value, lines, indent, options, depth, recursionLimit) {
+    var name = formatFieldName(field),
+        sp = spaces(indent);
+    if (field.resolvedType instanceof Type) {
+        lines.push(sp + name + " {");
+        writeMessage(field.resolvedType, value, lines, indent + 2, options, depth + 1, recursionLimit);
+        lines.push(sp + "}");
+    } else
+        lines.push(sp + name + ": " + formatScalar(field, value));
+}
+
+function writeUnknowns(unknowns, lines, indent) {
+    for (var i = 0; i < unknowns.length; ++i) {
+        var reader = Reader.create(unknowns[i]);
+        writeUnknownFieldSet(reader, lines, indent, undefined, textformat.unknownRecursionLimit);
+        if (reader.pos !== reader.len)
+            throw Error("invalid unknown field data");
+    }
+}
+
+function writeUnknownFieldSet(reader, lines, indent, endGroup, recursionBudget) {
+    if (recursionBudget < 0)
+        throw Error("max depth exceeded");
+    while (reader.pos < reader.len) {
+        var tag = reader.tag(),
+            fieldNumber = tag >>> 3,
+            wireType = tag & 7;
+        if (!fieldNumber)
+            throw Error("illegal tag: field number 0");
+        if (wireType === 4) {
+            if (fieldNumber !== endGroup)
+                throw Error("invalid end group tag");
+            return;
+        }
+        writeUnknownField(reader, fieldNumber, wireType, lines, indent, recursionBudget);
+    }
+    if (endGroup !== undefined)
+        throw Error("missing end group tag");
+}
+
+function writeUnknownField(reader, fieldNumber, wireType, lines, indent, recursionBudget) {
+    var sp = spaces(indent),
+        lo;
+    switch (wireType) {
+        case 0:
+            lines.push(sp + fieldNumber + ": " + readUnknownVarint(reader));
+            break;
+        case 1:
+            lo = reader.fixed32();
+            lines.push(sp + fieldNumber + ": 0x" + hexPad(reader.fixed32(), 8) + hexPad(lo, 8));
+            break;
+        case 2:
+            writeUnknownLengthDelimited(reader, fieldNumber, lines, indent, recursionBudget);
+            break;
+        case 3:
+            lines.push(sp + fieldNumber + " {");
+            writeUnknownFieldSet(reader, lines, indent + 2, fieldNumber, recursionBudget - 1);
+            lines.push(sp + "}");
+            break;
+        case 5:
+            lines.push(sp + fieldNumber + ": 0x" + hexPad(reader.fixed32(), 8));
+            break;
+        default:
+            throw Error("invalid wire type " + wireType);
+    }
+}
+
+function writeUnknownLengthDelimited(reader, fieldNumber, lines, indent, recursionBudget) {
+    var value = reader.bytes(),
+        nested = value.length && recursionBudget > 0
+            ? tryFormatUnknownMessage(value, indent + 2, recursionBudget - 1)
+            : null,
+        sp = spaces(indent);
+    if (nested) {
+        lines.push(sp + fieldNumber + " {");
+        for (var i = 0; i < nested.length; ++i)
+            lines.push(nested[i]);
+        lines.push(sp + "}");
+    } else
+        lines.push(sp + fieldNumber + ": " + quoteBytes(value));
+}
+
+function tryFormatUnknownMessage(bytes, indent, recursionBudget) {
+    var reader = Reader.create(bytes),
+        lines = [];
+    try {
+        writeUnknownFieldSet(reader, lines, indent, undefined, recursionBudget);
+        return reader.pos === reader.len ? lines : null;
+    } catch (e) {
+        return null;
+    }
+}
+
+function readUnknownVarint(reader) {
+    var BigInt = util.global.BigInt;
+    if (typeof BigInt !== "function")
+        return String(reader.uint64());
+
+    var value = BigInt(0),
+        shift = BigInt(0),
+        b;
+    for (var i = 0; i < 10; ++i) {
+        if (reader.pos >= reader.len)
+            throw Error("invalid varint encoding");
+        b = reader.buf[reader.pos++];
+        value += BigInt(b & 127) << shift;
+        if (b < 128)
+            return value.toString();
+        shift += BigInt(7);
+    }
+    throw Error("invalid varint encoding");
+}
+
+function hexPad(value, length) {
+    var str = value.toString(16);
+    while (str.length < length)
+        str = "0" + str;
+    return str;
+}
+
+function formatFieldName(field) {
+    if (field.declaringField || field.name.charAt(0) === ".")
+        return "[" + formatExtensionName(field) + "]";
+    if (field.delimited && field.resolvedType instanceof Type && compact(field.name) === compact(field.resolvedType.name))
+        return field.resolvedType.name;
+    return underScore(field.name);
+}
+
+function formatExtensionName(field) {
+    var name = field.name.replace(/^\./, ""),
+        dot = name.lastIndexOf("."),
+        path = name.substring(0, dot + 1),
+        last = name.substring(dot + 1);
+    if (field.delimited && field.resolvedType instanceof Type && field.resolvedType.group)
+        last = last.toLowerCase();
+    else
+        last = underScore(last);
+    return path + last;
+}
+
+function formatScalar(field, value) {
+    if (field.resolvedType instanceof Enum) {
+        var name = field.resolvedType.valuesById[value];
+        return name === undefined ? String(value) : name;
+    }
+    switch (field.type) {
+        case "string":
+            return quoteBytes(utf8Bytes(String(value)));
+        case "bytes":
+            return quoteBytes(bytesValue(value));
+        case "bool":
+            return value ? "true" : "false";
+        case "double":
+        case "float":
+            if (isNaN(value))
+                return "nan";
+            if (value === 0 && 1 / value === -Infinity)
+                return "-0";
+            if (value === Infinity)
+                return "inf";
+            if (value === -Infinity)
+                return "-inf";
+            return String(value);
+        default:
+            return String(value);
+    }
+}
+
+function bytesValue(value) {
+    if (typeof value === "string") {
+        var length = util.base64.length(value),
+            buffer = util.newBuffer(length);
+        util.base64.decode(value, buffer, 0);
+        return buffer;
+    }
+    return value;
+}
+
+function quoteBytes(bytes) {
+    var out = "\"",
+        oct;
+    for (var i = 0; i < bytes.length; ++i) {
+        var b = bytes[i];
+        switch (b) {
+            case 9: out += "\\t"; break;
+            case 10: out += "\\n"; break;
+            case 13: out += "\\r"; break;
+            case 34: out += "\\\""; break;
+            case 92: out += "\\\\"; break;
+            default:
+                if (b >= 32 && b <= 126)
+                    out += String.fromCharCode(b);
+                else {
+                    oct = b.toString(8);
+                    out += "\\" + (oct.length < 2 ? "00" : oct.length < 3 ? "0" : "") + oct;
+                }
+                break;
+        }
+    }
+    return out + "\"";
+}
+
+function spaces(indent) {
+    var str = "";
+    while (str.length < indent)
+        str += " ";
+    return str;
+}
+
+function utf8Read(bytes, strict) {
+    if (strict && !validUtf8(bytes))
+        throw Error("invalid UTF-8 string");
+    var buffer = util.newBuffer(bytes);
+    return util.utf8.read(buffer, 0, buffer.length);
+}
+
+function validUtf8(bytes) {
+    for (var i = 0, b; i < bytes.length;) {
+        b = bytes[i++];
+        if (b <= 0x7F)
+            continue;
+        if (b >= 0xC2 && b <= 0xDF) {
+            if ((b = bytes[i++]) < 0x80 || b > 0xBF)
+                return false;
+        } else if (b === 0xE0) {
+            if ((b = bytes[i++]) < 0xA0 || b > 0xBF || (b = bytes[i++]) < 0x80 || b > 0xBF)
+                return false;
+        } else if (b >= 0xE1 && b <= 0xEC || b >= 0xEE && b <= 0xEF) {
+            if ((b = bytes[i++]) < 0x80 || b > 0xBF || (b = bytes[i++]) < 0x80 || b > 0xBF)
+                return false;
+        } else if (b === 0xED) {
+            if ((b = bytes[i++]) < 0x80 || b > 0x9F || (b = bytes[i++]) < 0x80 || b > 0xBF)
+                return false;
+        } else if (b === 0xF0) {
+            if ((b = bytes[i++]) < 0x90 || b > 0xBF || (b = bytes[i++]) < 0x80 || b > 0xBF || (b = bytes[i++]) < 0x80 || b > 0xBF)
+                return false;
+        } else if (b >= 0xF1 && b <= 0xF3) {
+            if ((b = bytes[i++]) < 0x80 || b > 0xBF || (b = bytes[i++]) < 0x80 || b > 0xBF || (b = bytes[i++]) < 0x80 || b > 0xBF)
+                return false;
+        } else if (b === 0xF4) {
+            if ((b = bytes[i++]) < 0x80 || b > 0x8F || (b = bytes[i++]) < 0x80 || b > 0xBF || (b = bytes[i++]) < 0x80 || b > 0xBF)
+                return false;
+        } else
+            return false;
+    }
+    return true;
+}
+
+function utf8Bytes(str) {
+    var buffer = util.newBuffer(util.utf8.length(str));
+    util.utf8.write(str, buffer, 0);
+    return buffer;
+}
+
+function pushUtf8(bytes, code) {
+    if (code < 0x80) {
+        bytes.push(code);
+    } else if (code < 0x800) {
+        bytes.push(code >> 6 | 192, code & 63 | 128);
+    } else if (code < 0x10000) {
+        bytes.push(code >> 12 | 224, code >> 6 & 63 | 128, code & 63 | 128);
+    } else {
+        bytes.push(code >> 18 | 240, code >> 12 & 63 | 128, code >> 6 & 63 | 128, code & 63 | 128);
+    }
+}
+
+function verifyTextMessage(type, message) {
+    var fields = type.fieldsArray;
+    for (var i = 0; i < fields.length; ++i) {
+        var field = fields[i].resolve(),
+            value = message[field.name];
+        if (value == null || !Object.prototype.hasOwnProperty.call(message, field.name)) {
+            if (field.required)
+                return field.fullName + ": missing required field";
+            continue;
+        }
+        if (field.map) {
+            if (field.resolvedType instanceof Type)
+                for (var key in value)
+                    if (Object.prototype.hasOwnProperty.call(value, key)) {
+                        var mapErr = verifyTextMessage(field.resolvedType, value[key]);
+                        if (mapErr)
+                            return mapErr;
+                    }
+        } else if (field.repeated) {
+            if (field.resolvedType instanceof Type)
+                for (var j = 0; j < value.length; ++j) {
+                    var repeatedErr = verifyTextMessage(field.resolvedType, value[j]);
+                    if (repeatedErr)
+                        return repeatedErr;
+                }
+        } else if (field.resolvedType instanceof Type) {
+            var err = verifyTextMessage(field.resolvedType, value);
+            if (err)
+                return err;
+        }
+    }
+    return null;
+}
+
+function isSeparator(token) {
+    return token.value === "," || token.value === ";";
+}
+
+function validateTypeUrl(typeUrl) {
+    for (var i = 0; i < typeUrl.length; ++i)
+        if (typeUrl.charAt(i) === "%") {
+            if (i + 2 >= typeUrl.length || !hexRe.test(typeUrl.charAt(i + 1)) || !hexRe.test(typeUrl.charAt(i + 2)))
+                throw Error("invalid Any type URL");
+            i += 2;
+        }
+}
+
+function lookupExtensionField(type, fullName) {
+    var fields = type.fieldsArray;
+    for (var i = 0; i < fields.length; ++i) {
+        var field = fields[i].resolve();
+        if (field.name.charAt(0) === "." && "." + formatExtensionName(field) === fullName)
+            return field;
+    }
+    return null;
+}
+
+function checkEnumValue(field, value) {
+    if (isClosedEnum(field) && field.resolvedType.valuesById[value] === undefined)
+        throw Error(field.fullName + ": enum value expected");
+    return value;
+}
+
+function isClosedEnum(field) {
+    return field.resolvedType
+        && field.resolvedType._features
+        && field.resolvedType._features.enum_type === "CLOSED";
+}
+
+function compact(str) {
+    return str.replace(/_/g, "").toLowerCase();
+}
+
+function underScore(str) {
+    return str.substring(0, 1)
+         + str.substring(1)
+               .replace(/([A-Z])(?=[a-z]|$)/g, function($0, $1) { return "_" + $1.toLowerCase(); });
+}

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "prof": "node bench/prof",
     "test": "npm run test:sources && npm run test:types",
     "test:sources": "tape -r ./lib/tape-adapter tests/*.js tests/node/*.js",
-    "test:types": "tsc tests/comp_typescript.ts --types node --lib es2015 --esModuleInterop --strictNullChecks --experimentalDecorators --emitDecoratorMetadata && tsc tests/comp_descriptor.ts --types node --lib es2015 --esModuleInterop --noEmit --strictNullChecks && tsc tests/data/test.js.ts --types node --lib es2015 --esModuleInterop --noEmit --strictNullChecks && tsc tests/data/*.ts --types node --lib es2015 --esModuleInterop --noEmit --strictNullChecks",
+    "test:types": "tsc tests/comp_typescript.ts --types node --lib es2015 --esModuleInterop --strictNullChecks --experimentalDecorators --emitDecoratorMetadata && tsc tests/comp_descriptor.ts --types node --lib es2015 --esModuleInterop --noEmit --strictNullChecks && tsc tests/comp_textformat.ts --types node --lib es2015 --esModuleInterop --noEmit --strictNullChecks && tsc tests/data/test.js.ts --types node --lib es2015 --esModuleInterop --noEmit --strictNullChecks && tsc tests/data/*.ts --types node --lib es2015 --esModuleInterop --noEmit --strictNullChecks",
     "make": "npm run lint:sources && npm run build && npm run lint:types && node ./scripts/gentests.js && npm test"
   },
   "dependencies": {

--- a/tests/api_textformat.js
+++ b/tests/api_textformat.js
@@ -1,0 +1,254 @@
+var tape = require("tape");
+
+var protobuf = require("..");
+require("../ext/textformat");
+
+var proto = "syntax = \"proto3\";\
+message Child { string name = 1; }\
+enum Kind { ZERO = 0; ONE = 1; }\
+message Msg {\
+  int32 int32_field = 1;\
+  uint32 uint32_field = 2;\
+  int64 int64_field = 3;\
+  uint64 uint64_field = 4;\
+  double double_field = 5;\
+  float float_field = 6;\
+  bool bool_field = 7;\
+  string string_field = 8;\
+  bytes bytes_field = 9;\
+  repeated int32 repeated_int32 = 10;\
+  Child child = 11;\
+  repeated Child children = 12;\
+  map<string, int32> string_map = 13;\
+  Kind kind = 14;\
+  oneof pick { string first = 15; string second = 16; }\
+  reserved \"old_field\";\
+}";
+
+var root = protobuf.parse(proto).root,
+    Msg = root.lookupType("Msg"),
+    Child = root.lookupType("Child"),
+    Kind = root.lookupEnum("Kind");
+
+tape.test("textformat - parses scalar, repeated, map and nested fields", function(test) {
+    var msg = Msg.fromText(
+        "int32_field: - 052\n" +
+        "uint32_field: 0x2a\n" +
+        "int64_field: - 9007199254740991\n" +
+        "uint64_field: 18446744073709551615\n" +
+        "double_field: - inf\n" +
+        "float_field: nan\n" +
+        "bool_field: t\n" +
+        "string_field: \"hello\" \" \" \"\\303\\274\"\n" +
+        "bytes_field: \"\\000\\xff\\n\"\n" +
+        "repeated_int32: [1, 2]\n" +
+        "repeated_int32: 3\n" +
+        "child { name: \"kid\" }\n" +
+        "children: [{ name: \"a\" }, { name: \"b\" }]\n" +
+        "string_map { key: \"b\" value: 2 }\n" +
+        "string_map { key: \"a\" value: 1 }\n" +
+        "kind: ONE\n" +
+        "first: \"choice\"\n" +
+        "old_field: \"ignored\"\n"
+    );
+
+    test.equal(msg.int32Field, -42, "parses signed octal int32");
+    test.equal(msg.uint32Field, 42, "parses unsigned hex uint32");
+    test.equal(msg.int64Field.toString(), "-9007199254740991", "parses int64");
+    test.equal(msg.uint64Field.toString(), "18446744073709551615", "parses uint64");
+    test.equal(msg.doubleField, -Infinity, "parses signed infinity");
+    test.ok(isNaN(msg.floatField), "parses nan");
+    test.equal(msg.boolField, true, "parses bool shorthand");
+    test.equal(msg.stringField, "hello \u00fc", "parses concatenated utf8 strings");
+    test.same(Array.prototype.slice.call(msg.bytesField), [0, 255, 10], "parses bytes");
+    test.same(msg.repeatedInt32, [1, 2, 3], "parses repeated list and repeated field occurrences");
+    test.equal(msg.child.name, "kid", "parses nested message");
+    test.same(msg.children.map(function(child) { return child.name; }), ["a", "b"], "parses repeated message list");
+    test.same(msg.stringMap, { a: 1, b: 2 }, "parses map entries");
+    test.equal(msg.kind, Kind.values.ONE, "parses enum names");
+    test.equal(msg.first, "choice", "parses oneof member");
+    test.end();
+});
+
+tape.test("textformat - formats deterministically", function(test) {
+    var text = Msg.toText(Msg.create({
+        stringMap: { b: 2, a: 1 },
+        child: Child.create({ name: "kid" }),
+        repeatedInt32: [2, 1],
+        stringField: "a\nb",
+        bytesField: protobuf.util.newBuffer([0, 10, 255]),
+        kind: Kind.values.ONE
+    }));
+
+    test.equal(text, [
+        "string_field: \"a\\nb\"",
+        "bytes_field: \"\\000\\n\\377\"",
+        "repeated_int32: 2",
+        "repeated_int32: 1",
+        "child {",
+        "  name: \"kid\"",
+        "}",
+        "string_map {",
+        "  key: \"a\"",
+        "  value: 1",
+        "}",
+        "string_map {",
+        "  key: \"b\"",
+        "  value: 2",
+        "}",
+        "kind: ONE"
+    ].join("\n"), "formats in field-number order with sorted map keys");
+    test.end();
+});
+
+tape.test("textformat - rejects duplicate singular and oneof fields", function(test) {
+    test.throws(function() {
+        Msg.fromText("string_field: \"a\" string_field: \"b\"");
+    }, /multiple values/, "rejects duplicate singular fields");
+    test.throws(function() {
+        Msg.fromText("first: \"a\" second: \"b\"");
+    }, /multiple values/, "rejects multiple oneof fields");
+    test.throws(function() {
+        Msg.fromText("unknown_field: 1");
+    }, /unknown field/, "rejects unknown fields");
+    test.throws(function() {
+        Msg.fromText("string_field: \"\\xff\"");
+    }, /invalid UTF-8/, "rejects invalid UTF-8 strings");
+    test.throws(function() {
+        Msg.fromText("repeated_int32: 1,, repeated_int32: 2");
+    }, /unexpected separator/, "rejects duplicate separators");
+    test.throws(function() {
+        Msg.fromText("bytes_field: \"\\ud800\"");
+    }, /illegal unicode escape/, "rejects surrogate unicode escapes");
+    test.end();
+});
+
+tape.test("textformat - parses groups", function(test) {
+    var GroupRoot = protobuf.parse("syntax = \"proto2\"; message WithGroup { optional group MyGroup = 1 { optional int32 group_value = 2; } }").root,
+        WithGroup = GroupRoot.lookupType("WithGroup"),
+        msg = WithGroup.fromText("MyGroup { group_value: 7 }");
+    test.equal(msg.myGroup.groupValue, 7, "parses group field by group name");
+    test.equal(WithGroup.toText(msg), "MyGroup {\n  group_value: 7\n}", "formats group field by group name");
+    test.end();
+});
+
+tape.test("textformat - parses extensions", function(test) {
+    var ExtRoot = protobuf.parse("syntax = \"proto2\"; package pkg; message Base { extensions 100 to max; } extend Base { optional string ext_field = 100; }").root,
+        Base = ExtRoot.lookupType("pkg.Base"),
+        msg = Base.fromText("[pkg.ext_field]: \"x\"");
+    test.equal(msg[".pkg.extField"], "x", "parses extension field");
+    test.equal(Base.toText(msg), "[pkg.ext_field]: \"x\"", "formats extension field with proto-style name");
+    test.end();
+});
+
+tape.test("textformat - parses group extensions by field name", function(test) {
+    var ExtRoot = protobuf.parse("syntax = \"proto2\"; package pkg; message Base { extensions 100 to max; } extend Base { optional group GroupField = 100 { optional int32 group_value = 1; } }").root,
+        Base = ExtRoot.lookupType("pkg.Base"),
+        msg = Base.fromText("[pkg.groupfield] { group_value: 1 }");
+    test.equal(msg[".pkg.groupField"].groupValue, 1, "parses group extension field name");
+    test.equal(Base.toText(msg), "[pkg.groupfield] {\n  group_value: 1\n}", "formats group extension field name");
+    test.throws(function() {
+        Base.fromText("[pkg.GroupField] { group_value: 1 }");
+    }, /unknown extension/, "rejects group type name as extension field name");
+    test.end();
+});
+
+tape.test("textformat - parses Any expansion", function(test) {
+    var AnyRoot = protobuf.parse("syntax = \"proto3\"; package google.protobuf; message Any { string type_url = 1; bytes value = 2; }").root;
+    protobuf.parse("syntax = \"proto3\"; message Payload { string value = 1; } message Wrap { google.protobuf.Any any = 1; }", AnyRoot);
+    var
+        Wrap = AnyRoot.lookupType("Wrap"),
+        Payload = AnyRoot.lookupType("Payload"),
+        msg = Wrap.fromText("any { [type.googleapis.com/Payload] { value: \"x\" } }"),
+        payload = Payload.decode(msg.any.value);
+    test.equal(msg.any.typeUrl, "type.googleapis.com/Payload", "sets Any type_url");
+    test.equal(payload.value, "x", "encodes expanded Any payload");
+    test.end();
+});
+
+tape.test("textformat - preserves explicit defaults", function(test) {
+    var OpenRoot = protobuf.parse("syntax = \"proto3\"; enum E { A = 0; } message M { float value = 1; E choice = 2; }").root,
+        M = OpenRoot.lookupType("M"),
+        msg = M.fromText("value: -0 choice: 42");
+    test.equal(1 / msg.value, -Infinity, "preserves explicit negative zero");
+    test.equal(msg.choice, 42, "preserves unknown open enum number");
+    test.equal(M.toText(msg), "value: -0\nchoice: 42", "formats explicit default and open enum number");
+    test.end();
+});
+
+tape.test("textformat - enforces recursion limit", function(test) {
+    var RecRoot = protobuf.parse("syntax = \"proto3\"; message Node { Node child = 1; reserved \"old\"; }").root,
+        Node = RecRoot.lookupType("Node"),
+        limit = protobuf.util.recursionLimit;
+    protobuf.textformat.recursionLimit = undefined;
+    protobuf.util.recursionLimit = 1;
+    try {
+        test.equal(protobuf.textformat.recursionLimit, 1, "defaults to util recursion limit");
+        test.doesNotThrow(function() {
+            Node.fromText("child {}");
+        }, "parses nesting at limit");
+        test.throws(function() {
+            Node.fromText("child { child {} }");
+        }, /max depth exceeded/, "rejects parse nesting over limit");
+        test.throws(function() {
+            Node.fromText("old { old {} }");
+        }, /max depth exceeded/, "rejects reserved value nesting over limit");
+        test.doesNotThrow(function() {
+            Node.toText({ child: {} });
+        }, "formats nesting at limit");
+        test.throws(function() {
+            Node.toText({ child: { child: {} } });
+        }, /max depth exceeded/, "rejects format nesting over limit");
+
+        protobuf.textformat.recursionLimit = 2;
+        protobuf.util.recursionLimit = 0;
+        test.equal(protobuf.textformat.recursionLimit, 2, "supports textformat-specific override");
+        test.doesNotThrow(function() {
+            Node.fromText("child { child {} }");
+        }, "parse override is independent from util recursion limit");
+    } finally {
+        protobuf.textformat.recursionLimit = undefined;
+        protobuf.util.recursionLimit = limit;
+    }
+    test.end();
+});
+
+tape.test("textformat - optionally formats unknown fields", function(test) {
+    var UnknownRoot = protobuf.parse("syntax = \"proto3\"; message M { int32 known = 1; }").root,
+        M = UnknownRoot.lookupType("M"),
+        nested = protobuf.Writer.create().uint32(8).uint32(111).finish(),
+        bytes = protobuf.util.newBuffer([0, 255]),
+        encoded = protobuf.Writer.create()
+            .uint32(1001 << 3 | 0).uint32(123)
+            .uint32(1002 << 3 | 2).bytes(nested)
+            .uint32(1003 << 3 | 2).bytes(bytes)
+            .uint32(1004 << 3 | 5).fixed32(0x12345678)
+            .uint32(1005 << 3 | 1).raw([0xf0, 0xde, 0xbc, 0x9a, 0x78, 0x56, 0x34, 0x12])
+            .uint32(1006 << 3 | 3).uint32(8).uint32(321).uint32(1006 << 3 | 4)
+            .finish(),
+        msg = M.decode(encoded);
+
+    test.equal(M.toText(msg), "", "omits unknown fields by default");
+    test.equal(M.toText(msg, { unknowns: true }), [
+        "1001: 123",
+        "1002 {",
+        "  1: 111",
+        "}",
+        "1003: \"\\000\\377\"",
+        "1004: 0x12345678",
+        "1005: 0x123456789abcdef0",
+        "1006 {",
+        "  1: 321",
+        "}"
+    ].join("\n"), "formats unknown fields with numeric text format syntax");
+
+    var unknownLimit = protobuf.textformat.unknownRecursionLimit,
+        nestedOnly = M.decode(protobuf.Writer.create().uint32(1002 << 3 | 2).bytes(nested).finish());
+    protobuf.textformat.unknownRecursionLimit = 0;
+    try {
+        test.equal(M.toText(nestedOnly, { unknowns: true }), "1002: \"\\010o\"", "unknown recursion limit disables nested heuristic");
+    } finally {
+        protobuf.textformat.unknownRecursionLimit = unknownLimit;
+    }
+    test.end();
+});

--- a/tests/comp_textformat.ts
+++ b/tests/comp_textformat.ts
@@ -1,0 +1,27 @@
+import * as protobuf from "../index";
+import textformat = require("../ext/textformat");
+
+const root = protobuf.Root.fromJSON({
+    nested: {
+        Message: {
+            fields: {
+                value: {
+                    type: "int32",
+                    id: 1
+                }
+            }
+        }
+    }
+});
+root.resolveAll();
+
+const type = root.lookupType("Message");
+const message = type.fromText("value: 1");
+const text: string = type.toText(message, { unknowns: true });
+
+textformat.recursionLimit = protobuf.util.recursionLimit;
+textformat.unknownRecursionLimit = 10;
+protobuf.textformat.recursionLimit = textformat.recursionLimit;
+
+if (text.length < 0)
+    throw Error("unreachable");

--- a/tests/conformance/check.js
+++ b/tests/conformance/check.js
@@ -5,17 +5,22 @@ var fs = require("fs");
 var args = process.argv.slice(2),
     file = args[0],
     binaryThreshold = 100,
+    textFormatThreshold = null,
     report,
     binary,
-    binaryPercent;
+    binaryPercent,
+    textFormat,
+    textFormatPercent;
 
 for (var i = 1; i < args.length; ++i) {
     if (args[i] === "--binary")
         binaryThreshold = Number(args[++i]);
+    else if (args[i] === "--text-format")
+        textFormatThreshold = Number(args[++i]);
 }
 
-if (!file || !isFinite(binaryThreshold)) {
-    console.error("usage: node tests/conformance/check.js <conformance-json> [--binary <percent>]");
+if (!file || !isFinite(binaryThreshold) || textFormatThreshold !== null && !isFinite(textFormatThreshold)) {
+    console.error("usage: node tests/conformance/check.js <conformance-json> [--binary <percent>] [--text-format <percent>]");
     process.exit(1);
 }
 
@@ -43,3 +48,18 @@ if (binaryPercent + 1e-9 < binaryThreshold) {
 }
 
 console.log("Binary conformance: " + binaryPercent.toFixed(2) + "% (" + binary.passed + "/" + binary.total + ")");
+
+textFormat = report.totals && report.totals.byFormat && report.totals.byFormat.textFormat;
+if (textFormat && textFormat.total) {
+    textFormatPercent = textFormat.passPercent * 100;
+    if (textFormatThreshold !== null && textFormatPercent + 1e-9 < textFormatThreshold) {
+        console.error("Text Format conformance below " + textFormatThreshold.toFixed(2) + "%: "
+            + textFormatPercent.toFixed(2) + "% (" + textFormat.passed + "/" + textFormat.total + ")");
+        if (textFormat.failed)
+            console.error("Text Format failures: " + textFormat.failed);
+        if (textFormat.skipped)
+            console.error("Text Format skipped: " + textFormat.skipped);
+        process.exit(1);
+    }
+    console.log("Text Format conformance: " + textFormatPercent.toFixed(2) + "% (" + textFormat.passed + "/" + textFormat.total + ")");
+}

--- a/tests/conformance/generate.js
+++ b/tests/conformance/generate.js
@@ -8,6 +8,7 @@ var rootDir = path.resolve(__dirname, "../.."),
     upstreamDir = process.env.PROTOBUF_UPSTREAM || path.join(__dirname, "upstream"),
     outputDir = path.join(__dirname, "generated"),
     outputFile = path.join(outputDir, "messages.js"),
+    outputJsonFile = path.join(outputDir, "messages.json"),
     upstreamUnstableSchemaFile = "conformance/test_protos/test_messages_edition_unstable.proto",
     unstableSchemaFile = path.join(outputDir, "test_messages_edition_unstable.proto"),
     importRoots = [
@@ -46,7 +47,17 @@ if (fs.existsSync(fromUpstream(upstreamUnstableSchemaFile))) {
     schemaFiles.push(unstableSchemaFile);
 }
 
-runPbjs(importRoots.map(fromUpstream), schemaFiles.map(fromSchemaFile));
+runPbjs({
+    target: "static-module",
+    wrap: "commonjs",
+    dependency: "../../../minimal",
+    out: outputFile
+}, importRoots.map(fromUpstream), schemaFiles.map(fromSchemaFile));
+
+runPbjs({
+    target: "json",
+    out: outputJsonFile
+}, importRoots.map(fromUpstream), schemaFiles.map(fromSchemaFile));
 
 function fromUpstream(relativePath) {
     return path.join(upstreamDir, relativePath);
@@ -56,14 +67,16 @@ function fromSchemaFile(schemaFile) {
     return path.isAbsolute(schemaFile) ? schemaFile : fromUpstream(schemaFile);
 }
 
-function runPbjs(importPaths, protoFiles) {
+function runPbjs(options, importPaths, protoFiles) {
     var args = [
         path.join(rootDir, "cli/bin/pbjs"),
-        "-t", "static-module",
-        "-w", "commonjs",
-        "--dependency", "../../../minimal",
-        "-o", outputFile
+        "-t", options.target
     ];
+    if (options.wrap)
+        args.push("-w", options.wrap);
+    if (options.dependency)
+        args.push("--dependency", options.dependency);
+    args.push("-o", options.out);
 
     importPaths.forEach(function(importPath) {
         args.push("-p", importPath);
@@ -78,5 +91,6 @@ function runPbjs(importPaths, protoFiles) {
     if (result.error)
         throw result.error;
 
-    process.exit(result.status || 0);
+    if (result.status)
+        process.exit(result.status);
 }

--- a/tests/conformance/report.js
+++ b/tests/conformance/report.js
@@ -43,39 +43,49 @@ if (!runnerSummary) {
 
 totals = report.totals;
 printTable([
-    metric("Binary passing", totals.byFormat.binary),
-    metric("ProtoJSON passing", totals.byFormat.json),
-    metric("Required passing", totals.byRequirement.required),
-    metric("Recommended passing", totals.byRequirement.recommended),
-    metric("Total passing", totals.overall),
-    ["Skipped", String(runnerSummary.skipped)],
-    ["Expected failures", String(runnerSummary.expectedFailures)],
-    ["Unexpected failures", String(runnerSummary.unexpectedFailures)]
+    suite("Binary", "binary"),
+    suite("ProtoJSON", "json"),
+    suite("TextFormat", "textFormat"),
+    ["Overall", formatResult(totals.overall), formatResult(totals.byRequirement.required), formatResult(totals.byRequirement.recommended)]
 ].filter(Boolean));
 
-function metric(label, value) {
-    if (value && value.total)
-        return [label, formatResult(value)];
-    return null;
+function suite(label, format) {
+    var byRequirement = totals.byFormatRequirement && totals.byFormatRequirement[format];
+    if (!totals.byFormat[format])
+        return null;
+    return [
+        label,
+        formatResult(totals.byFormat[format]),
+        formatResult(byRequirement && byRequirement.required),
+        formatResult(byRequirement && byRequirement.recommended)
+    ];
 }
 
 function printTable(rows) {
-    var metricWidth = maxWidth(["Metric"].concat(rows.map(function(row) {
+    var suiteWidth = maxWidth(["Category"].concat(rows.map(function(row) {
             return row[0];
         }))),
-        countWidth = maxWidth(["Count"].concat(rows.map(function(row) {
+        totalWidth = maxWidth(["Total"].concat(rows.map(function(row) {
             return row[1];
+        }))),
+        requiredWidth = maxWidth(["Required"].concat(rows.map(function(row) {
+            return row[2];
+        }))),
+        recommendedWidth = maxWidth(["Recommended"].concat(rows.map(function(row) {
+            return row[3];
         })));
 
-    console.log("| " + padRight("Metric", metricWidth) + " | " + padLeft("Count", countWidth) + " |");
-    console.log("| " + repeat("-", metricWidth) + " | " + repeat("-", countWidth) + ": |");
+    console.log("| " + padRight("Category", suiteWidth) + " | " + padLeft("Total", totalWidth) + " | " + padLeft("Required", requiredWidth) + " | " + padLeft("Recommended", recommendedWidth) + " |");
+    console.log("| " + repeat("-", suiteWidth) + " | " + repeat("-", totalWidth) + ": | " + repeat("-", requiredWidth) + ": | " + repeat("-", recommendedWidth) + ": |");
     rows.forEach(function(row) {
-        console.log("| " + padRight(row[0], metricWidth) + " | " + padLeft(row[1], countWidth) + " |");
+        console.log("| " + padRight(row[0], suiteWidth) + " | " + padLeft(row[1], totalWidth) + " | " + padLeft(row[2], requiredWidth) + " | " + padLeft(row[3], recommendedWidth) + " |");
     });
 }
 
 function formatResult(value) {
-    return pct(value.passPercent) + " (" + value.passed + "/" + value.total + ")";
+    return value && value.total
+        ? pct(value.passPercent) + " (" + value.passed + "/" + value.total + ")"
+        : "-";
 }
 
 function pct(value) {

--- a/tests/conformance/report.js
+++ b/tests/conformance/report.js
@@ -42,12 +42,31 @@ if (!runnerSummary) {
 }
 
 totals = report.totals;
-printTable([
+if (printTable("Wire format by syntax", "Syntax", [
+    binarySyntax("proto2"),
+    binarySyntax("proto3"),
+    binarySyntax("editions")
+].filter(Boolean)))
+    console.log("");
+printTable("By harness category", "Category", [
     suite("Binary", "binary"),
     suite("ProtoJSON", "json"),
     suite("TextFormat", "textFormat"),
     ["Overall", formatResult(totals.overall), formatResult(totals.byRequirement.required), formatResult(totals.byRequirement.recommended)]
 ].filter(Boolean));
+
+function binarySyntax(syntax) {
+    var byRequirement = totals.byBinarySyntaxRequirement && totals.byBinarySyntaxRequirement[syntax],
+        total = totals.byBinarySyntax && totals.byBinarySyntax[syntax];
+    if (!total)
+        return null;
+    return [
+        total.label,
+        formatResult(total),
+        formatResult(byRequirement && byRequirement.required),
+        formatResult(byRequirement && byRequirement.recommended)
+    ];
+}
 
 function suite(label, format) {
     var byRequirement = totals.byFormatRequirement && totals.byFormatRequirement[format];
@@ -61,8 +80,8 @@ function suite(label, format) {
     ];
 }
 
-function printTable(rows) {
-    var suiteWidth = maxWidth(["Category"].concat(rows.map(function(row) {
+function printTable(title, firstColumn, rows) {
+    var suiteWidth = maxWidth([firstColumn].concat(rows.map(function(row) {
             return row[0];
         }))),
         totalWidth = maxWidth(["Total"].concat(rows.map(function(row) {
@@ -75,11 +94,17 @@ function printTable(rows) {
             return row[3];
         })));
 
-    console.log("| " + padRight("Category", suiteWidth) + " | " + padLeft("Total", totalWidth) + " | " + padLeft("Required", requiredWidth) + " | " + padLeft("Recommended", recommendedWidth) + " |");
-    console.log("| " + repeat("-", suiteWidth) + " | " + repeat("-", totalWidth) + ": | " + repeat("-", requiredWidth) + ": | " + repeat("-", recommendedWidth) + ": |");
+    if (!rows.length)
+        return false;
+
+    console.log(title + ":");
+    console.log("");
+    console.log("| " + padRight(firstColumn, suiteWidth) + " | " + padLeft("Total", totalWidth) + " | " + padLeft("Required", requiredWidth) + " | " + padLeft("Recommended", recommendedWidth) + " |");
+    console.log("| " + repeat("-", suiteWidth) + " | " + repeat("-", totalWidth - 1) + ": | " + repeat("-", requiredWidth - 1) + ": | " + repeat("-", recommendedWidth - 1) + ": |");
     rows.forEach(function(row) {
         console.log("| " + padRight(row[0], suiteWidth) + " | " + padLeft(row[1], totalWidth) + " | " + padLeft(row[2], requiredWidth) + " | " + padLeft(row[3], recommendedWidth) + " |");
     });
+    return true;
 }
 
 function formatResult(value) {

--- a/tests/conformance/summary.js
+++ b/tests/conformance/summary.js
@@ -26,8 +26,6 @@ function readTests(file) {
         return [];
 
     log = readText(file);
-    if (log.indexOf("CONFORMANCE SUITE") >= 0)
-        log = log.substring(0, log.indexOf("CONFORMANCE SUITE"));
     while ((match = pattern.exec(log)) !== null) {
         name = match[1];
         tests[name] = classifyTest(name);
@@ -70,18 +68,29 @@ function readSkips(file) {
 }
 
 function readRunnerSummary(file) {
-    var match;
+    var log,
+        match,
+        pattern = /CONFORMANCE SUITE [^:]+: (\d+) successes, (\d+) skipped, (\d+) expected failures, (\d+) unexpected failures\./g,
+        summary = null;
 
     if (!file || !fs.existsSync(file))
         return null;
 
-    match = /CONFORMANCE SUITE \w+: (\d+) successes, (\d+) skipped, (\d+) expected failures, (\d+) unexpected failures\./.exec(readText(file));
-    return match ? {
-        successes: Number(match[1]),
-        skipped: Number(match[2]),
-        expectedFailures: Number(match[3]),
-        unexpectedFailures: Number(match[4])
-    } : null;
+    log = readText(file);
+    while ((match = pattern.exec(log)) !== null) {
+        if (!summary)
+            summary = {
+                successes: 0,
+                skipped: 0,
+                expectedFailures: 0,
+                unexpectedFailures: 0
+            };
+        summary.successes += Number(match[1]);
+        summary.skipped += Number(match[2]);
+        summary.expectedFailures += Number(match[3]);
+        summary.unexpectedFailures += Number(match[4]);
+    }
+    return summary;
 }
 
 function summarize(tests, failures, skips) {
@@ -89,6 +98,7 @@ function summarize(tests, failures, skips) {
         overall: summarizeTests(tests, failures, skips),
         byRequirement: summarizeGroups(tests, failures, skips, "requirement", requirementOrder()),
         byFormat: summarizeGroups(tests, failures, skips, "format", formatOrder()),
+        byFormatRequirement: summarizeMatrix(tests, failures, skips, "format", "requirement", formatOrder(), requirementOrder()),
         bySyntax: summarizeGroups(tests, failures, skips, "syntax", syntaxOrder())
     };
 }
@@ -101,6 +111,26 @@ function summarizeGroups(tests, failures, skips, property, groups) {
         });
         if (groupTests.length)
             out[group.id] = Object.assign({ id: group.id, label: group.label }, summarizeTests(groupTests, failures, skips));
+    });
+    return out;
+}
+
+function summarizeMatrix(tests, failures, skips, rowProperty, columnProperty, rows, columns) {
+    var out = Object.create(null);
+    rows.forEach(function(row) {
+        var rowTests = tests.filter(function(test) {
+            return test[rowProperty] === row.id;
+        });
+        if (rowTests.length) {
+            out[row.id] = Object.create(null);
+            columns.forEach(function(column) {
+                var columnTests = rowTests.filter(function(test) {
+                    return test[columnProperty] === column.id;
+                });
+                if (columnTests.length)
+                    out[row.id][column.id] = Object.assign({ id: column.id, label: column.label }, summarizeTests(columnTests, failures, skips));
+            });
+        }
     });
     return out;
 }

--- a/tests/conformance/summary.js
+++ b/tests/conformance/summary.js
@@ -94,11 +94,17 @@ function readRunnerSummary(file) {
 }
 
 function summarize(tests, failures, skips) {
+    var binaryTests = tests.filter(function(test) {
+        return test.format === "binary";
+    });
+
     return {
         overall: summarizeTests(tests, failures, skips),
         byRequirement: summarizeGroups(tests, failures, skips, "requirement", requirementOrder()),
         byFormat: summarizeGroups(tests, failures, skips, "format", formatOrder()),
         byFormatRequirement: summarizeMatrix(tests, failures, skips, "format", "requirement", formatOrder(), requirementOrder()),
+        byBinarySyntax: summarizeGroups(binaryTests, failures, skips, "syntax", syntaxOrder()),
+        byBinarySyntaxRequirement: summarizeMatrix(binaryTests, failures, skips, "syntax", "requirement", syntaxOrder(), requirementOrder()),
         bySyntax: summarizeGroups(tests, failures, skips, "syntax", syntaxOrder())
     };
 }
@@ -203,8 +209,8 @@ function formatOrder() {
 
 function syntaxOrder() {
     return [
-        { id: "proto2", label: "proto2" },
-        { id: "proto3", label: "proto3" },
+        { id: "proto2", label: "Proto2" },
+        { id: "proto3", label: "Proto3" },
         { id: "editions", label: "Editions" },
         { id: "other", label: "Other" }
     ];

--- a/tests/conformance/testee.js
+++ b/tests/conformance/testee.js
@@ -1,47 +1,46 @@
 "use strict";
 
 var fs = require("fs"),
+    protobuf = require("../.."),
     generated = require("./generated/messages.js"),
+    reflectionRoot = protobuf.Root.fromJSON(require("./generated/messages.json")).resolveAll(),
     conformance = generated.conformance,
     list = process.argv.indexOf("--list") >= 0,
     testTypes = Object.create(null);
 
+require("../../ext/textformat");
+
 var TEST_TYPES = [
-    {
-        name: "protobuf_test_messages.proto2.TestAllTypesProto2",
-        type: generated.protobuf_test_messages.proto2.TestAllTypesProto2
-    },
-    {
-        name: "protobuf_test_messages.proto3.TestAllTypesProto3",
-        type: generated.protobuf_test_messages.proto3.TestAllTypesProto3
-    },
-    {
-        name: "protobuf_test_messages.editions.proto2.TestAllTypesProto2",
-        type: generated.protobuf_test_messages.editions.proto2.TestAllTypesProto2
-    },
-    {
-        name: "protobuf_test_messages.editions.proto3.TestAllTypesProto3",
-        type: generated.protobuf_test_messages.editions.proto3.TestAllTypesProto3
-    },
-    {
-        name: "protobuf_test_messages.editions.TestAllTypesEdition2023",
-        type: generated.protobuf_test_messages.editions.TestAllTypesEdition2023
-    }
+    makeTestType("protobuf_test_messages.proto2.TestAllTypesProto2", generated.protobuf_test_messages.proto2.TestAllTypesProto2),
+    makeTestType("protobuf_test_messages.proto3.TestAllTypesProto3", generated.protobuf_test_messages.proto3.TestAllTypesProto3),
+    makeTestType("protobuf_test_messages.editions.proto2.TestAllTypesProto2", generated.protobuf_test_messages.editions.proto2.TestAllTypesProto2),
+    makeTestType("protobuf_test_messages.editions.proto3.TestAllTypesProto3", generated.protobuf_test_messages.editions.proto3.TestAllTypesProto3),
+    makeTestType("protobuf_test_messages.editions.TestAllTypesEdition2023", generated.protobuf_test_messages.editions.TestAllTypesEdition2023)
 ];
 
 // Register the local stable-edition copy of UNSTABLE if included by generate.js.
 if (generated.protobuf_test_messages.edition_unstable) {
-    TEST_TYPES.push({
-        name: "protobuf_test_messages.edition_unstable.TestAllTypesEditionUnstable",
-        type: generated.protobuf_test_messages.edition_unstable.TestAllTypesEditionUnstable
-    });
+    TEST_TYPES.push(makeTestType(
+        "protobuf_test_messages.edition_unstable.TestAllTypesEditionUnstable",
+        generated.protobuf_test_messages.edition_unstable.TestAllTypesEditionUnstable
+    ));
 }
 
-TEST_TYPES.forEach(function(testType) {
-    if (!testType.type)
-        throw Error("missing generated test type: " + testType.name);
-    testTypes[testType.name] = testType.type;
+TEST_TYPES.forEach(function(testCase) {
+    if (!testCase.type)
+        throw Error("missing generated test type: " + testCase.name);
+    if (!testCase.textType)
+        throw Error("missing reflected test type: " + testCase.name);
+    testTypes[testCase.name] = testCase;
 });
+
+function makeTestType(name, type) {
+    return {
+        name: name,
+        type: type,
+        textType: reflectionRoot.lookupType(name)
+    };
+}
 
 // Keep stdout synchronous because it carries the framed testee protocol.
 if (process.stdout._handle)
@@ -54,6 +53,7 @@ var count = 0,
     requestBuffer,
     response,
     sizeBuffer,
+    testCase,
     type;
 
 try {
@@ -79,10 +79,11 @@ try {
         } else if (list) {
             response = { skipped: "list mode" };
         } else {
-            type = testTypes[request.messageType];
-            if (!type) {
+            testCase = testTypes[request.messageType];
+            if (!testCase) {
                 response = { runtimeError: "unknown message type: " + request.messageType };
             } else {
+                type = testCase.type;
                 // Parse the request payload into the requested generated type.
                 try {
                     switch (request.payload) {
@@ -96,7 +97,7 @@ try {
                             response = { parseError: "JSPB not supported" };
                             break;
                         case "textPayload":
-                            response = { parseError: "TextFormat not supported" };
+                            message = testCase.textType.fromText(request.textPayload);
                             break;
                         default:
                             response = { parseError: "unsupported format" };
@@ -127,7 +128,11 @@ try {
                                 response = { skipped: "JSPB not supported" };
                                 break;
                             case conformance.WireFormat.TEXT_FORMAT:
-                                response = { skipped: "text format not supported" };
+                                response = {
+                                    textPayload: testCase.textType.toText(message, {
+                                        unknowns: request.printUnknownFields
+                                    })
+                                };
                                 break;
                             default:
                                 response = { runtimeError: "unknown output format: " + request.requestedOutputFormat };


### PR DESCRIPTION
Adds an optional `ext/textformat` extension that, similar to `ext/descriptor`, patches reflected `Type`s with `fromText(...)` and `toText(...)`.

Also adds the usual declarations and tests, and wires TextFormat into the conformance harness.

[Conformance](https://github.com/protobufjs/protobuf.js/actions/runs/25520666498?pr=2233#summary-74903535534)

---

Note to self: This one is stacked upon #2232.