### PR TITLE
fix: Make optional Node module lookups bundler-safe

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2223,6 +2223,7 @@ export namespace util {
      * Requires a module only if available.
      * @param moduleName Module to require
      * @returns Required module if available and not empty, otherwise `null`
+     * @deprecated Legacy optional require helper. Will be removed in a future release.
      */
     function inquire(moduleName: string): object;
 

--- a/package.json
+++ b/package.json
@@ -19,6 +19,9 @@
   "main": "index.js",
   "type": "commonjs",
   "types": "index.d.ts",
+  "browser": {
+    "fs": false
+  },
   "scripts": {
     "bench": "node bench",
     "build": "npm run build:bundle && npm run build:types",

--- a/src/util.js
+++ b/src/util.js
@@ -23,7 +23,7 @@ var reservedRe = util.patterns.reservedRe,
  * Node's fs module if available.
  * @type {Object.<string,*>}
  */
-util.fs = util.inquire("fs");
+util.fs = require("./util/fs");
 
 /**
  * Converts an object's values to an array.

--- a/src/util/fetch.js
+++ b/src/util/fetch.js
@@ -2,9 +2,7 @@
 module.exports = fetch;
 
 var asPromise = require("./aspromise"),
-    inquire   = require("./inquire");
-
-var fs = inquire("fs");
+    fs        = require("./fs");
 
 /**
  * Node-style callback as used by {@link util.fetch}.

--- a/src/util/fs.js
+++ b/src/util/fs.js
@@ -1,0 +1,11 @@
+"use strict";
+
+var fs = null;
+try {
+    fs = require(/* webpackIgnore: true */ "fs");
+    if (!fs || !fs.readFile || !fs.readFileSync)
+        fs = null;
+} catch (e) {
+    // `fs` is unavailable in browsers and browser-like bundles.
+}
+module.exports = fs;

--- a/src/util/inquire.d.ts
+++ b/src/util/inquire.d.ts
@@ -5,5 +5,6 @@ export = inquire;
  * @memberof util
  * @param {string} moduleName Module to require
  * @returns {?Object} Required module if available and not empty, otherwise `null`
+ * @deprecated Legacy optional require helper. Will be removed in a future release.
  */
 declare function inquire(moduleName: string): object;

--- a/src/util/inquire.js
+++ b/src/util/inquire.js
@@ -6,6 +6,7 @@ module.exports = inquire;
  * @memberof util
  * @param {string} moduleName Module to require
  * @returns {?Object} Required module if available and not empty, otherwise `null`
+ * @deprecated Legacy optional require helper. Will be removed in a future release.
  */
 function inquire(moduleName) {
   try {

--- a/src/util/minimal.js
+++ b/src/util/minimal.js
@@ -125,7 +125,7 @@ util.isSet = function isSet(obj, prop) {
  */
 util.Buffer = (function() {
     try {
-        var Buffer = util.inquire("buffer").Buffer;
+        var Buffer = util.global.Buffer;
         // refuse to use non-node buffers if not explicitly assigned (perf reasons):
         return Buffer.prototype.utf8Write ? Buffer : /* istanbul ignore next */ null;
     } catch (e) {

--- a/src/util/minimal.js
+++ b/src/util/minimal.js
@@ -179,7 +179,15 @@ util.Array = typeof Uint8Array !== "undefined" ? Uint8Array /* istanbul ignore n
  */
 util.Long = /* istanbul ignore next */ util.global.dcodeIO && /* istanbul ignore next */ util.global.dcodeIO.Long
          || /* istanbul ignore next */ util.global.Long
-         || util.inquire("long");
+         || (function() {
+                try {
+                    var Long = require("long");
+                    return Long && Long.isLong ? Long : null;
+                } catch (e) {
+                    /* istanbul ignore next */
+                    return null;
+                }
+            })();
 
 /**
  * Regular expression used to verify 2 bit (`bool`) map keys.


### PR DESCRIPTION
Fixes the internal optional module lookups that can confuse bundlers after `util.inquire` was inlined.

`fs` is now resolved through a literal optional require, with a `browser` field mapping so browser bundles receive an empty stub that is normalized to `null`. `Buffer` is read from the runtime environment instead of going through `util.inquire`, and `Long` is resolved through a literal optional `require("long")` so bundlers can include it normally.

Also marks `util.inquire` as deprecated so we can remove it in a future release.

Supersedes #2226.
Follow-up to #2146.