### PR TITLE
chore: Fix API docs publishing

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -62,7 +62,7 @@ jobs:
 
       - name: Publish API docs
         if: ${{ steps.release.outputs.release_created == 'true' }}
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          npm run docs:publish
+        continue-on-error: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: npm run docs:publish

--- a/scripts/pages.js
+++ b/scripts/pages.js
@@ -1,16 +1,30 @@
-/*eslint-disable no-console*/
+/*eslint-disable no-console, no-process-env*/
 "use strict";
 
 var ghpages = require("gh-pages"),
-    path    = require("path");
+    path    = require("path"),
+    pkg     = require("../package.json");
 
-ghpages.publish(path.join(__dirname, "..", "docs"), {
-    logger: function(message) {
-        console.log(message);
-    }
-}, function(err) {
-    if (err)
-        console.error(err);
-    else
+var options = {
+    message: "docs: update API documentation for v" + pkg.version,
+    nojekyll: true
+};
+
+// Auth for the gh-pages clone in CI.
+if (process.env.GITHUB_TOKEN && process.env.GITHUB_REPOSITORY) {
+    options.repo = "https://git:" + process.env.GITHUB_TOKEN
+        + "@github.com/" + process.env.GITHUB_REPOSITORY + ".git";
+    options.silent = true;
+    options.user = {
+        name: "github-actions[bot]",
+        email: "41898282+github-actions[bot]@users.noreply.github.com"
+    };
+}
+
+ghpages.publish(path.join(__dirname, "..", "docs"), options, function(err) {
+    if (err) {
+        console.error(err.message || err);
+        process.exitCode = 1;
+    } else
         console.log("done");
 });


### PR DESCRIPTION
Fixes credentials for API docs publishing in the release workflow and marks the docs publish step optional in case it fails again.
