### PR TITLE
fix: Align reserved range semantics

### DIFF
--- a/cli/targets/proto.js
+++ b/cli/targets/proto.js
@@ -25,6 +25,8 @@ var out = [];
 var indent = 0;
 var first = false;
 var syntax = 3;
+var maxFieldId = 0x1FFFFFFF; // 2^29 - 1
+var maxEnumId = 0x7FFFFFFF; // 2^31 - 1
 
 function proto_target(root, options, callback) {
     if (options) {
@@ -146,23 +148,29 @@ function buildEnum(enm) {
         }
         push(name + " = " + val + ";");
     });
+    buildRanges("reserved", enm.reserved, maxEnumId);
     --indent; first = false;
     push("}");
 }
 
-function buildRanges(keyword, ranges) {
+function buildRanges(keyword, ranges, max) {
+    max = max || maxFieldId;
     if (ranges && ranges.length) {
-        var parts = [];
+        var parts = [],
+            names = [];
         ranges.forEach(function(range) {
             if (typeof range === "string")
-                parts.push("\"" + escape(range) + "\"");
+                names.push("\"" + escape(range) + "\"");
             else if (range[0] === range[1])
                 parts.push(range[0]);
             else
-                parts.push(range[0] + " to " + (range[1] === 0x1FFFFFFF ? "max" : range[1]));
+                parts.push(range[0] + " to " + (range[1] === max ? "max" : range[1]));
         });
         push("");
-        push(keyword + " " + parts.join(", ") + ";");
+        if (parts.length)
+            push(keyword + " " + parts.join(", ") + ";");
+        if (names.length)
+            push(keyword + " " + names.join(", ") + ";");
     }
 }
 

--- a/ext/descriptor.js
+++ b/ext/descriptor.js
@@ -268,13 +268,13 @@ Type.fromDescriptor = function fromDescriptor(descriptor, edition, nested, depth
     /* Extension ranges */ if (descriptor.extensionRange && descriptor.extensionRange.length) {
         type.extensions = [];
         for (i = 0; i < descriptor.extensionRange.length; ++i)
-            type.extensions.push([ descriptor.extensionRange[i].start, descriptor.extensionRange[i].end ]);
+            type.extensions.push([ descriptor.extensionRange[i].start, descriptor.extensionRange[i].end - 1 ]);
     }
     /* Reserved... */ if (descriptor.reservedRange && descriptor.reservedRange.length || descriptor.reservedName && descriptor.reservedName.length) {
         type.reserved = [];
         /* Ranges */ if (descriptor.reservedRange)
             for (i = 0; i < descriptor.reservedRange.length; ++i)
-                type.reserved.push([ descriptor.reservedRange[i].start, descriptor.reservedRange[i].end ]);
+                type.reserved.push([ descriptor.reservedRange[i].start, descriptor.reservedRange[i].end - 1 ]);
         /* Names */ if (descriptor.reservedName)
             for (i = 0; i < descriptor.reservedName.length; ++i)
                 type.reserved.push(descriptor.reservedName[i]);
@@ -324,13 +324,13 @@ Type.prototype.toDescriptor = function toDescriptor(edition) {
     }
     /* Extension ranges */ if (this.extensions)
         for (i = 0; i < this.extensions.length; ++i)
-            descriptor.extensionRange.push(exports.DescriptorProto.ExtensionRange.create({ start: this.extensions[i][0], end: this.extensions[i][1] }));
+            descriptor.extensionRange.push(exports.DescriptorProto.ExtensionRange.create({ start: this.extensions[i][0], end: this.extensions[i][1] + 1 }));
     /* Reserved... */ if (this.reserved)
         for (i = 0; i < this.reserved.length; ++i)
             /* Names */ if (typeof this.reserved[i] === "string")
                 descriptor.reservedName.push(this.reserved[i]);
             /* Ranges */ else
-                descriptor.reservedRange.push(exports.DescriptorProto.ReservedRange.create({ start: this.reserved[i][0], end: this.reserved[i][1] }));
+                descriptor.reservedRange.push(exports.DescriptorProto.ReservedRange.create({ start: this.reserved[i][0], end: this.reserved[i][1] + 1 }));
 
     descriptor.options = toDescriptorOptions(this.options, exports.MessageOptions);
 
@@ -657,9 +657,10 @@ Enum.fromDescriptor = function fromDescriptor(descriptor, edition, nested) {
 
     // Construct values object
     var values = {},
-        valuesOptions;
+        valuesOptions,
+        i;
     if (descriptor.value)
-        for (var i = 0; i < descriptor.value.length; ++i) {
+        for (i = 0; i < descriptor.value.length; ++i) {
             var name  = descriptor.value[i].name,
                 valueName = name && name.length ? name : "NAME" + (descriptor.value[i].number || 0),
                 value = descriptor.value[i].number || 0,
@@ -681,6 +682,16 @@ Enum.fromDescriptor = function fromDescriptor(descriptor, edition, nested) {
     if (!nested)
         enm._edition = edition;
 
+    /* Reserved... */ if (descriptor.reservedRange && descriptor.reservedRange.length || descriptor.reservedName && descriptor.reservedName.length) {
+        enm.reserved = [];
+        /* Ranges */ if (descriptor.reservedRange)
+            for (i = 0; i < descriptor.reservedRange.length; ++i)
+                enm.reserved.push([ descriptor.reservedRange[i].start, descriptor.reservedRange[i].end ]);
+        /* Names */ if (descriptor.reservedName)
+            for (i = 0; i < descriptor.reservedName.length; ++i)
+                enm.reserved.push(descriptor.reservedName[i]);
+    }
+
     return enm;
 };
 
@@ -691,19 +702,30 @@ Enum.fromDescriptor = function fromDescriptor(descriptor, edition, nested) {
 Enum.prototype.toDescriptor = function toDescriptor() {
 
     // Values
-    var values = [];
-    for (var i = 0, ks = Object.keys(this.values); i < ks.length; ++i)
+    var values = [],
+        i,
+        ks = Object.keys(this.values);
+    for (i = 0; i < ks.length; ++i)
         values.push(exports.EnumValueDescriptorProto.create({
             name: ks[i],
             number: this.values[ks[i]],
             options: this.valuesOptions && toDescriptorOptions(this.valuesOptions[ks[i]], exports.EnumValueOptions)
         }));
 
-    return exports.EnumDescriptorProto.create({
+    var descriptor = exports.EnumDescriptorProto.create({
         name: this.name,
         value: values,
         options: toDescriptorOptions(this.options, exports.EnumOptions)
     });
+
+    /* Reserved... */ if (this.reserved)
+        for (i = 0; i < this.reserved.length; ++i)
+            /* Names */ if (typeof this.reserved[i] === "string")
+                descriptor.reservedName.push(this.reserved[i]);
+            /* Ranges */ else
+                descriptor.reservedRange.push(exports.EnumDescriptorProto.EnumReservedRange.create({ start: this.reserved[i][0], end: this.reserved[i][1] }));
+
+    return descriptor;
 };
 
 // --- OneOf ---

--- a/src/namespace.js
+++ b/src/namespace.js
@@ -68,7 +68,7 @@ Namespace.arrayToJSON = arrayToJSON;
 Namespace.isReservedId = function isReservedId(reserved, id) {
     if (reserved)
         for (var i = 0; i < reserved.length; ++i)
-            if (typeof reserved[i] !== "string" && reserved[i][0] <= id && reserved[i][1] > id)
+            if (typeof reserved[i] !== "string" && reserved[i][0] <= id && reserved[i][1] >= id)
                 return true;
     return false;
 };

--- a/src/parse.js
+++ b/src/parse.js
@@ -27,6 +27,9 @@ var base10Re    = /^[1-9][0-9]*$/,
     nameRe      = /^[a-zA-Z_][a-zA-Z_0-9]*$/,
     typeRefRe   = util.patterns.typeRefRe;
 
+var maxFieldId = 536870911, // 2^29 - 1
+    maxEnumId = 2147483647; // 2^31 - 1
+
 /**
  * Result object returned from {@link parse}.
  * @interface IParserResult
@@ -146,7 +149,7 @@ function parse(source, root, options) {
         }
     }
 
-    function readRanges(target, acceptStrings) {
+    function readRanges(target, acceptStrings, max, acceptNegative) {
         var token, start;
         do {
             if (acceptStrings && ((token = peek()) === "\"" || token === "'")) {
@@ -157,7 +160,7 @@ function parse(source, root, options) {
                 }
             } else {
                 try {
-                    target.push([ start = parseId(next()), skip("to", true) ? parseId(next()) : start ]);
+                    target.push([ start = parseId(next(), acceptNegative, max), skip("to", true) ? parseId(next(), acceptNegative, max) : start ]);
                 } catch (err) {
                     if (acceptStrings && typeRefRe.test(token) && edition >= 2023) {
                         target.push(token);
@@ -216,10 +219,10 @@ function parse(source, root, options) {
         throw illegal(token, "number", insideTryCatch);
     }
 
-    function parseId(token, acceptNegative) {
+    function parseId(token, acceptNegative, max) {
         switch (token) {
             case "max": case "MAX": case "Max":
-                return 536870911;
+                return max || maxFieldId;
             case "0":
                 return 0;
         }
@@ -677,7 +680,7 @@ function parse(source, root, options) {
               break;
 
             case "reserved":
-              readRanges(enm.reserved || (enm.reserved = []), true);
+              readRanges(enm.reserved || (enm.reserved = []), true, maxEnumId, true);
               if(enm.reserved === undefined) enm.reserved = [];
               break;
 

--- a/tests/api_descriptor.js
+++ b/tests/api_descriptor.js
@@ -51,6 +51,48 @@ tape.test("descriptor - proto2 roundtrip", function (test) {
     test.end();
 });
 
+tape.test("descriptor - ranges use descriptor end semantics at boundary", function (test) {
+    var root = protobuf.parse(`syntax = "proto2";
+
+        message Message {
+            extensions 100 to 199;
+            reserved 2, 9 to 11;
+            reserved "old";
+            optional string value = 1;
+
+            enum Values {
+                reserved -2 to -1, 2, 40 to max;
+                reserved "OLD";
+                ZERO = 0;
+                OK = 1;
+            }
+        }
+    `).root.resolveAll();
+
+    var descriptorSet = root.toDescriptor("proto2"),
+        descriptorMessage = descriptorSet.file[0].messageType[0],
+        descriptorEnum = descriptorMessage.enumType[0];
+
+    test.same(root.lookupType("Message").extensions, [[100, 199]], "extensions are inclusive internally");
+    test.same(root.lookupType("Message").reserved, [[2, 2], [9, 11], "old"], "message reserved ranges are inclusive internally");
+    test.same(root.lookupEnum("Message.Values").reserved, [[-2, -1], [2, 2], [40, 2147483647], "OLD"], "enum reserved ranges are inclusive internally");
+
+    test.same(descriptorMessage.extensionRange.map(function(range) {
+        return [range.start, range.end];
+    }), [[100, 200]], "message extension descriptors use exclusive end");
+    test.same(descriptorMessage.reservedRange.map(function(range) {
+        return [range.start, range.end];
+    }), [[2, 3], [9, 12]], "message reserved descriptors use exclusive end");
+    test.same(descriptorEnum.reservedRange.map(function(range) {
+        return [range.start, range.end];
+    }), [[-2, -1], [2, 2], [40, 2147483647]], "enum reserved descriptors keep inclusive end");
+    test.same(descriptorEnum.reservedName, ["OLD"], "enum reserved names are emitted");
+
+    test.same(protobuf.Root.fromDescriptor(descriptorSet).toJSON(), root.toJSON(), "JSON should roundtrip");
+
+    test.end();
+});
+
 tape.test("descriptor - proto3 roundtrip", function (test) {
     var root = protobuf.parse(`syntax = "proto3";
 

--- a/tests/api_enum.js
+++ b/tests/api_enum.js
@@ -105,6 +105,15 @@ tape.test("reflected enums", function(test) {
     }, Error, "should throw if id is a reserved number");
 
     test.throws(function() {
+        enm.add("d", 200);
+    }, Error, "should throw if id is a reserved range end");
+
+    enm.reserved = [[100,100], "BAD_NAME"];
+    test.throws(function() {
+        enm.add("d", 100);
+    }, Error, "should throw if id is a reserved singleton number");
+
+    test.throws(function() {
         enm.add("BAD_NAME", 5);
     }, Error, "should throw if id is a reserved name");
 

--- a/tests/api_type.js
+++ b/tests/api_type.js
@@ -109,6 +109,10 @@ tape.test("reflected types", function(test) {
     }, Error, "should throw when trying to add reserved ids");
 
     test.throws(function() {
+        type.add(new protobuf.Field("c", 999, "uint32"));
+    }, Error, "should throw when trying to add reserved range end ids");
+
+    test.throws(function() {
         type.add(new protobuf.Field("b", 2, "uint32"));
     }, Error, "should throw when trying to add reserved names");
 

--- a/tests/cli-proto.js
+++ b/tests/cli-proto.js
@@ -33,6 +33,31 @@ message OptionalFields {
     });
 });
 
+tape.test("proto3 enum reserved max roundtrip", function(test) {
+    const proto = `syntax = "proto3";
+
+enum Values {
+
+    ZERO = 0;
+    OK = 1;
+
+    reserved -2 to -1, 40 to max;
+    reserved "OLD";
+}`;
+    cliTest(test, function() {
+        var root = protobuf.parse(proto).root.resolveAll();
+        var protoTarget = require("../cli/targets/proto3");
+
+        protoTarget(root, {}, function(err, output) {
+            test.error(err, "proto code generation worked");
+
+            test.equal(output, proto);
+
+            test.end();
+        });
+    });
+});
+
 tape.test("proto2 roundtrip", function(test) {
     const proto = `syntax = "proto2";
 

--- a/tests/comp_parse-uncommon.js
+++ b/tests/comp_parse-uncommon.js
@@ -26,6 +26,31 @@ tape.test("uncommon statements", function(test) {
     });
 });
 
+tape.test("negative enum reserved values", function(test) {
+    test.doesNotThrow(function() {
+        var Enum = protobuf.parse("syntax = \"proto3\"; enum Values { reserved -1; INVALID = 0; OK = 1; }").root.lookupEnum("Values");
+        test.same(Enum.reserved, [[-1, -1]], "should parse negative singleton enum reserved value");
+    }, "should parse negative enum reserved values");
+
+    test.throws(function() {
+        protobuf.parse("syntax = \"proto3\"; enum Values { reserved -2 to -1; INVALID = 0; RESERVED = -1; }");
+    }, /id -1 is reserved/, "should reject negative reserved enum range end ids");
+
+    test.throws(function() {
+        protobuf.parse("syntax = \"proto3\"; enum Values { reserved 1 to max; INVALID = 0; RESERVED = 2147483647; }");
+    }, /id 2147483647 is reserved/, "should use int32 max for enum reserved max");
+
+    test.throws(function() {
+        protobuf.parse("syntax = \"proto3\"; enum Values { reserved -1; INVALID = 0; RESERVED = -1; }");
+    }, /id -1 is reserved/, "should reject negative reserved enum value ids");
+
+    test.throws(function() {
+        protobuf.parse("syntax = \"proto3\"; message M { reserved -1; int32 value = 1; }");
+    }, /illegal id '-1'/, "should still reject negative message reserved field ids");
+
+    test.end();
+});
+
 function traverseTypes(current, fn) {
     if (current instanceof protobuf.Type) // and/or protobuf.Enum, protobuf.Service etc.
         fn(current);


### PR DESCRIPTION
Aligns reserved and extension range handling with upstream semantics by consistently treating internal ranges as inclusive. In descriptors, message reserved and extension `end`s are exclusive, whereas enum reserved `end`s and `.proto` source ranges are inclusive.

Also allows negative enum reserved values, which upstream accepts, uses the correct maximums, and preserves reserved ranges/names in descriptor and `.proto` text output.

Fixes #1214
Follow-up to #1122