### PR TITLE
docs: Share JSDoc patch with API docs

### DIFF
--- a/cli/lib/tsd-jsdoc/patch.js
+++ b/cli/lib/tsd-jsdoc/patch.js
@@ -1,0 +1,98 @@
+"use strict";
+
+var typeParserPatched = false;
+var typeLinkerPatched = false;
+var typeScriptTypePattern = /[&;]|\?:|=>|\bkeyof\b|\btypeof\b/;
+
+function normalizeType(type) {
+    return type.replace(/\r?\n|\r/g, "\n");
+}
+
+function patchTypeExpressionParser(dictionary) {
+    var type = require("jsdoc/tag/type");
+    var parse = type.parse,
+        typeTag = dictionary.lookUp("type");
+
+    if (typeTag && !typeTag.protobufjsPatched) {
+        typeTag.onTagText = function onTypeTagText(text) {
+            var openIdx = text.indexOf("{"),
+                closeIdx = text.indexOf("}");
+
+            if (openIdx !== 0 || closeIdx <= openIdx + 1)
+                text = "{" + text + "}";
+
+            return text;
+        };
+        typeTag.protobufjsPatched = true;
+    }
+
+    if (typeParserPatched)
+        return;
+    typeParserPatched = true;
+
+    type.parse = function parseTypeScriptType(tagValue, canHaveName, canHaveType) {
+        try {
+            return parse(tagValue, canHaveName, canHaveType);
+        } catch (e) {
+            if (!canHaveType)
+                throw e;
+
+            var text = String(tagValue || "");
+            var open = text.indexOf("{");
+            if (open < 0)
+                throw e;
+
+            var depth = 0;
+            var close = -1;
+            for (var i = open; i < text.length; ++i) {
+                var ch = text.charAt(i);
+                if (ch === "{")
+                    ++depth;
+                else if (ch === "}" && --depth === 0) {
+                    close = i;
+                    break;
+                }
+            }
+            if (close < 0)
+                throw e;
+
+            var expression = normalizeType(text.substring(open + 1, close)).trim();
+            if (!typeScriptTypePattern.test(expression) && !/^\s*\{/.test(expression))
+                throw e;
+
+            var name = canHaveName ? text.substring(close + 1).trim() : "";
+            return {
+                type: [ expression ],
+                typeExpression: expression,
+                name: name
+            };
+        }
+    };
+}
+
+function patchTypeExpressionLinks() {
+    if (typeLinkerPatched)
+        return;
+    typeLinkerPatched = true;
+
+    var helper = require("jsdoc/util/templateHelper");
+    var linkto = helper.linkto;
+
+    helper.linkto = function linkTypeScriptType(longname, linkText, cssClass, fragmentId) {
+        var stripped = longname ? String(longname).replace(/^<|>$/g, "") : "";
+        if (stripped && typeScriptTypePattern.test(stripped) &&
+            !/^(http|ftp)s?:\/\//.test(stripped) &&
+            /\{@.+\}/.test(stripped) === false &&
+            /^<[\s\S]+>/.test(stripped) === false)
+            return linkText || helper.htmlsafe(longname);
+
+        return linkto.call(this, longname, linkText, cssClass, fragmentId);
+    };
+}
+
+exports.normalizeType = normalizeType;
+
+exports.defineTags = function(dictionary) {
+    patchTypeExpressionParser(dictionary);
+    patchTypeExpressionLinks();
+};

--- a/cli/lib/tsd-jsdoc/plugin.js
+++ b/cli/lib/tsd-jsdoc/plugin.js
@@ -1,75 +1,9 @@
 "use strict";
 
-var typeParserPatched = false;
-
-function normalizeType(type) {
-    return type.replace(/\r?\n|\r/g, "\n");
-}
-
-function patchTypeScriptTypes(dictionary) {
-    var type = require("jsdoc/tag/type");
-    var parse = type.parse,
-        typeTag = dictionary.lookUp("type");
-
-    if (typeTag && !typeTag.protobufjsPatched) {
-        typeTag.onTagText = function onTypeTagText(text) {
-            var openIdx = text.indexOf("{"),
-                closeIdx = text.indexOf("}");
-
-            if (openIdx !== 0 || closeIdx <= openIdx + 1)
-                text = "{" + text + "}";
-
-            return text;
-        };
-        typeTag.protobufjsPatched = true;
-    }
-
-    if (typeParserPatched)
-        return;
-    typeParserPatched = true;
-
-    type.parse = function parseTypeScriptType(tagValue, canHaveName, canHaveType) {
-        try {
-            return parse(tagValue, canHaveName, canHaveType);
-        } catch (e) {
-            if (!canHaveType)
-                throw e;
-
-            var text = String(tagValue || "");
-            var open = text.indexOf("{");
-            if (open < 0)
-                throw e;
-
-            var depth = 0;
-            var close = -1;
-            for (var i = open; i < text.length; ++i) {
-                var ch = text.charAt(i);
-                if (ch === "{")
-                    ++depth;
-                else if (ch === "}" && --depth === 0) {
-                    close = i;
-                    break;
-                }
-            }
-            if (close < 0)
-                throw e;
-
-            var expression = normalizeType(text.substring(open + 1, close)).trim();
-            if (!/[&;]|\?:|=>|\bkeyof\b|\btypeof\b|^\s*\{/.test(expression))
-                throw e;
-
-            var name = canHaveName ? text.substring(close + 1).trim() : "";
-            return {
-                type: [ expression ],
-                typeExpression: expression,
-                name: name
-            };
-        }
-    };
-}
+var patch = require("./patch");
 
 exports.defineTags = function(dictionary) {
-    patchTypeScriptTypes(dictionary);
+    patch.defineTags(dictionary);
 
     dictionary.defineTag("template", {
         mustHaveValue: true,
@@ -85,7 +19,7 @@ exports.defineTags = function(dictionary) {
         canHaveType: false,
         canHaveName: false,
         onTagged: function(doclet, tag) {
-            doclet.tsType = normalizeType(tag.text);
+            doclet.tsType = patch.normalizeType(tag.text);
         }
     });
 };

--- a/config/jsdoc.json
+++ b/config/jsdoc.json
@@ -11,6 +11,7 @@
         "excludePattern": "(^|\\/|\\\\)_"
     },
     "plugins": [
+        "./cli/lib/tsd-jsdoc/patch",
         "./node_modules/jsdoc/plugins/markdown"
     ],
     "templates": {

--- a/src/util/pool.js
+++ b/src/util/pool.js
@@ -16,7 +16,7 @@ module.exports = pool;
  * @param {number} start Start offset
  * @param {number} end End offset
  * @returns {Uint8Array} Buffer slice
- * @this {Uint8Array}
+ * @this Uint8Array
  */
 
 /**


### PR DESCRIPTION
Extracts JSDoc patching into a shared helper so both pbts and API docs use it, and updates the jsdoc-template submodule. This unblocks API docs publishing in CI, which tripped over the TS-aware changes in #2244.