### PR TITLE
fix: Consolidate depth limit checks

### DIFF
--- a/ext/descriptor.js
+++ b/ext/descriptor.js
@@ -221,9 +221,14 @@ var unnamedMessageIndex = 0;
  * @param {IDescriptorProto|Reader|Uint8Array} descriptor Descriptor
  * @param {string} [edition="proto2"] The syntax or edition to use
  * @param {boolean} [nested=false] Whether or not this is a nested object
+ * @param {number} [depth] Current nesting depth, defaults to `0`
  * @returns {Type} Type instance
  */
-Type.fromDescriptor = function fromDescriptor(descriptor, edition, nested) {
+Type.fromDescriptor = function fromDescriptor(descriptor, edition, nested, depth) {
+    if (depth === undefined)
+        depth = 0;
+    if (depth > $protobuf.util.nestingLimit)
+        throw Error("max depth exceeded");
     descriptor = decodeDescriptor(descriptor, exports.DescriptorProto);
 
     var type = new Type(descriptor.name.length ? descriptor.name : "Type" + unnamedMessageIndex++, fromDescriptorOptions(descriptor.options, exports.MessageOptions)),
@@ -255,7 +260,7 @@ Type.fromDescriptor = function fromDescriptor(descriptor, edition, nested) {
         for (i = 0; i < descriptor.nestedType.length; ++i) {
             if (descriptor.nestedType[i].options && descriptor.nestedType[i].options.mapEntry)
                 continue;
-            type.add(Type.fromDescriptor(descriptor.nestedType[i], edition, true));
+            type.add(Type.fromDescriptor(descriptor.nestedType[i], edition, true, depth + 1));
         }
     /* Nested enums */ if (descriptor.enumType)
         for (i = 0; i < descriptor.enumType.length; ++i)

--- a/ext/textformat.d.ts
+++ b/ext/textformat.d.ts
@@ -5,17 +5,11 @@ export interface ITextFormatOptions {
     unknowns?: boolean;
 }
 
-/** Maximum recursion depth for text format parsing and formatting. Defaults to util.recursionLimit. */
-export let recursionLimit: number;
-
 /** Maximum recursion depth for formatting length-delimited unknown fields. */
 export let unknownRecursionLimit: number;
 
 declare module ".." {
     namespace textformat {
-        /** Maximum recursion depth for text format parsing and formatting. Defaults to util.recursionLimit. */
-        let recursionLimit: number;
-
         /** Maximum recursion depth for formatting length-delimited unknown fields. */
         let unknownRecursionLimit: number;
     }

--- a/ext/textformat.js
+++ b/ext/textformat.js
@@ -10,21 +10,6 @@ var Type    = protobuf.Type,
 
 var textformat = protobuf.textformat = module.exports = {};
 
-var recursionLimit;
-
-/**
- * Maximum recursion depth for text format parsing and formatting. Defaults to util.recursionLimit.
- * @type {number}
- */
-Object.defineProperty(textformat, "recursionLimit", {
-    get: function get() {
-        return recursionLimit === undefined ? util.recursionLimit : recursionLimit;
-    },
-    set: function set(value) {
-        recursionLimit = value == null ? undefined : value;
-    }
-});
-
 /**
  * Maximum recursion depth for formatting length-delimited unknown fields.
  * @type {number}
@@ -88,7 +73,7 @@ function formatText(type, message, options) {
         throw TypeError("type must be a Type");
     type.root.resolveAll();
     var lines = [];
-    writeMessage(type, message, lines, 0, options || {}, 0, textformat.recursionLimit);
+    writeMessage(type, message, lines, 0, options || {}, 0);
     return lines.join("\n");
 }
 
@@ -318,7 +303,6 @@ Tokenizer.prototype.readCodePoint = function readCodePoint(size) {
 
 function Parser(source) {
     this.tn = new Tokenizer(source);
-    this.recursionLimit = textformat.recursionLimit;
 }
 
 Parser.prototype.error = function error(message) {
@@ -331,13 +315,9 @@ Parser.prototype.expectEnd = function expectEnd() {
         this.error("unexpected token '" + token.value + "'");
 };
 
-Parser.prototype.checkRecursion = function checkRecursion(depth) {
-    if (depth > this.recursionLimit)
-        this.error("max depth exceeded");
-};
-
 Parser.prototype.parseMessage = function parseMessage(type, end, depth) {
-    this.checkRecursion(depth);
+    if (depth > util.recursionLimit)
+        this.error("max depth exceeded");
     var object = {},
         seen = {};
     for (;;) {
@@ -473,7 +453,8 @@ Parser.prototype.parseMessageFieldDelimiter = function parseMessageFieldDelimite
 };
 
 Parser.prototype.parseMapEntry = function parseMapEntry(field, depth) {
-    this.checkRecursion(depth);
+    if (depth > util.recursionLimit)
+        this.error("max depth exceeded");
     var end;
     if (this.tn.skip("{"))
         end = "}";
@@ -617,7 +598,7 @@ Parser.prototype.skipBalanced = function skipBalanced(open, close, depth) {
         if (!token)
             this.error("expected '" + close + "'");
         if (token.value === open) {
-            if (depth + ++balance > this.recursionLimit)
+            if (depth + ++balance > util.recursionLimit)
                 this.error("max depth exceeded");
         }
         else if (token.value === close)
@@ -855,13 +836,9 @@ function parseIntegerBigInt(digits, radix, sign, unsigned, bits) {
     return Number(value);
 }
 
-function checkRecursion(depth, recursionLimit) {
-    if (depth > recursionLimit)
+function writeMessage(type, message, lines, indent, options, depth) {
+    if (depth > util.recursionLimit)
         throw Error("max depth exceeded");
-}
-
-function writeMessage(type, message, lines, indent, options, depth, recursionLimit) {
-    checkRecursion(depth, recursionLimit);
     var fields = type.fieldsArray.slice().sort(util.compareFieldsById);
     for (var i = 0; i < fields.length; ++i) {
         var field = fields[i].resolve(),
@@ -869,25 +846,26 @@ function writeMessage(type, message, lines, indent, options, depth, recursionLim
         if (value == null || !Object.prototype.hasOwnProperty.call(message, field.name))
             continue;
         if (field.map)
-            writeMapField(field, value, lines, indent, options, depth, recursionLimit);
+            writeMapField(field, value, lines, indent, options, depth);
         else if (field.repeated)
             for (var j = 0; j < value.length; ++j)
-                writeField(field, value[j], lines, indent, options, depth, recursionLimit);
+                writeField(field, value[j], lines, indent, options, depth);
         else
-            writeField(field, value, lines, indent, options, depth, recursionLimit);
+            writeField(field, value, lines, indent, options, depth);
     }
     if (options.unknowns && message.$unknowns != null && Object.prototype.hasOwnProperty.call(message, "$unknowns"))
         writeUnknowns(message.$unknowns, lines, indent);
 }
 
-function writeMapField(field, map, lines, indent, options, depth, recursionLimit) {
+function writeMapField(field, map, lines, indent, options, depth) {
     var keys = Object.keys(map).sort(),
         keyField = mapKeyField(field),
         valueField = mapValueField(field),
         name = formatFieldName(field),
         sp = spaces(indent);
     for (var i = 0; i < keys.length; ++i) {
-        checkRecursion(depth + 1, recursionLimit);
+        if (depth + 1 > util.recursionLimit)
+            throw Error("max depth exceeded");
         var key = keyField.long ? util.longFromKey(keys[i], keyField.type === "uint64" || keyField.type === "fixed64") : keys[i];
         if (keyField.type === "bool")
             key = util.boolFromKey(keys[i]);
@@ -895,7 +873,7 @@ function writeMapField(field, map, lines, indent, options, depth, recursionLimit
         lines.push(spaces(indent + 2) + "key: " + formatScalar(keyField, key));
         if (valueField.resolvedType instanceof Type) {
             lines.push(spaces(indent + 2) + "value {");
-            writeMessage(valueField.resolvedType, map[keys[i]], lines, indent + 4, options, depth + 2, recursionLimit);
+            writeMessage(valueField.resolvedType, map[keys[i]], lines, indent + 4, options, depth + 2);
             lines.push(spaces(indent + 2) + "}");
         } else
             lines.push(spaces(indent + 2) + "value: " + formatScalar(valueField, map[keys[i]]));
@@ -903,12 +881,12 @@ function writeMapField(field, map, lines, indent, options, depth, recursionLimit
     }
 }
 
-function writeField(field, value, lines, indent, options, depth, recursionLimit) {
+function writeField(field, value, lines, indent, options, depth) {
     var name = formatFieldName(field),
         sp = spaces(indent);
     if (field.resolvedType instanceof Type) {
         lines.push(sp + name + " {");
-        writeMessage(field.resolvedType, value, lines, indent + 2, options, depth + 1, recursionLimit);
+        writeMessage(field.resolvedType, value, lines, indent + 2, options, depth + 1);
         lines.push(sp + "}");
     } else
         lines.push(sp + name + ": " + formatScalar(field, value));

--- a/index.d.ts
+++ b/index.d.ts
@@ -2436,6 +2436,9 @@ export namespace util {
      */
     function merge(dst: { [k: string]: any }, src: { [k: string]: any }, ifNotSet?: boolean): { [k: string]: any };
 
+    /** Schema declaration nesting limit. */
+    let nestingLimit: number;
+
     /** Recursion limit. */
     let recursionLimit: number;
 
@@ -2573,14 +2576,6 @@ export namespace util {
 
     /** Node's fs module if available. */
     let fs: { [k: string]: any };
-
-    /**
-     * Checks a recursion depth.
-     * @param depth Depth of recursion
-     * @returns Depth of recursion
-     * @throws {Error} If depth exceeds util.recursionLimit
-     */
-    function checkDepth(depth: (number|undefined)): number;
 
     /**
      * Converts an object's values to an array.

--- a/src/namespace.js
+++ b/src/namespace.js
@@ -34,7 +34,10 @@ var Type,    // cyclic
  * @throws {TypeError} If arguments are invalid
  */
 Namespace.fromJSON = function fromJSON(name, json, depth) {
-    depth = util.checkDepth(depth);
+    if (depth === undefined)
+        depth = 0;
+    if (depth > util.recursionLimit)
+        throw Error("max depth exceeded");
     return new Namespace(name, json.options).addJSON(json.nested, depth);
 };
 
@@ -197,7 +200,10 @@ Namespace.prototype.toJSON = function toJSON(toJSONOptions) {
  * @returns {Namespace} `this`
  */
 Namespace.prototype.addJSON = function addJSON(nestedJson, depth) {
-    depth = util.checkDepth(depth);
+    if (depth === undefined)
+        depth = 0;
+    if (depth > util.recursionLimit)
+        throw Error("max depth exceeded");
     var ns = this;
     /* istanbul ignore else */
     if (nestedJson) {
@@ -337,6 +343,8 @@ Namespace.prototype.define = function define(path, json) {
         throw TypeError("illegal path");
     if (path && path.length && path[0] === "")
         throw Error("path must be relative");
+    if (path.length > util.recursionLimit)
+        throw Error("max depth exceeded");
 
     var ptr = this;
     while (path.length > 0) {

--- a/src/parse.js
+++ b/src/parse.js
@@ -312,7 +312,9 @@ function parse(source, root, options) {
 
 
     function parseCommon(parent, token, depth) {
-        depth = util.checkDepth(depth);
+        if (depth === undefined)
+            depth = 0;
+        // depth is checked by dispatched functions
         switch (token) {
 
             case "option":
@@ -378,7 +380,10 @@ function parse(source, root, options) {
     }
 
     function parseType(parent, token, depth) {
-        depth = util.checkDepth(depth);
+        if (depth === undefined)
+            depth = 0;
+        if (depth > util.nestingLimit)
+            throw Error("max depth exceeded");
 
         /* istanbul ignore if */
         if (!nameRe.test(token = next()))
@@ -507,7 +512,10 @@ function parse(source, root, options) {
     }
 
     function parseGroup(parent, rule, extend, depth) {
-        depth = util.checkDepth(depth);
+        if (depth === undefined)
+            depth = 0;
+        if (depth > util.nestingLimit)
+            throw Error("max depth exceeded");
         if (edition >= 2023) {
             throw illegal("group");
         }
@@ -754,7 +762,10 @@ function parse(source, root, options) {
     }
 
     function parseOptionValue(parent, name, depth) {
-        depth = util.checkDepth(depth);
+        if (depth === undefined)
+            depth = 0;
+        if (depth > util.recursionLimit)
+            throw Error("max depth exceeded");
         // { a: "foo" b { c: "bar" } }
         if (skip("{", true)) {
             var objectResult = {};
@@ -845,7 +856,10 @@ function parse(source, root, options) {
     }
 
     function parseService(parent, token, depth) {
-        depth = util.checkDepth(depth);
+        if (depth === undefined)
+            depth = 0;
+        if (depth > util.recursionLimit)
+            throw Error("max depth exceeded");
 
         /* istanbul ignore if */
         if (!nameRe.test(token = next()))

--- a/src/root.js
+++ b/src/root.js
@@ -59,7 +59,10 @@ function Root(options) {
  * @returns {Root} Root namespace
  */
 Root.fromJSON = function fromJSON(json, root, depth) {
-    depth = util.checkDepth(depth);
+    if (depth === undefined)
+        depth = 0;
+    if (depth > util.recursionLimit)
+        throw Error("max depth exceeded");
     if (!root)
         root = new Root();
     if (json.options)

--- a/src/service.js
+++ b/src/service.js
@@ -53,7 +53,10 @@ function Service(name, options) {
  * @throws {TypeError} If arguments are invalid
  */
 Service.fromJSON = function fromJSON(name, json, depth) {
-    depth = util.checkDepth(depth);
+    if (depth === undefined)
+        depth = 0;
+    if (depth > util.recursionLimit)
+        throw Error("max depth exceeded");
     var service = new Service(name, json.options);
     /* istanbul ignore else */
     if (json.methods)

--- a/src/type.js
+++ b/src/type.js
@@ -239,7 +239,10 @@ function clearCache(type) {
  * @returns {Type} Created message type
  */
 Type.fromJSON = function fromJSON(name, json, depth) {
-    depth = util.checkDepth(depth);
+    if (depth === undefined)
+        depth = 0;
+    if (depth > util.nestingLimit)
+        throw Error("max depth exceeded");
     var type = new Type(name, json.options);
     type.extensions = json.extensions;
     type.reserved = json.reserved;

--- a/src/util.js
+++ b/src/util.js
@@ -26,20 +26,6 @@ var reservedRe = util.patterns.reservedRe,
 util.fs = require("./util/fs");
 
 /**
- * Checks a recursion depth.
- * @param {number|undefined} depth Depth of recursion
- * @returns {number} Depth of recursion
- * @throws {Error} If depth exceeds util.recursionLimit
- */
-util.checkDepth = function checkDepth(depth) {
-    if (depth === undefined)
-        depth = 0;
-    if (depth > util.recursionLimit)
-        throw Error("max depth exceeded");
-    return depth;
-};
-
-/**
  * Converts an object's values to an array.
  * @param {Object.<string,*>} object Object to convert
  * @returns {Array.<*>} Converted array
@@ -215,6 +201,8 @@ util.setProperty = function setProperty(dst, path, value, ifNotSet) {
         throw TypeError("path must be specified");
 
     path = path.split(".");
+    if (path.length > util.recursionLimit)
+        throw Error("max depth exceeded");
     return setProp(dst, path, value);
 };
 

--- a/src/util/minimal.js
+++ b/src/util/minimal.js
@@ -274,11 +274,18 @@ function merge(dst, src, ifNotSet) { // used by converters
 util.merge = merge;
 
 /**
+ * Schema declaration nesting limit.
+ * @memberof util
+ * @type {number}
+ */
+util.nestingLimit = 32; // protoc: MaxMessageDeclarationNestingDepth
+
+/**
  * Recursion limit.
  * @memberof util
  * @type {number}
  */
-util.recursionLimit = 100;
+util.recursionLimit = 100; // protoc: CodedInputStream::default_recursion_limit_
 
 /**
  * Makes a property safe for assignment as an own property.

--- a/tests/api_descriptor.js
+++ b/tests/api_descriptor.js
@@ -310,6 +310,58 @@ tape.test("descriptor - encoded descriptor inputs", function(test) {
     test.end();
 });
 
+tape.test("descriptor - nesting", function(test) {
+    function nestedMessageDescriptor(depth) {
+        var root = descriptor.DescriptorProto.create({ name: "Message0" }),
+            nested = root;
+        for (var i = 1; i <= depth; ++i) {
+            var child = descriptor.DescriptorProto.create({ name: "Message" + i });
+            nested.nestedType.push(child);
+            nested = child;
+        }
+        return root;
+    }
+
+    function packageDescriptor(depth) {
+        var packageName = "a";
+        for (var i = 1; i < depth; ++i)
+            packageName += ".a";
+        return descriptor.FileDescriptorSet.create({
+            file: [ descriptor.FileDescriptorProto.create({
+                name: "test.proto",
+                "package": packageName
+            }) ]
+        });
+    }
+
+    var recursionLimit = protobuf.util.recursionLimit,
+        nestingLimit = protobuf.util.nestingLimit;
+    try {
+        protobuf.util.recursionLimit = 100;
+        protobuf.util.nestingLimit = 3;
+        test.doesNotThrow(function() {
+            protobuf.Type.fromDescriptor(nestedMessageDescriptor(3), "proto3");
+        }, "should load descriptor message nesting up to the nesting limit");
+        test.throws(function() {
+            protobuf.Type.fromDescriptor(nestedMessageDescriptor(4), "proto3");
+        }, /max depth exceeded/, "should reject excessively nested descriptor messages");
+
+        protobuf.util.recursionLimit = 3;
+        protobuf.util.nestingLimit = 100;
+        test.doesNotThrow(function() {
+            protobuf.Root.fromDescriptor(packageDescriptor(3));
+        }, "should load descriptor package paths up to the recursion limit");
+        test.throws(function() {
+            protobuf.Root.fromDescriptor(packageDescriptor(4));
+        }, /max depth exceeded/, "should reject excessively nested descriptor package paths");
+    } finally {
+        protobuf.util.recursionLimit = recursionLimit;
+        protobuf.util.nestingLimit = nestingLimit;
+    }
+
+    test.end();
+});
+
 tape.test("descriptor - proto3 optional field without options", function(test) {
     var fieldDescriptor = descriptor.FieldDescriptorProto.create({
         name: "value",

--- a/tests/api_namespace.js
+++ b/tests/api_namespace.js
@@ -86,6 +86,19 @@ tape.test("reflected namespaces", function(test) {
     var sub = ns.define("sub", {});
     test.equal(ns.lookup("sub"), sub, "should define sub namespaces");
 
+    var recursionLimit = protobuf.util.recursionLimit;
+    protobuf.util.recursionLimit = 3;
+    try {
+        test.doesNotThrow(function() {
+            ns.define("a.b.c");
+        }, "should define namespace paths up to the recursion limit");
+        test.throws(function() {
+            ns.define("a.b.c.d");
+        }, /max depth exceeded/, "should reject excessively nested namespace paths");
+    } finally {
+        protobuf.util.recursionLimit = recursionLimit;
+    }
+
     test.throws(function() {
         ns.add(new protobuf.ReflectionObject("invalid"));
     }, TypeError, "should throw when adding invalid nested objects");
@@ -188,29 +201,53 @@ tape.test("JSON descriptor nesting", function(test) {
         return root;
     }
 
-    var recursionLimit = protobuf.util.recursionLimit;
-    protobuf.util.recursionLimit = 3;
+    function nestedOptionPathDescriptor(depth) {
+        var path = "features";
+        for (var i = 0; i < depth; ++i)
+            path += ".a";
+        var descriptor = { options: {}, nested: {} };
+        descriptor.options[path] = true;
+        return descriptor;
+    }
+
+    var recursionLimit = protobuf.util.recursionLimit,
+        nestingLimit = protobuf.util.nestingLimit;
     try {
+        protobuf.util.recursionLimit = 3;
+        protobuf.util.nestingLimit = 100;
         test.doesNotThrow(function() {
             protobuf.Root.fromJSON(nestedNamespaceDescriptor(3));
         }, "should load namespace descriptors up to the recursion limit");
         test.throws(function() {
             protobuf.Root.fromJSON(nestedNamespaceDescriptor(4));
         }, /max depth exceeded/, "should reject excessively nested namespace descriptors");
+
+        protobuf.util.recursionLimit = 100;
+        protobuf.util.nestingLimit = 3;
         test.doesNotThrow(function() {
             protobuf.Root.fromJSON(nestedTypeDescriptor(3));
-        }, "should load type descriptors up to the recursion limit");
+        }, "should load type descriptors up to the nesting limit");
         test.throws(function() {
             protobuf.Root.fromJSON(nestedTypeDescriptor(4));
         }, /max depth exceeded/, "should reject excessively nested type descriptors");
+
+        protobuf.util.recursionLimit = 3;
+        protobuf.util.nestingLimit = 100;
         test.doesNotThrow(function() {
             protobuf.Root.fromJSON(nestedServiceDescriptor(3));
         }, "should load service descriptors up to the recursion limit");
         test.throws(function() {
             protobuf.Root.fromJSON(nestedServiceDescriptor(4));
         }, /max depth exceeded/, "should reject excessively nested service descriptors");
+        test.doesNotThrow(function() {
+            protobuf.Root.fromJSON(nestedOptionPathDescriptor(2));
+        }, "should load option paths up to the recursion limit");
+        test.throws(function() {
+            protobuf.Root.fromJSON(nestedOptionPathDescriptor(3));
+        }, /max depth exceeded/, "should reject excessively nested option paths");
     } finally {
         protobuf.util.recursionLimit = recursionLimit;
+        protobuf.util.nestingLimit = nestingLimit;
     }
 
     test.end();

--- a/tests/api_textformat.js
+++ b/tests/api_textformat.js
@@ -180,10 +180,8 @@ tape.test("textformat - enforces recursion limit", function(test) {
     var RecRoot = protobuf.parse("syntax = \"proto3\"; message Node { Node child = 1; reserved \"old\"; }").root,
         Node = RecRoot.lookupType("Node"),
         limit = protobuf.util.recursionLimit;
-    protobuf.textformat.recursionLimit = undefined;
     protobuf.util.recursionLimit = 1;
     try {
-        test.equal(protobuf.textformat.recursionLimit, 1, "defaults to util recursion limit");
         test.doesNotThrow(function() {
             Node.fromText("child {}");
         }, "parses nesting at limit");
@@ -199,15 +197,7 @@ tape.test("textformat - enforces recursion limit", function(test) {
         test.throws(function() {
             Node.toText({ child: { child: {} } });
         }, /max depth exceeded/, "rejects format nesting over limit");
-
-        protobuf.textformat.recursionLimit = 2;
-        protobuf.util.recursionLimit = 0;
-        test.equal(protobuf.textformat.recursionLimit, 2, "supports textformat-specific override");
-        test.doesNotThrow(function() {
-            Node.fromText("child { child {} }");
-        }, "parse override is independent from util recursion limit");
     } finally {
-        protobuf.textformat.recursionLimit = undefined;
         protobuf.util.recursionLimit = limit;
     }
     test.end();

--- a/tests/api_util.js
+++ b/tests/api_util.js
@@ -99,7 +99,20 @@ tape.test("util", function(test) {
 
         util.setProperty(o, 'prop.subprop', { subsub2: 7});
         test.same(o, {prop1: [5, 6], prop: {subprop: [{subsub: [5,6]}, {subsub2: 7}]}}, "should convert nested properties to array");
-        
+
+        var recursionLimit = util.recursionLimit;
+        util.recursionLimit = 3;
+        try {
+            test.doesNotThrow(function() {
+                util.setProperty({}, 'a.b.c', 1);
+            }, "should set property paths up to the recursion limit");
+            test.throws(function() {
+                util.setProperty({}, 'a.b.c.d', 1);
+            }, /max depth exceeded/, "should reject excessively nested property paths");
+        } finally {
+            util.recursionLimit = recursionLimit;
+        }
+
         util.setProperty({}, "__proto__.test", "value");
         test.is({}.test, undefined);
 

--- a/tests/comp_parse-uncommon.js
+++ b/tests/comp_parse-uncommon.js
@@ -81,35 +81,72 @@ tape.test("parser nesting", function(test) {
         return source + "}; }";
     }
 
-    var recursionLimit = protobuf.util.recursionLimit;
-    protobuf.util.recursionLimit = 3;
+    function dottedOptionPath(depth) {
+        var source = "syntax = \"proto2\"; message M { optional int32 a = 1 [(.foo)";
+        for (var i = 0; i < depth; ++i)
+            source += ".a";
+        return source + " = 1]; }";
+    }
+
+    function packagePath(depth) {
+        var source = "syntax = \"proto3\"; package a";
+        for (var i = 1; i < depth; ++i)
+            source += ".a";
+        return source + ";";
+    }
+
+    var recursionLimit = protobuf.util.recursionLimit,
+        nestingLimit = protobuf.util.nestingLimit;
     try {
+        protobuf.util.recursionLimit = 100;
+        protobuf.util.nestingLimit = 3;
         test.doesNotThrow(function() {
             protobuf.parse(nestedMessages(3));
-        }, "should parse message nesting up to the recursion limit");
+        }, "should parse message nesting up to the nesting limit");
         test.throws(function() {
             protobuf.parse(nestedMessages(4));
         }, /max depth exceeded/, "should reject excessively nested messages");
+        protobuf.util.recursionLimit = 1;
+        test.doesNotThrow(function() {
+            protobuf.parse(nestedMessages(3));
+        }, "should not apply recursion limit to message declarations");
+        protobuf.util.recursionLimit = 100;
         test.doesNotThrow(function() {
             protobuf.parse(nestedGroups(2));
-        }, "should parse group nesting up to the recursion limit");
+        }, "should parse group nesting up to the nesting limit");
         test.throws(function() {
             protobuf.parse(nestedGroups(3));
         }, /max depth exceeded/, "should reject excessively nested groups");
         test.doesNotThrow(function() {
             protobuf.parse(nestedExportMessages(3));
-        }, "should parse exported message nesting up to the recursion limit");
+        }, "should parse exported message nesting up to the nesting limit");
         test.throws(function() {
             protobuf.parse(nestedExportMessages(4));
         }, /max depth exceeded/, "should reject excessively nested exported messages");
+
+        protobuf.util.recursionLimit = 3;
+        protobuf.util.nestingLimit = 100;
         test.doesNotThrow(function() {
             protobuf.parse(nestedOptionValue(3));
         }, "should parse aggregate option nesting up to the recursion limit");
         test.throws(function() {
             protobuf.parse(nestedOptionValue(4));
         }, /max depth exceeded/, "should reject excessively nested aggregate options");
+        test.doesNotThrow(function() {
+            protobuf.parse(dottedOptionPath(3));
+        }, "should parse dotted option paths up to the recursion limit");
+        test.throws(function() {
+            protobuf.parse(dottedOptionPath(4));
+        }, /max depth exceeded/, "should reject excessively nested dotted option paths");
+        test.doesNotThrow(function() {
+            protobuf.parse(packagePath(3));
+        }, "should parse package paths up to the recursion limit");
+        test.throws(function() {
+            protobuf.parse(packagePath(4));
+        }, /max depth exceeded/, "should reject excessively nested package paths");
     } finally {
         protobuf.util.recursionLimit = recursionLimit;
+        protobuf.util.nestingLimit = nestingLimit;
     }
 
     test.end();

--- a/tests/comp_textformat.ts
+++ b/tests/comp_textformat.ts
@@ -19,9 +19,7 @@ const type = root.lookupType("Message");
 const message = type.fromText("value: 1");
 const text: string = type.toText(message, { unknowns: true });
 
-textformat.recursionLimit = protobuf.util.recursionLimit;
 textformat.unknownRecursionLimit = 10;
-protobuf.textformat.recursionLimit = textformat.recursionLimit;
 
 if (text.length < 0)
     throw Error("unreachable");


### PR DESCRIPTION
Consolidates depth limit checks across parser, descriptor, JSON and textformat, and introduces `util.nestingLimit` as a second limit aligned with protoc’s `MaxMessageDeclarationNestingDepth`.

Also removes the `util.checkDepth` helper again, given that it is less clear with multiple limits.