### PR TITLE
fix: Correct util helper typing

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2030,13 +2030,6 @@ export interface IFetchOptions {
 }
 
 /**
- * Tests if the specified key can affect object prototypes.
- * @param key Key to test
- * @returns `true` if the key is unsafe
- */
-export function isUnsafeProperty(key: string): boolean;
-
-/**
  * Any compatible Buffer instance.
  * This is a minimal stand-alone definition of a Buffer instance. The actual type is that exported by node's typings.
  */
@@ -2368,6 +2361,13 @@ export namespace util {
          */
         length(): number;
     }
+
+    /**
+     * Tests if the specified key can affect object prototypes.
+     * @param key Key to test
+     * @returns `true` if the key is unsafe
+     */
+    function isUnsafeProperty(key: string): boolean;
 
     /** Whether running within node or not. */
     let isNode: boolean;

--- a/src/util/minimal.js
+++ b/src/util/minimal.js
@@ -27,6 +27,7 @@ util.LongBits = require("./longbits");
 
 /**
  * Tests if the specified key can affect object prototypes.
+ * @memberof util
  * @param {string} key Key to test
  * @returns {boolean} `true` if the key is unsafe
  */


### PR DESCRIPTION
Moves the `isUnsafeProperty` helper under `util`, matching where the helper is exposed at runtime.