### PR TITLE
fix: Add no-mixed-operators eslint disable

### DIFF
--- a/cli/pbjs.js
+++ b/cli/pbjs.js
@@ -15,6 +15,7 @@ var lintDefault = "eslint-disable " + [
     "id-length",
     "no-control-regex",
     "no-magic-numbers",
+    "no-mixed-operators",
     "no-prototype-builtins",
     "no-redeclare",
     "no-shadow",


### PR DESCRIPTION
Fixes #1632
Supersedes #1633