### PR TITLE
feat: Support BigInt conversions

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Common `ConversionOptions` are:
 
 | Option | Effect |
 |--------|--------|
+| `longs: BigInt` | Converts 64-bit values to bigint values |
 | `longs: String` | Converts 64-bit values to decimal strings |
 | `longs: Number` | Converts 64-bit values to JS numbers (may lose precision) |
 | `enums: String` | Converts enum values to names |

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -278,9 +278,9 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "long": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
-      "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q==",
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
       "dev": true
     },
     "lru-cache": {
@@ -376,7 +376,7 @@
         "@protobufjs/path": "^1.1.2",
         "@protobufjs/pool": "^1.1.0",
         "@protobufjs/utf8": "^1.1.0",
-        "long": "^5.0.0"
+        "long": "^5.3.2"
       }
     },
     "requizzle": {

--- a/index.d.ts
+++ b/index.d.ts
@@ -1851,7 +1851,7 @@ export interface IConversionOptions {
 
     /**
      * Long conversion type.
-     * Valid values are `String` and `Number` (the global types).
+     * Valid values are `BigInt`, `String` and `Number` (the global types).
      * Defaults to copy the present value, which is a possibly unsafe number without and a {@link Long} with a long library.
      */
     longs?: Function;

--- a/package-lock.json
+++ b/package-lock.json
@@ -4274,9 +4274,9 @@
       }
     },
     "long": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/long/-/long-5.2.0.tgz",
