### PR TITLE
fix: Omit proto3 synthetic oneofs in toObject

### DIFF
--- a/src/converter.js
+++ b/src/converter.js
@@ -326,7 +326,7 @@ converter.toObject = function toObject(mtype) {
         } else { gen
     ("if(m%s!=null&&m.hasOwnProperty(%j)){", prop, field.name); // !== undefined && !== null
         genValuePartial_toObject(gen, field, /* sorted */ index, prop);
-        if (field.partOf) gen
+        if (field.partOf && !field.partOf.isProto3Optional) gen
         ("if(o.oneofs)")
             ("d%s=%j", util.safeProp(field.partOf.name), field.name);
         }

--- a/tests/comp_optional.js
+++ b/tests/comp_optional.js
@@ -43,6 +43,26 @@ tape.test("proto3 optional", function(test) {
     test.end();
 });
 
+tape.test("proto3 optional does not emit synthetic oneof discriminator", function(test) {
+    var root = protobuf.parse(proto).root;
+    root.resolveAll();
+
+    var Message = root.lookupType("Message");
+
+    test.same(
+        Message.toObject(Message.create({ optionalInt32: 1 }), { oneofs: true }),
+        { optionalInt32: 1 },
+        "should not emit synthetic oneof discriminator"
+    );
+    test.same(
+        Message.toObject(Message.create({ oneofInt32: 1 }), { oneofs: true }),
+        { oneofInt32: 1, _oneofInt32: "oneofInt32" },
+        "should still emit real oneof discriminator"
+    );
+
+    test.end();
+});
+
 tape.test("proto3 implicit scalar defaults", function(test) {
     var root = protobuf.parse(proto).root;
     root.resolveAll();


### PR DESCRIPTION
Proto3 optional fields are represented internally using synthetic oneofs for descriptor/reflection compatibility (see #1584), but these should not appear as user-facing oneof discriminators. This change omits synthetic proto3 optional oneofs in `toObject(..., { oneofs: true })`.

Fixes #2037
Related: grpc/grpc-node#2754