### PR TITLE
chore: Link CLI peer dependency in releases

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -20,7 +20,7 @@
     "protoc-gen-pbjs": "bin/protoc-gen-pbjs"
   },
   "peerDependencies": {
-    "protobufjs": ">=8.4.0 <9"
+    "protobufjs": "^8.4.0"
   },
   "dependencies": {
     "chalk": "^4.0.0",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,9 +1,22 @@
 {
   "bootstrap-sha": "6fc37d9ea3502cdc08ef988494c041aacd0f7e7f",
+  "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "packages": {
-    "cli": {},
+    "cli": {
+      "release-type": "node",
+      "package-name": "protobufjs-cli"
+    },
     ".": {
+      "release-type": "node",
+      "package-name": "protobufjs",
       "exclude-paths": ["cli"]
     }
-  }
+  },
+  "plugins": [
+    {
+      "type": "node-workspace",
+      "updatePeerDependencies": true
+    }
+  ],
+  "always-link-local": false
 }


### PR DESCRIPTION
Instead of sometimes needing to manually bump the CLI peer dependency, this configures release-please to do that automatically.