-      "integrity": "sha512-9RTUNjK60eJbx3uz+TEGF7fUr29ZDxR5QzXcyDpeSfeH28S9ycINflOgOlppit5U+4kNTe83KQnMEerw7GmE8w=="
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA=="
     },
     "lru-queue": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "make": "npm run lint:sources && npm run build && npm run lint:types && node ./scripts/gentests.js && npm test"
   },
   "dependencies": {
-    "long": "^5.0.0"
+    "long": "^5.3.2"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.0",

--- a/src/converter.js
+++ b/src/converter.js
@@ -209,7 +209,9 @@ function genValuePartial_toObject(gen, field, fieldIndex, dstProp, srcProp) {
             case "sint64":
             case "fixed64":
             case "sfixed64": gen
-            ("if(typeof m%s===\"number\")", srcProp)
+            ("if(typeof BigInt!==\"undefined\"&&o.longs===BigInt)")
+                ("d%s=typeof m%s===\"number\"?BigInt(m%s):util.Long.fromBits(m%s.low>>>0,m%s.high>>>0,%j).toBigInt()", dstProp, srcProp, srcProp, srcProp, srcProp, isUnsigned)
+            ("else if(typeof m%s===\"number\")", srcProp)
                 ("d%s=o.longs===String?String(m%s):m%s", dstProp, srcProp, srcProp)
             ("else") // Long-like
                 ("d%s=o.longs===String?util.Long.prototype.toString.call(m%s):o.longs===Number?new util.LongBits(m%s.low>>>0,m%s.high>>>0).toNumber(%s):m%s", dstProp, srcProp, srcProp, srcProp, isUnsigned ? "true": "", srcProp);
@@ -277,9 +279,9 @@ converter.toObject = function toObject(mtype) {
             else if (field.long) gen
         ("if(util.Long){")
             ("var n=new util.Long(%i,%i,%j)", field.typeDefault.low, field.typeDefault.high, field.typeDefault.unsigned)
-            ("d%s=o.longs===String?n.toString():o.longs===Number?n.toNumber():n", prop)
+            ("d%s=o.longs===String?n.toString():o.longs===Number?n.toNumber():typeof BigInt!==\"undefined\"&&o.longs===BigInt?n.toBigInt():n", prop)
         ("}else")
-            ("d%s=o.longs===String?%j:%i", prop, field.typeDefault.toString(), field.typeDefault.toNumber());
+            ("d%s=o.longs===String?%j:typeof BigInt!==\"undefined\"&&o.longs===BigInt?BigInt(%j):%i", prop, field.typeDefault.toString(), field.typeDefault.toString(), field.typeDefault.toNumber());
             else if (field.bytes) {
                 var arrayDefault = Array.prototype.slice.call(field.typeDefault);
                 gen

--- a/src/type.js
+++ b/src/type.js
@@ -585,7 +585,7 @@ Type.prototype.fromObject = function fromObject(object) { // eslint-disable-line
  * Conversion options as used by {@link Type#toObject} and {@link Message.toObject}.
  * @interface IConversionOptions
  * @property {Function} [longs] Long conversion type.
- * Valid values are `String` and `Number` (the global types).
+ * Valid values are `BigInt`, `String` and `Number` (the global types).
  * Defaults to copy the present value, which is a possibly unsafe number without and a {@link Long} with a long library.
  * @property {Function} [enums] Enum value conversion type.
  * Only valid value is `String` (the global type).

--- a/tests/api_converters.js
+++ b/tests/api_converters.js
@@ -12,7 +12,7 @@ tape.test("converters", function(test) {
 
         test.test(test.name + " - Message#toObject", function(test) {
 
-            test.plan(7);
+            test.plan(8);
 
             test.test(test.name + " - called with defaults = true", function(test) {
                 var obj = Message.toObject(Message.create(), { defaults: true });
@@ -30,6 +30,14 @@ tape.test("converters", function(test) {
                 test.same(obj.enumRepeated, [], "should set enumRepeated");
 
                 test.same(obj.int64Map, {}, "should set int64Map");
+
+                test.end();
+            });
+
+            test.test(test.name + " - called with defaults = true and longs = BigInt", function(test) {
+                var obj = Message.toObject(Message.create(), { defaults: true, longs: BigInt });
+
+                test.equal(obj.uint64Val, 0n, "should set uint64Val");
 
                 test.end();
             });
@@ -98,28 +106,35 @@ tape.test("converters", function(test) {
                 var buf = protobuf.util.newBuffer(3);
                 buf[0] = buf[1] = buf[2] = 49; // "111"
                 var msg = Message.create({
-                    uint64Val: protobuf.util.Long.fromNumber(1),
+                    // This number was chosen to be > 2^63 and < 2^64.
+                    uint64Val: protobuf.util.Long.fromString("11000000000000000001", true),
                     uint64Repeated: [2, 3],
                     bytesVal: buf,
                     bytesRepeated: [buf, buf],
                     enumVal: 2,
                     enumRepeated: [1, 100, 2],
                     int64Map: {
-                        a: protobuf.util.Long.fromNumber(2),
-                        b: protobuf.util.Long.fromNumber(3)
+                        // These numbers were chosen to be < Number.MIN_SAFE_INTEGER.
+                        a: protobuf.util.Long.fromString("-200000000000000001"),
+                        b: protobuf.util.Long.fromString("-300000000000000001")
                     }
                 });
 
                 var msgLongsToNumber = Message.toObject(msg, { longs: Number }),
-                    msgLongsToString = Message.toObject(msg, { longs: String });
+                    msgLongsToString = Message.toObject(msg, { longs: String }),
+                    msgLongsToBigInt = Message.toObject(msg, { longs: BigInt });
 
                 test.same(Message.ctor.toObject(msg, { longs: Number}), msgLongsToNumber, "should convert the same using the static and the instance method");
                 test.same(Message.ctor.toObject(msg, { longs: String}), msgLongsToString, "should convert the same using the static and the instance method");
+                test.same(Message.ctor.toObject(msg, { longs: BigInt}), msgLongsToBigInt, "should convert the same using the static and the instance method");
 
-                test.equal(msgLongsToNumber.uint64Val, 1, "longs to numbers");
-                test.equal(msgLongsToString.uint64Val, "1", "longs to strings");
-                test.same(msgLongsToNumber.int64Map, { a: 2, b: 3}, "long map values to numbers");
-                test.same(msgLongsToString.int64Map, { a: "2", b: "3"}, "long map values to strings");
+                test.equal(msgLongsToNumber.uint64Val, 11000000000000000000, "longs to numbers");
+                test.equal(msgLongsToString.uint64Val, "11000000000000000001", "longs to strings");
+                test.equal(msgLongsToBigInt.uint64Val, 11000000000000000001n, "longs to bigints");
+                test.same(msgLongsToBigInt.uint64Repeated, [2n, 3n], "long arrays to bigints");
+                test.same(msgLongsToNumber.int64Map, { a: -200000000000000000, b: -300000000000000000}, "long map values to numbers");
+                test.same(msgLongsToString.int64Map, { a: "-200000000000000001", b: "-300000000000000001"}, "long map values to strings");
+                test.same(msgLongsToBigInt.int64Map, { a: -200000000000000001n, b: -300000000000000001n}, "long map values to bigints");
 
                 test.equal(Object.prototype.toString.call(Message.toObject(msg, { bytes: Array }).bytesVal), "[object Array]", "bytes to arrays");
                 test.equal(Message.toObject(msg, { bytes: String }).bytesVal, "MTEx", "bytes to base64 strings");
@@ -203,6 +218,25 @@ tape.test("converters", function(test) {
             test.equal(msg.enumVal, 1, "should set enumVal from a string");
             test.same(msg.enumRepeated, [ 2, 2, 100 ], "should set enumRepeated from a number and a string and preserve unknown value");
             test.same(msg.int64Map, { a: { low: 2, high: 0, unsigned: false }, b: { low: 3, high: 0, unsigned: false } }, "should set int64Map from a number and a string");
+
+            var bigMsg = Message.fromObject({
+                uint64Val: 11000000000000000001n,
+                uint64Repeated: [2n, 3n],
+                int64Map: {
+                    a: -200000000000000001n,
+                    b: -300000000000000001n
+                }
+            });
+
+            test.same(bigMsg.uint64Val, protobuf.util.Long.fromString("11000000000000000001", true), "should set uint64Val from a bigint");
+            test.same(bigMsg.uint64Repeated, [
+                protobuf.util.Long.fromString("2", true),
+                protobuf.util.Long.fromString("3", true)
+            ], "should set uint64Repeated from bigints");
+            test.same(bigMsg.int64Map, {
+                a: protobuf.util.Long.fromString("-200000000000000001"),
+                b: protobuf.util.Long.fromString("-300000000000000001")
+            }, "should set int64Map from bigints");
 
             test.end();
         });

--- a/tests/data/convert.js
+++ b/tests/data/convert.js
@@ -297,7 +297,7 @@ $root.Message = (function() {
             case 7: {
                     if (wireType !== 0)
                         break;
-                    if (value = reader.int32())
+                    if ((value = reader.int32()) !== 1)
                         message.enumVal = value;
                     else
                         delete message.enumVal;
@@ -600,9 +600,9 @@ $root.Message = (function() {
             object.stringVal = "";
             if ($util.Long) {
                 var long = new $util.Long(0, 0, true);
-                object.uint64Val = options.longs === String ? long.toString() : options.longs === Number ? long.toNumber() : long;
+                object.uint64Val = options.longs === String ? long.toString() : options.longs === Number ? long.toNumber() : typeof BigInt !== "undefined" && options.longs === BigInt ? long.toBigInt() : long;
             } else
-                object.uint64Val = options.longs === String ? "0" : 0;
+                object.uint64Val = options.longs === String ? "0" : typeof BigInt !== "undefined" && options.longs === BigInt ? BigInt("0") : 0;
             if (options.bytes === String)
                 object.bytesVal = "";
             else {
@@ -620,14 +620,18 @@ $root.Message = (function() {
                 object.stringRepeated[j] = message.stringRepeated[j];
         }
         if (message.uint64Val != null && message.hasOwnProperty("uint64Val"))
-            if (typeof message.uint64Val === "number")
+            if (typeof BigInt !== "undefined" && options.longs === BigInt)
+                object.uint64Val = typeof message.uint64Val === "number" ? BigInt(message.uint64Val) : $util.Long.fromBits(message.uint64Val.low >>> 0, message.uint64Val.high >>> 0, true).toBigInt();
+            else if (typeof message.uint64Val === "number")
                 object.uint64Val = options.longs === String ? String(message.uint64Val) : message.uint64Val;
             else
                 object.uint64Val = options.longs === String ? $util.Long.prototype.toString.call(message.uint64Val) : options.longs === Number ? new $util.LongBits(message.uint64Val.low >>> 0, message.uint64Val.high >>> 0).toNumber(true) : message.uint64Val;
         if (message.uint64Repeated && message.uint64Repeated.length) {
             object.uint64Repeated = Array(message.uint64Repeated.length);
             for (var j = 0; j < message.uint64Repeated.length; ++j)
-                if (typeof message.uint64Repeated[j] === "number")
+                if (typeof BigInt !== "undefined" && options.longs === BigInt)
+                    object.uint64Repeated[j] = typeof message.uint64Repeated[j] === "number" ? BigInt(message.uint64Repeated[j]) : $util.Long.fromBits(message.uint64Repeated[j].low >>> 0, message.uint64Repeated[j].high >>> 0, true).toBigInt();
+                else if (typeof message.uint64Repeated[j] === "number")
                     object.uint64Repeated[j] = options.longs === String ? String(message.uint64Repeated[j]) : message.uint64Repeated[j];
                 else
                     object.uint64Repeated[j] = options.longs === String ? $util.Long.prototype.toString.call(message.uint64Repeated[j]) : options.longs === Number ? new $util.LongBits(message.uint64Repeated[j].low >>> 0, message.uint64Repeated[j].high >>> 0).toNumber(true) : message.uint64Repeated[j];
@@ -652,7 +656,9 @@ $root.Message = (function() {
             for (var j = 0; j < keys2.length; ++j) {
                 if (keys2[j] === "__proto__")
                     $util.makeProp(object.int64Map, keys2[j]);
-                if (typeof message.int64Map[keys2[j]] === "number")
+                if (typeof BigInt !== "undefined" && options.longs === BigInt)
+                    object.int64Map[keys2[j]] = typeof message.int64Map[keys2[j]] === "number" ? BigInt(message.int64Map[keys2[j]]) : $util.Long.fromBits(message.int64Map[keys2[j]].low >>> 0, message.int64Map[keys2[j]].high >>> 0, false).toBigInt();
+                else if (typeof message.int64Map[keys2[j]] === "number")
                     object.int64Map[keys2[j]] = options.longs === String ? String(message.int64Map[keys2[j]]) : message.int64Map[keys2[j]];
                 else
                     object.int64Map[keys2[j]] = options.longs === String ? $util.Long.prototype.toString.call(message.int64Map[keys2[j]]) : options.longs === Number ? new $util.LongBits(message.int64Map[keys2[j]].low >>> 0, message.int64Map[keys2[j]].high >>> 0).toNumber() : message.int64Map[keys2[j]];

--- a/tests/data/mapbox/vector_tile.js
+++ b/tests/data/mapbox/vector_tile.js
@@ -666,19 +666,19 @@ $root.vector_tile = (function() {
                     object.doubleValue = 0;
                     if ($util.Long) {
                         var long = new $util.Long(0, 0, false);
-                        object.intValue = options.longs === String ? long.toString() : options.longs === Number ? long.toNumber() : long;
+                        object.intValue = options.longs === String ? long.toString() : options.longs === Number ? long.toNumber() : typeof BigInt !== "undefined" && options.longs === BigInt ? long.toBigInt() : long;
                     } else
-                        object.intValue = options.longs === String ? "0" : 0;
+                        object.intValue = options.longs === String ? "0" : typeof BigInt !== "undefined" && options.longs === BigInt ? BigInt("0") : 0;
                     if ($util.Long) {
                         var long = new $util.Long(0, 0, true);
-                        object.uintValue = options.longs === String ? long.toString() : options.longs === Number ? long.toNumber() : long;
+                        object.uintValue = options.longs === String ? long.toString() : options.longs === Number ? long.toNumber() : typeof BigInt !== "undefined" && options.longs === BigInt ? long.toBigInt() : long;
                     } else
-                        object.uintValue = options.longs === String ? "0" : 0;
+                        object.uintValue = options.longs === String ? "0" : typeof BigInt !== "undefined" && options.longs === BigInt ? BigInt("0") : 0;
                     if ($util.Long) {
                         var long = new $util.Long(0, 0, false);
-                        object.sintValue = options.longs === String ? long.toString() : options.longs === Number ? long.toNumber() : long;
+                        object.sintValue = options.longs === String ? long.toString() : options.longs === Number ? long.toNumber() : typeof BigInt !== "undefined" && options.longs === BigInt ? long.toBigInt() : long;
                     } else
-                        object.sintValue = options.longs === String ? "0" : 0;
+                        object.sintValue = options.longs === String ? "0" : typeof BigInt !== "undefined" && options.longs === BigInt ? BigInt("0") : 0;
                     object.boolValue = false;
                 }
                 if (message.stringValue != null && message.hasOwnProperty("stringValue"))
@@ -688,17 +688,23 @@ $root.vector_tile = (function() {
                 if (message.doubleValue != null && message.hasOwnProperty("doubleValue"))
                     object.doubleValue = options.json && !isFinite(message.doubleValue) ? String(message.doubleValue) : message.doubleValue;
                 if (message.intValue != null && message.hasOwnProperty("intValue"))
-                    if (typeof message.intValue === "number")
+                    if (typeof BigInt !== "undefined" && options.longs === BigInt)
+                        object.intValue = typeof message.intValue === "number" ? BigInt(message.intValue) : $util.Long.fromBits(message.intValue.low >>> 0, message.intValue.high >>> 0, false).toBigInt();
+                    else if (typeof message.intValue === "number")
                         object.intValue = options.longs === String ? String(message.intValue) : message.intValue;
                     else
                         object.intValue = options.longs === String ? $util.Long.prototype.toString.call(message.intValue) : options.longs === Number ? new $util.LongBits(message.intValue.low >>> 0, message.intValue.high >>> 0).toNumber() : message.intValue;
                 if (message.uintValue != null && message.hasOwnProperty("uintValue"))
-                    if (typeof message.uintValue === "number")
+                    if (typeof BigInt !== "undefined" && options.longs === BigInt)
+                        object.uintValue = typeof message.uintValue === "number" ? BigInt(message.uintValue) : $util.Long.fromBits(message.uintValue.low >>> 0, message.uintValue.high >>> 0, true).toBigInt();
+                    else if (typeof message.uintValue === "number")
                         object.uintValue = options.longs === String ? String(message.uintValue) : message.uintValue;
                     else
                         object.uintValue = options.longs === String ? $util.Long.prototype.toString.call(message.uintValue) : options.longs === Number ? new $util.LongBits(message.uintValue.low >>> 0, message.uintValue.high >>> 0).toNumber(true) : message.uintValue;
                 if (message.sintValue != null && message.hasOwnProperty("sintValue"))
-                    if (typeof message.sintValue === "number")
+                    if (typeof BigInt !== "undefined" && options.longs === BigInt)
+                        object.sintValue = typeof message.sintValue === "number" ? BigInt(message.sintValue) : $util.Long.fromBits(message.sintValue.low >>> 0, message.sintValue.high >>> 0, false).toBigInt();
+                    else if (typeof message.sintValue === "number")
                         object.sintValue = options.longs === String ? String(message.sintValue) : message.sintValue;
                     else
                         object.sintValue = options.longs === String ? $util.Long.prototype.toString.call(message.sintValue) : options.longs === Number ? new $util.LongBits(message.sintValue.low >>> 0, message.sintValue.high >>> 0).toNumber() : message.sintValue;
@@ -1101,13 +1107,15 @@ $root.vector_tile = (function() {
                 if (options.defaults) {
                     if ($util.Long) {
                         var long = new $util.Long(0, 0, true);
-                        object.id = options.longs === String ? long.toString() : options.longs === Number ? long.toNumber() : long;
+                        object.id = options.longs === String ? long.toString() : options.longs === Number ? long.toNumber() : typeof BigInt !== "undefined" && options.longs === BigInt ? long.toBigInt() : long;
                     } else
-                        object.id = options.longs === String ? "0" : 0;
+                        object.id = options.longs === String ? "0" : typeof BigInt !== "undefined" && options.longs === BigInt ? BigInt("0") : 0;
                     object.type = options.enums === String ? "UNKNOWN" : 0;
                 }
                 if (message.id != null && message.hasOwnProperty("id"))
-                    if (typeof message.id === "number")
+                    if (typeof BigInt !== "undefined" && options.longs === BigInt)
+                        object.id = typeof message.id === "number" ? BigInt(message.id) : $util.Long.fromBits(message.id.low >>> 0, message.id.high >>> 0, true).toBigInt();
+                    else if (typeof message.id === "number")
                         object.id = options.longs === String ? String(message.id) : message.id;
                     else
                         object.id = options.longs === String ? $util.Long.prototype.toString.call(message.id) : options.longs === Number ? new $util.LongBits(message.id.low >>> 0, message.id.high >>> 0).toNumber(true) : message.id;

--- a/tests/data/test.js
+++ b/tests/data/test.js
@@ -4426,9 +4426,9 @@ $root.jspb = (function() {
                     object.boolField = true;
                     if ($util.Long) {
                         var long = new $util.Long(11, 0, false);
-                        object.intField = options.longs === String ? long.toString() : options.longs === Number ? long.toNumber() : long;
+                        object.intField = options.longs === String ? long.toString() : options.longs === Number ? long.toNumber() : typeof BigInt !== "undefined" && options.longs === BigInt ? long.toBigInt() : long;
                     } else
-                        object.intField = options.longs === String ? "11" : 11;
+                        object.intField = options.longs === String ? "11" : typeof BigInt !== "undefined" && options.longs === BigInt ? BigInt("11") : 11;
                     object.enumField = options.enums === String ? "E1" : 13;
                     object.emptyField = "";
                     if (options.bytes === String)
@@ -4448,7 +4448,9 @@ $root.jspb = (function() {
                 if (message.boolField != null && message.hasOwnProperty("boolField"))
                     object.boolField = message.boolField;
                 if (message.intField != null && message.hasOwnProperty("intField"))
-                    if (typeof message.intField === "number")
+                    if (typeof BigInt !== "undefined" && options.longs === BigInt)
+                        object.intField = typeof message.intField === "number" ? BigInt(message.intField) : $util.Long.fromBits(message.intField.low >>> 0, message.intField.high >>> 0, false).toBigInt();
+                    else if (typeof message.intField === "number")
                         object.intField = options.longs === String ? String(message.intField) : message.intField;
                     else
                         object.intField = options.longs === String ? $util.Long.prototype.toString.call(message.intField) : options.longs === Number ? new $util.LongBits(message.intField.low >>> 0, message.intField.high >>> 0).toNumber() : message.intField;
@@ -10235,7 +10237,9 @@ $root.jspb = (function() {
                     for (var j = 0; j < keys2.length; ++j) {
                         if (keys2[j] === "__proto__")
                             $util.makeProp(object.mapStringInt64, keys2[j]);
-                        if (typeof message.mapStringInt64[keys2[j]] === "number")
+                        if (typeof BigInt !== "undefined" && options.longs === BigInt)
+                            object.mapStringInt64[keys2[j]] = typeof message.mapStringInt64[keys2[j]] === "number" ? BigInt(message.mapStringInt64[keys2[j]]) : $util.Long.fromBits(message.mapStringInt64[keys2[j]].low >>> 0, message.mapStringInt64[keys2[j]].high >>> 0, false).toBigInt();
+                        else if (typeof message.mapStringInt64[keys2[j]] === "number")
                             object.mapStringInt64[keys2[j]] = options.longs === String ? String(message.mapStringInt64[keys2[j]]) : message.mapStringInt64[keys2[j]];
                         else
                             object.mapStringInt64[keys2[j]] = options.longs === String ? $util.Long.prototype.toString.call(message.mapStringInt64[keys2[j]]) : options.longs === Number ? new $util.LongBits(message.mapStringInt64[keys2[j]].low >>> 0, message.mapStringInt64[keys2[j]].high >>> 0).toNumber() : message.mapStringInt64[keys2[j]];
@@ -22208,14 +22212,14 @@ $root.google = (function() {
                     object.identifierValue = "";
                     if ($util.Long) {
                         var long = new $util.Long(0, 0, true);
-                        object.positiveIntValue = options.longs === String ? long.toString() : options.longs === Number ? long.toNumber() : long;
+                        object.positiveIntValue = options.longs === String ? long.toString() : options.longs === Number ? long.toNumber() : typeof BigInt !== "undefined" && options.longs === BigInt ? long.toBigInt() : long;
                     } else
-                        object.positiveIntValue = options.longs === String ? "0" : 0;
+                        object.positiveIntValue = options.longs === String ? "0" : typeof BigInt !== "undefined" && options.longs === BigInt ? BigInt("0") : 0;
                     if ($util.Long) {
                         var long = new $util.Long(0, 0, false);
-                        object.negativeIntValue = options.longs === String ? long.toString() : options.longs === Number ? long.toNumber() : long;
+                        object.negativeIntValue = options.longs === String ? long.toString() : options.longs === Number ? long.toNumber() : typeof BigInt !== "undefined" && options.longs === BigInt ? long.toBigInt() : long;
                     } else
-                        object.negativeIntValue = options.longs === String ? "0" : 0;
+                        object.negativeIntValue = options.longs === String ? "0" : typeof BigInt !== "undefined" && options.longs === BigInt ? BigInt("0") : 0;
                     object.doubleValue = 0;
                     if (options.bytes === String)
                         object.stringValue = "";
@@ -22234,12 +22238,16 @@ $root.google = (function() {
                 if (message.identifierValue != null && message.hasOwnProperty("identifierValue"))
                     object.identifierValue = message.identifierValue;
                 if (message.positiveIntValue != null && message.hasOwnProperty("positiveIntValue"))
-                    if (typeof message.positiveIntValue === "number")
+                    if (typeof BigInt !== "undefined" && options.longs === BigInt)
+                        object.positiveIntValue = typeof message.positiveIntValue === "number" ? BigInt(message.positiveIntValue) : $util.Long.fromBits(message.positiveIntValue.low >>> 0, message.positiveIntValue.high >>> 0, true).toBigInt();
+                    else if (typeof message.positiveIntValue === "number")
                         object.positiveIntValue = options.longs === String ? String(message.positiveIntValue) : message.positiveIntValue;
                     else
                         object.positiveIntValue = options.longs === String ? $util.Long.prototype.toString.call(message.positiveIntValue) : options.longs === Number ? new $util.LongBits(message.positiveIntValue.low >>> 0, message.positiveIntValue.high >>> 0).toNumber(true) : message.positiveIntValue;
                 if (message.negativeIntValue != null && message.hasOwnProperty("negativeIntValue"))
-                    if (typeof message.negativeIntValue === "number")
+                    if (typeof BigInt !== "undefined" && options.longs === BigInt)
+                        object.negativeIntValue = typeof message.negativeIntValue === "number" ? BigInt(message.negativeIntValue) : $util.Long.fromBits(message.negativeIntValue.low >>> 0, message.negativeIntValue.high >>> 0, false).toBigInt();
+                    else if (typeof message.negativeIntValue === "number")
                         object.negativeIntValue = options.longs === String ? String(message.negativeIntValue) : message.negativeIntValue;
                     else
                         object.negativeIntValue = options.longs === String ? $util.Long.prototype.toString.call(message.negativeIntValue) : options.longs === Number ? new $util.LongBits(message.negativeIntValue.low >>> 0, message.negativeIntValue.high >>> 0).toNumber() : message.negativeIntValue;


### PR DESCRIPTION
With Long.js nowadays supporting BigInt construction and conversion, this upgrades Long.js and wires `{ longs: BigInt }` into conversion options. Note that for 8.x this affects `fromObject` and `toObject` conversions, whereas switching the runtime representation to BigInt is scheduled for 9.x.

Supersedes #1908
Related: #1151, grpc/grpc-node#3047