### PR TITLE
fix: Preserve explicit enum zero if not the default

### DIFF
--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -120,7 +120,6 @@ module.exports = [
             "no-useless-return": 1,
             "no-useless-assignment": 0,
             "no-void": 1,
-            "no-warning-comments": 1,
             "no-with": 1,
             "radix": 1,
             "vars-on-top": 0,                   // makes code harder to read, not faster

--- a/src/decoder.js
+++ b/src/decoder.js
@@ -156,7 +156,11 @@ function decoder(mtype) {
             ("case %i:{", field.id)
                 ("if(u!==%i)", types.basic[type])
                     ("break");
-            if (type === "string" || type === "bytes") gen
+            if (field.resolvedType instanceof Enum && field.typeDefault !== 0) gen
+                // TODO: Protoc rejects open enums whose first value is not zero.
+                // We should do the same, but for v8 this would be a regression.
+                ("if((v=r.%s())!==%j)", type, field.typeDefault);
+            else if (type === "string" || type === "bytes") gen
                 ("if((v=r.%s()).length)", type);
             else if (types.long[type] !== undefined) gen
                 ("if(typeof(v=r.%s())===\"object\"?v.low||v.high:v!==0)", type);

--- a/tests/api_type.js
+++ b/tests/api_type.js
@@ -264,6 +264,28 @@ tape.test("decode known fields by wire type", function(test) {
     test.end();
 });
 
+// TODO: Protoc rejects open enums whose first value is not zero.
+// We should do the same, but for v8 this would be a regression.
+// Remove this test once we enforce this restriction.
+tape.test("decode implicit enum zero with non-zero default", function(test) {
+    var Message = protobuf.Root.fromJSON({
+        nested: {
+            Op: { values: { UNKNOWN: -1, INSERT: 0 } },
+            Message: {
+                fields: {
+                    op: { type: "Op", id: 4 }
+                }
+            }
+        }
+    }).lookupType("Message");
+
+    test.notOk(Message.fields.op.hasPresence, "enum field should have implicit presence");
+    test.equal(Message.fields.op.typeDefault, -1, "enum field should use the first value as default");
+    test.equal(Message.decode(protobuf.util.newBuffer([0x20, 0x00])).op, 0, "should preserve explicit enum zero");
+
+    test.end();
+});
+
 tape.test("object conversion nesting", function(test) {
     function nestedObject(depth) {
         var object = { value: 42 };


### PR DESCRIPTION
Preserves explicit wire value `0` for implicit enum fields whose schema default is non-zero. This restores 8.x behavior for currently accepted non-conformant schemas, adding a note to revisit in a major release.

Fixes #2247