### PR TITLE
fix: Decode omitted long map values as Long

### DIFF
--- a/src/decoder.js
+++ b/src/decoder.js
@@ -63,7 +63,9 @@ function decoder(mtype) {
             else gen
                 ("k=null");
 
-            if (types.defaults[type] !== undefined) gen
+            if (types.long[type] !== undefined) gen
+                ("v=util.Long?util.Long.fromNumber(0,%j):0", type === "uint64" || type === "fixed64");
+            else if (types.defaults[type] !== undefined) gen
                 ("v=%j", types.defaults[type]);
             else gen
                 ("v=null");

--- a/tests/comp_maps.js
+++ b/tests/comp_maps.js
@@ -185,6 +185,42 @@ tape.test("maps", function(test) {
         test.end();
     });
 
+    test.test(test.name + " - omitted long values", function(test) {
+
+        var fields = {},
+            bytes = [],
+            cases = [
+                [ "ints", "int64", protobuf.util.Long.ZERO ],
+                [ "uints", "uint64", protobuf.util.Long.UZERO ],
+                [ "sints", "sint64", protobuf.util.Long.ZERO ],
+                [ "fixeds", "fixed64", protobuf.util.Long.UZERO ],
+                [ "sfixeds", "sfixed64", protobuf.util.Long.ZERO ]
+            ];
+
+        cases.forEach(function(testCase, index) {
+            var id = index + 1;
+            fields[testCase[0]] = {
+                keyType: "int32",
+                type: testCase[1],
+                id: id
+            };
+            bytes.push((id << 3) | 2, 2, 8, id);
+        });
+
+        var MapMessage = protobuf.Root.fromJSON({
+            nested: {
+                MapMessage: { fields: fields }
+            }
+        }).lookup("MapMessage");
+        var dec = MapMessage.decode(Uint8Array.from(bytes));
+
+        cases.forEach(function(testCase, index) {
+            test.ok(testCase[2].equals(dec[testCase[0]][index + 1]), "should decode omitted " + testCase[1] + " values as zero");
+        });
+
+        test.end();
+    });
+
     test.test(test.name + " - scalar key roundtrip", function(test) {
         var mapRoot = protobuf.Root.fromJSON({
             nested: {


### PR DESCRIPTION
Supersedes #2006