### PR TITLE
fix: Improve message return typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -581,7 +581,7 @@ export class Message<T extends object = object> {
      * @param [properties] Properties to set
      * @returns Message instance
      */
-    static create<T extends Message<T>>(this: Constructor<T>, properties?: { [k: string]: any }): Message<T>;
+    static create<T extends Message<T>>(this: Constructor<T>, properties?: { [k: string]: any }): T;
 
     /**
      * Encodes a message of this type.
@@ -1743,7 +1743,7 @@ export class Type extends NamespaceBase {
      * @param [properties] Properties to set
      * @returns Message instance
      */
-    create(properties?: { [k: string]: any }): Message<{}>;
+    create(properties?: { [k: string]: any }): ReflectedMessage;
 
     /**
      * Sets up {@link Type#encode|encode}, {@link Type#decode|decode} and {@link Type#verify|verify}.
@@ -1775,7 +1775,7 @@ export class Type extends NamespaceBase {
      * @throws {Error} If the payload is not a reader or valid buffer
      * @throws {util.ProtocolError<{}>} If required fields are missing
      */
-    decode(reader: (Reader|Uint8Array), length?: number): Message<{}>;
+    decode(reader: (Reader|Uint8Array), length?: number): ReflectedMessage;
 
     /**
      * Decodes a message of this type preceeded by its byte length as a varint.
@@ -1784,7 +1784,7 @@ export class Type extends NamespaceBase {
      * @throws {Error} If the payload is not a reader or valid buffer
      * @throws {util.ProtocolError} If required fields are missing
      */
-    decodeDelimited(reader: (Reader|Uint8Array)): Message<{}>;
+    decodeDelimited(reader: (Reader|Uint8Array)): ReflectedMessage;
 
     /**
      * Verifies that field values are valid and that required fields are present.
@@ -1798,7 +1798,7 @@ export class Type extends NamespaceBase {
      * @param object Plain object to convert
      * @returns Message instance
      */
-    fromObject(object: { [k: string]: any }): Message<{}>;
+    fromObject(object: { [k: string]: any }): ReflectedMessage;
 
     /**
      * Creates a plain object from a message of this type. Also converts values to other types if specified.
@@ -1986,6 +1986,9 @@ export type Constructor<T> = Function & { new(...params: any[]): T; prototype: T
 
 /** Properties type. */
 export type Properties<T> = { [P in keyof T]?: T[P] };
+
+/** Dynamically reflected message type. */
+export type ReflectedMessage = Message<{}> & { [k: string]: any };
 
 /**
  * Callback as used by {@link util.asPromise}.

--- a/src/message.js
+++ b/src/message.js
@@ -36,7 +36,7 @@ function Message(properties) {
 /**
  * Creates a new message of this type using the specified properties.
  * @param {Object.<string,*>} [properties] Properties to set
- * @returns {Message<T>} Message instance
+ * @returns {T} Message instance
  * @template T extends Message<T>
  * @this Constructor<T>
  */

--- a/src/type.js
+++ b/src/type.js
@@ -458,7 +458,7 @@ Type.prototype.isReservedName = function isReservedName(name) {
 /**
  * Creates a new message of this type using the specified properties.
  * @param {Object.<string,*>} [properties] Properties to set
- * @returns {Message<{}>} Message instance
+ * @returns {ReflectedMessage} Message instance
  */
 Type.prototype.create = function create(properties) {
     return new this.ctor(properties);
@@ -542,7 +542,7 @@ Type.prototype.encodeDelimited = function encodeDelimited(message, writer) {
  * Decodes a message of this type.
  * @param {Reader|Uint8Array} reader Reader or buffer to decode from
  * @param {number} [length] Length of the message, if known beforehand
- * @returns {Message<{}>} Decoded message
+ * @returns {ReflectedMessage} Decoded message
  * @throws {Error} If the payload is not a reader or valid buffer
  * @throws {util.ProtocolError<{}>} If required fields are missing
  */
@@ -553,7 +553,7 @@ Type.prototype.decode = function decode_setup(reader, length) { // eslint-disabl
 /**
  * Decodes a message of this type preceeded by its byte length as a varint.
  * @param {Reader|Uint8Array} reader Reader or buffer to decode from
- * @returns {Message<{}>} Decoded message
+ * @returns {ReflectedMessage} Decoded message
  * @throws {Error} If the payload is not a reader or valid buffer
  * @throws {util.ProtocolError} If required fields are missing
  */
@@ -575,7 +575,7 @@ Type.prototype.verify = function verify_setup(message) { // eslint-disable-line 
 /**
  * Creates a new message of this type from a plain object. Also converts values to their respective internal types.
  * @param {Object.<string,*>} object Plain object to convert
- * @returns {Message<{}>} Message instance
+ * @returns {ReflectedMessage} Message instance
  */
 Type.prototype.fromObject = function fromObject(object) { // eslint-disable-line no-unused-vars
     return this.setup().fromObject.apply(this, arguments);

--- a/src/typescript.js
+++ b/src/typescript.js
@@ -17,3 +17,9 @@ var Constructor;
  * @typedef {{ [P in keyof T]?: T[P] }} Properties
  */
 var Properties;
+
+/**
+ * Dynamically reflected message type.
+ * @typedef {Message<{}> & { [k: string]: any }} ReflectedMessage
+ */
+var ReflectedMessage;

--- a/tests/comp_typescript.js
+++ b/tests/comp_typescript.js
@@ -28,7 +28,10 @@ const root = __1.Root.fromJSON({
     }
 });
 const HelloReflected = root.lookupType("Hello");
-HelloReflected.create({ value: "hi" });
+const reflectedCreated = HelloReflected.create({ value: "hi" });
+const reflectedCreatedValue = reflectedCreated.value;
+const reflectedDecodedValue = HelloReflected.decode(HelloReflected.encode({ value: "hi" }).finish()).value;
+const reflectedConvertedValue = HelloReflected.fromObject({ value: "hi" }).value;
 const parsedOptionValue = (_a = HelloReflected.parsedOptions) === null || _a === void 0 ? void 0 : _a[0]["(custom_option)"];
 const reflectedMethod = new __1.Method("Call", undefined, "Hello", "Hello", false, false, undefined, undefined, [{ option: 1 }]);
 const parsedMethodOptionValue = (_b = reflectedMethod.parsedOptions) === null || _b === void 0 ? void 0 : _b[0].option;
@@ -54,7 +57,8 @@ class Hello extends __1.Message {
 }
 exports.Hello = Hello;
 root.lookupType("Hello").ctor = Hello;
-Hello.create({ value: "hi" });
+let helloCreated = Hello.create({ value: "hi" });
+helloCreated.foo();
 let helloMessage = new Hello({ value: "hi" });
 let helloBuffer = Hello.encode(helloMessage.foo()).finish();
 let helloDecoded = Hello.decode(helloBuffer);

--- a/tests/comp_typescript.ts
+++ b/tests/comp_typescript.ts
@@ -1,6 +1,6 @@
 // test currently consists only of not throwing
 
-import { Root, Message, Method, Type, Field, MapField, OneOf, IEnum, IField, IMethod, IOneOf, IService, IType } from "..";
+import { Root, Message, Method, Type, Field, MapField, OneOf, IEnum, IField, IMethod, IOneOf, IService, IType, ReflectedMessage } from "..";
 
 // Reflection
 const root = Root.fromJSON({
@@ -18,7 +18,12 @@ const root = Root.fromJSON({
 });
 const HelloReflected = root.lookupType("Hello");
 
-HelloReflected.create({ value: "hi" });
+const reflectedCreated: ReflectedMessage = HelloReflected.create({ value: "hi" });
+type Assert<T extends true> = T;
+type ReflectedTypeIsType = Assert<typeof reflectedCreated.$type extends Type ? true : false>;
+const reflectedCreatedValue: string = reflectedCreated.value;
+const reflectedDecodedValue: string = HelloReflected.decode(HelloReflected.encode({ value: "hi" }).finish()).value;
+const reflectedConvertedValue: string = HelloReflected.fromObject({ value: "hi" }).value;
 
 const parsedOptionValue: number | undefined = HelloReflected.parsedOptions?.[0]["(custom_option)"];
 const reflectedMethod = new Method("Call", undefined, "Hello", "Hello", false, false, undefined, undefined, [{ option: 1 }]);
@@ -52,7 +57,8 @@ export class Hello extends Message<Hello> {
 
 root.lookupType("Hello").ctor = Hello;
 
-Hello.create({ value: "hi" });
+let helloCreated: Hello = Hello.create({ value: "hi" });
+helloCreated.foo();
 let helloMessage = new Hello({ value: "hi" });
 let helloBuffer  = Hello.encode(helloMessage.foo()).finish();
 let helloDecoded = Hello.decode(helloBuffer);


### PR DESCRIPTION
Improves message return typings in two places: Static `Message.create` returns the concrete message type, matching `decode` and `fromObject`. Reflected `Type#create`, `decode`, `decodeDelimited`, and `fromObject` return `ReflectedMessage`, allowing dynamic field access.

Fixes #2028