### PR TITLE
fix: Backport bundler-safe optional module lookups

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -5,7 +5,7 @@
   "lib/base64": "1.1.2",
   "lib/codegen": "2.0.5",
   "lib/eventemitter": "1.1.0",
-  "lib/fetch": "1.1.1",
+  "lib/fetch": "1.1.0",
   "lib/float": "1.0.2",
   "lib/inquire": "1.1.1",
   "lib/path": "1.1.2",

--- a/index.d.ts
+++ b/index.d.ts
@@ -2484,6 +2484,7 @@ export namespace util {
      * Requires a module only if available.
      * @param moduleName Module to require
      * @returns Required module if available and not empty, otherwise `null`
+     * @deprecated Legacy optional require helper. Will be removed in a future release.
      */
     function inquire(moduleName: string): object;
 

--- a/lib/fetch/index.js
+++ b/lib/fetch/index.js
@@ -2,9 +2,7 @@
 module.exports = fetch;
 
 var asPromise = require("@protobufjs/aspromise"),
-    inquire   = require("@protobufjs/inquire");
-
-var fs = inquire("fs");
+    fs        = require("./util/fs");
 
 /**
  * Node-style callback as used by {@link util.fetch}.

--- a/lib/fetch/package.json
+++ b/lib/fetch/package.json
@@ -1,19 +1,21 @@
 {
   "name": "@protobufjs/fetch",
   "description": "Fetches the contents of a file accross node and browsers.",
-  "version": "1.1.1",
+  "version": "1.1.0",
   "author": "Daniel Wirtz <dcode+protobufjs@dcode.io>",
   "repository": {
     "type": "git",
     "url": "https://github.com/dcodeIO/protobuf.js.git"
   },
   "dependencies": {
-    "@protobufjs/aspromise": "^1.1.1",
-    "@protobufjs/inquire": "^1.1.0"
+    "@protobufjs/aspromise": "^1.1.1"
   },
   "license": "BSD-3-Clause",
   "main": "index.js",
   "types": "index.d.ts",
+  "browser": {
+    "fs": false
+  },
   "devDependencies": {
     "istanbul": "^0.4.5",
     "tape": "^5.0.0"

--- a/lib/fetch/util/fs.js
+++ b/lib/fetch/util/fs.js
@@ -1,0 +1,11 @@
+"use strict";
+
+var fs = null;
+try {
+    fs = require(/* webpackIgnore: true */ "fs");
+    if (!fs || !fs.readFile || !fs.readFileSync)
+        fs = null;
+} catch (e) {
+    // `fs` is unavailable in browsers and browser-like bundles.
+}
+module.exports = fs;

--- a/lib/inquire/index.d.ts
+++ b/lib/inquire/index.d.ts
@@ -5,5 +5,6 @@ export = inquire;
  * @memberof util
  * @param {string} moduleName Module to require
  * @returns {?Object} Required module if available and not empty, otherwise `null`
+ * @deprecated Legacy optional require helper. Will be removed in a future release.
  */
 declare function inquire(moduleName: string): object;

--- a/lib/inquire/index.js
+++ b/lib/inquire/index.js
@@ -6,6 +6,7 @@ module.exports = inquire;
  * @memberof util
  * @param {string} moduleName Module to require
  * @returns {?Object} Required module if available and not empty, otherwise `null`
+ * @deprecated Legacy optional require helper. Will be removed in a future release.
  */
 function inquire(moduleName) {
   try {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,9 @@
   ],
   "main": "index.js",
   "types": "index.d.ts",
+  "browser": {
+    "fs": false
+  },
   "publishConfig": {
     "tag": "latest-7"
   },

--- a/src/util.js
+++ b/src/util.js
@@ -23,7 +23,7 @@ var reservedRe = util.patterns.reservedRe,
  * Node's fs module if available.
  * @type {Object.<string,*>}
  */
-util.fs = util.inquire("fs");
+util.fs = require("./util/fs");
 
 /**
  * Checks a recursion depth.

--- a/src/util/fs.js
+++ b/src/util/fs.js
@@ -1,0 +1,11 @@
+"use strict";
+
+var fs = null;
+try {
+    fs = require(/* webpackIgnore: true */ "fs");
+    if (!fs || !fs.readFile || !fs.readFileSync)
+        fs = null;
+} catch (e) {
+    // `fs` is unavailable in browsers and browser-like bundles.
+}
+module.exports = fs;

--- a/src/util/minimal.js
+++ b/src/util/minimal.js
@@ -125,7 +125,7 @@ util.isSet = function isSet(obj, prop) {
  */
 util.Buffer = (function() {
     try {
-        var Buffer = util.inquire("buffer").Buffer;
+        var Buffer = util.global.Buffer;
         // refuse to use non-node buffers if not explicitly assigned (perf reasons):
         return Buffer.prototype.utf8Write ? Buffer : /* istanbul ignore next */ null;
     } catch (e) {
@@ -179,7 +179,15 @@ util.Array = typeof Uint8Array !== "undefined" ? Uint8Array /* istanbul ignore n
  */
 util.Long = /* istanbul ignore next */ util.global.dcodeIO && /* istanbul ignore next */ util.global.dcodeIO.Long
          || /* istanbul ignore next */ util.global.Long
-         || util.inquire("long");
+         || (function() {
+                try {
+                    var Long = require("long");
+                    return Long && Long.isLong ? Long : null;
+                } catch (e) {
+                    /* istanbul ignore next */
+                    return null;
+                }
+            })();
 
 /**
  * Regular expression used to verify 2 bit (`bool`) map keys.


### PR DESCRIPTION
Backports #2237 to the 7.x line as suggested in #2214.

Also updates the fetch micromodule that depends on inquire to obtain fs. It is currently published at `1.1.0`, but the 7.x branch had an unreleased version bump to `1.1.1`, so this PR reverts that bookkeeping and lets release automation pick up the changes as the actual `1.1.1` release.

Note that fetch needs to be published first, and the release-please PR for the main package amended, bumping the fetch dependency version.