### PR TITLE
fix: Backport misc utility hardening (7.x)

### DIFF
--- a/bench/data/static_pbjs.js
+++ b/bench/data/static_pbjs.js
@@ -21,15 +21,19 @@ $root.Test = (function() {
     Test.prototype.inner = null;
     Test.prototype.float = 0;
 
-    Test.encode = function encode(message, writer) {
+    Test.encode = function encode(message, writer, q) {
         if (!writer)
             writer = $Writer.create();
+        if (q === undefined)
+            q = 0;
+        if (q > $util.recursionLimit)
+            throw Error("max depth exceeded");
         if (message.string != null && Object.hasOwnProperty.call(message, "string"))
             writer.uint32(10).string(message.string);
         if (message.uint32 != null && Object.hasOwnProperty.call(message, "uint32"))
             writer.uint32(16).uint32(message.uint32);
         if (message.inner != null && Object.hasOwnProperty.call(message, "inner"))
-            $root.Test.Inner.encode(message.inner, writer.uint32(26).fork()).ldelim();
+            $root.Test.Inner.encode(message.inner, writer.uint32(26).fork(), q + 1).ldelim();
         if (message.float != null && Object.hasOwnProperty.call(message, "float"))
             writer.uint32(37).float(message.float);
         return writer;
@@ -85,15 +89,19 @@ $root.Test = (function() {
         Inner.prototype.innerInner = null;
         Inner.prototype.outer = null;
 
-        Inner.encode = function encode(message, writer) {
+        Inner.encode = function encode(message, writer, q) {
             if (!writer)
                 writer = $Writer.create();
+            if (q === undefined)
+                q = 0;
+            if (q > $util.recursionLimit)
+                throw Error("max depth exceeded");
             if (message.int32 != null && Object.hasOwnProperty.call(message, "int32"))
                 writer.uint32(8).int32(message.int32);
             if (message.innerInner != null && Object.hasOwnProperty.call(message, "innerInner"))
-                $root.Test.Inner.InnerInner.encode(message.innerInner, writer.uint32(18).fork()).ldelim();
+                $root.Test.Inner.InnerInner.encode(message.innerInner, writer.uint32(18).fork(), q + 1).ldelim();
             if (message.outer != null && Object.hasOwnProperty.call(message, "outer"))
-                $root.Outer.encode(message.outer, writer.uint32(26).fork()).ldelim();
+                $root.Outer.encode(message.outer, writer.uint32(26).fork(), q + 1).ldelim();
             return writer;
         };
 
@@ -143,9 +151,13 @@ $root.Test = (function() {
             InnerInner.prototype["enum"] = 0;
             InnerInner.prototype.sint32 = 0;
 
-            InnerInner.encode = function encode(message, writer) {
+            InnerInner.encode = function encode(message, writer, q) {
                 if (!writer)
                     writer = $Writer.create();
+                if (q === undefined)
+                    q = 0;
+                if (q > $util.recursionLimit)
+                    throw Error("max depth exceeded");
                 if (message.long != null && Object.hasOwnProperty.call(message, "long"))
                     writer.uint32(8).int64(message.long);
                 if (message["enum"] != null && Object.hasOwnProperty.call(message, "enum"))
@@ -220,9 +232,13 @@ $root.Outer = (function() {
     Outer.prototype.bool = $util.emptyArray;
     Outer.prototype.double = 0;
 
-    Outer.encode = function encode(message, writer) {
+    Outer.encode = function encode(message, writer, q) {
         if (!writer)
             writer = $Writer.create();
+        if (q === undefined)
+            q = 0;
+        if (q > $util.recursionLimit)
+            throw Error("max depth exceeded");
         if (message.bool != null && message.bool.length) {
             writer.uint32(10).fork();
             for (var i = 0; i < message.bool.length; ++i)

--- a/ext/descriptor/index.js
+++ b/ext/descriptor/index.js
@@ -223,9 +223,14 @@ var unnamedMessageIndex = 0;
  * @param {IDescriptorProto|Reader|Uint8Array} descriptor Descriptor
  * @param {string} [edition="proto2"] The syntax or edition to use
  * @param {boolean} [nested=false] Whether or not this is a nested object
+ * @param {number} [depth] Current nesting depth, defaults to `0`
  * @returns {Type} Type instance
  */
-Type.fromDescriptor = function fromDescriptor(descriptor, edition, nested) {
+Type.fromDescriptor = function fromDescriptor(descriptor, edition, nested, depth) {
+    if (depth === undefined)
+        depth = 0;
+    if (depth > $protobuf.util.nestingLimit)
+        throw Error("max depth exceeded");
     // Decode the descriptor message if specified as a buffer:
     if (typeof descriptor.length === "number")
         descriptor = exports.DescriptorProto.decode(descriptor);
@@ -252,7 +257,7 @@ Type.fromDescriptor = function fromDescriptor(descriptor, edition, nested) {
             type.add(Field.fromDescriptor(descriptor.extension[i], edition, true));
     /* Nested types */ if (descriptor.nestedType)
         for (i = 0; i < descriptor.nestedType.length; ++i) {
-            type.add(Type.fromDescriptor(descriptor.nestedType[i], edition, true));
+            type.add(Type.fromDescriptor(descriptor.nestedType[i], edition, true, depth + 1));
             if (descriptor.nestedType[i].options && descriptor.nestedType[i].options.mapEntry)
                 type.setOption("map_entry", true);
         }

--- a/index.d.ts
+++ b/index.d.ts
@@ -2033,6 +2033,13 @@ export namespace util {
         public length(): number;
     }
 
+    /**
+     * Tests if the specified key can affect object prototypes.
+     * @param key Key to test
+     * @returns `true` if the key is unsafe
+     */
+    function isUnsafeProperty(key: string): boolean;
+
     /** Whether running within node or not. */
     let isNode: boolean;
 
@@ -2126,11 +2133,13 @@ export namespace util {
     /**
      * Merges the properties of the source object into the destination object.
      * @param dst Destination object
-     * @param src Source object
-     * @param [ifNotSet=false] Merges only if the key is not already set
+     * @param src Source objects, optionally followed by an `ifNotSet` flag
      * @returns Destination object
      */
-    function merge(dst: { [k: string]: any }, src: { [k: string]: any }, ifNotSet?: boolean): { [k: string]: any };
+    function merge(dst: { [k: string]: any }, ...src: any[]): { [k: string]: any };
+
+    /** Schema declaration nesting limit. */
+    let nestingLimit: number;
 
     /** Recursion limit. */
     let recursionLimit: number;

--- a/lib/eventemitter/index.js
+++ b/lib/eventemitter/index.js
@@ -14,7 +14,7 @@ function EventEmitter() {
      * @type {Object.<string,*>}
      * @private
      */
-    this._listeners = {};
+    this._listeners = Object.create(null);
 }
 
 /**
@@ -48,12 +48,14 @@ EventEmitter.prototype.on = function on(evt, fn, ctx) {
  */
 EventEmitter.prototype.off = function off(evt, fn) {
     if (evt === undefined)
-        this._listeners = {};
+        this._listeners = Object.create(null);
     else {
         if (fn === undefined)
             this._listeners[evt] = [];
         else {
             var listeners = this._listeners[evt];
+            if (!listeners)
+                return this;
             for (var i = 0; i < listeners.length;)
                 if (listeners[i].fn === fn)
                     listeners.splice(i, 1);

--- a/lib/eventemitter/tests/index.js
+++ b/lib/eventemitter/tests/index.js
@@ -8,6 +8,8 @@ tape.test("eventemitter", function(test) {
     var fn;
     var ctx = {};
 
+    test.equal(Object.getPrototypeOf(ee._listeners), null, "should not inherit listener lookup keys");
+
     test.doesNotThrow(function() {
         ee.emit("a", 1);
         ee.off();
@@ -22,10 +24,12 @@ tape.test("eventemitter", function(test) {
     ee.emit("a", 1);
 
     ee.off("a");
-    test.same(ee._listeners, { a: [] }, "should remove all listeners of the respective event when calling off(evt)");
+    test.same(Object.keys(ee._listeners), [ "a" ], "should keep the event key when calling off(evt)");
+    test.same(ee._listeners.a, [], "should remove all listeners of the respective event when calling off(evt)");
 
     ee.off();
-    test.same(ee._listeners, {}, "should remove all listeners when just calling off()");
+    test.equal(Object.getPrototypeOf(ee._listeners), null, "should keep the listener table isolated when just calling off()");
+    test.same(Object.keys(ee._listeners), [], "should remove all listeners when just calling off()");
 
     ee.on("a", fn = function(arg1) {
         test.equal(this, ctx, "should be called with this = ctx");
@@ -33,7 +37,8 @@ tape.test("eventemitter", function(test) {
     }, ctx).emit("a", 1);
 
     ee.off("a", fn);
-    test.same(ee._listeners, { a: [] }, "should remove the exact listener when calling off(evt, fn)");
+    test.same(Object.keys(ee._listeners), [ "a" ], "should keep the event key when calling off(evt, fn)");
+    test.same(ee._listeners.a, [], "should remove the exact listener when calling off(evt, fn)");
 
     ee.on("a", function() {
         test.equal(this, ee, "should be called with this = ee");
@@ -42,6 +47,37 @@ tape.test("eventemitter", function(test) {
     test.doesNotThrow(function() {
         ee.off("a", fn);
     }, "should not throw if no such listener is found");
+
+    test.test(test.name + " - special event names", function(test) {
+        var ee = new EventEmitter();
+        var calls = 0;
+
+        test.doesNotThrow(function() {
+            ee.off("__proto__", function() {});
+        }, "should not throw when removing an absent special event listener");
+
+        ee.on("__proto__", function(arg) {
+            ++calls;
+            test.equal(arg, 1, "should pass arguments for __proto__ events");
+        });
+        ee.on("constructor", function(arg) {
+            ++calls;
+            test.equal(arg, 2, "should pass arguments for constructor events");
+        });
+        ee.emit("__proto__", 1);
+        ee.emit("constructor", 2);
+
+        test.equal(calls, 2, "should dispatch special event names");
+        test.equal(Object.getPrototypeOf(ee._listeners), null, "should keep the listener table isolated");
+        test.ok(Object.prototype.hasOwnProperty.call(ee._listeners, "__proto__"), "should store __proto__ as an own event key");
+        test.ok(Object.prototype.hasOwnProperty.call(ee._listeners, "constructor"), "should store constructor as an own event key");
+
+        ee.off("__proto__");
+        ee.off("constructor");
+        test.same(ee._listeners.__proto__, [], "should clear __proto__ listeners");
+        test.same(ee._listeners.constructor, [], "should clear constructor listeners");
+        test.end();
+    });
 
     test.end();
 });

--- a/src/converter.js
+++ b/src/converter.js
@@ -172,7 +172,7 @@ function genValuePartial_toObject(gen, field, fieldIndex, prop) {
         if (field.resolvedType instanceof Enum) gen
             ("d%s=o.enums===String?(types[%i].values[m%s]===undefined?m%s:types[%i].values[m%s]):m%s", prop, fieldIndex, prop, prop, fieldIndex, prop, prop);
         else gen
-            ("d%s=types[%i].toObject(m%s,o)", prop, fieldIndex, prop);
+            ("d%s=types[%i].toObject(m%s,o,q+1)", prop, fieldIndex, prop);
     } else {
         var isUnsigned = false;
         switch (field.type) {
@@ -216,9 +216,12 @@ converter.toObject = function toObject(mtype) {
     var fields = mtype.fieldsArray.slice().sort(util.compareFieldsById);
     if (!fields.length)
         return util.codegen()("return {}");
-    var gen = util.codegen(["m", "o"], mtype.name + "$toObject")
+    var gen = util.codegen(["m", "o", "q"], mtype.name + "$toObject")
     ("if(!o)")
         ("o={}")
+    ("if(q===undefined)q=0")
+    ("if(q>util.recursionLimit)")
+        ("throw Error(\"max depth exceeded\")")
     ("var d={}");
 
     var repeatedFields = [],

--- a/src/encoder.js
+++ b/src/encoder.js
@@ -16,8 +16,8 @@ var Enum     = require("./enum"),
  */
 function genTypePartial(gen, field, fieldIndex, ref) {
     return field.delimited
-        ? gen("types[%i].encode(%s,w.uint32(%i)).uint32(%i)", fieldIndex, ref, (field.id << 3 | 3) >>> 0, (field.id << 3 | 4) >>> 0)
-        : gen("types[%i].encode(%s,w.uint32(%i).fork()).ldelim()", fieldIndex, ref, (field.id << 3 | 2) >>> 0);
+        ? gen("types[%i].encode(%s,w.uint32(%i),q+1).uint32(%i)", fieldIndex, ref, (field.id << 3 | 3) >>> 0, (field.id << 3 | 4) >>> 0)
+        : gen("types[%i].encode(%s,w.uint32(%i).fork(),q+1).ldelim()", fieldIndex, ref, (field.id << 3 | 2) >>> 0);
 }
 
 /**
@@ -27,9 +27,12 @@ function genTypePartial(gen, field, fieldIndex, ref) {
  */
 function encoder(mtype) {
     /* eslint-disable no-unexpected-multiline, block-scoped-var, no-redeclare */
-    var gen = util.codegen(["m", "w"], mtype.name + "$encode")
+    var gen = util.codegen(["m", "w", "q"], mtype.name + "$encode")
     ("if(!w)")
-        ("w=Writer.create()");
+        ("w=Writer.create()")
+    ("if(q===undefined)q=0")
+    ("if(q>util.recursionLimit)")
+        ("throw Error(\"max depth exceeded\")");
 
     var i, ref;
 
@@ -50,7 +53,7 @@ function encoder(mtype) {
         ("for(var ks=Object.keys(%s),i=0;i<ks.length;++i){", ref)
             ("w.uint32(%i).fork().uint32(%i).%s(ks[i])", (field.id << 3 | 2) >>> 0, 8 | types.mapKey[field.keyType], field.keyType);
             if (wireType === undefined) gen
-            ("types[%i].encode(%s[ks[i]],w.uint32(18).fork()).ldelim().ldelim()", index, ref); // can't be groups
+            ("types[%i].encode(%s[ks[i]],w.uint32(18).fork(),q+1).ldelim().ldelim()", index, ref); // can't be groups
             else gen
             (".uint32(%i).%s(%s[ks[i]]).ldelim()", 16 | wireType, type, ref);
             gen

--- a/src/enum.js
+++ b/src/enum.js
@@ -86,8 +86,8 @@ Enum.prototype._resolveFeatures = function _resolveFeatures(edition) {
     ReflectionObject.prototype._resolveFeatures.call(this, edition);
 
     Object.keys(this.values).forEach(key => {
-        var parentFeaturesCopy = Object.assign({}, this._features);
-        this._valuesFeatures[key] = Object.assign(parentFeaturesCopy, this.valuesOptions && this.valuesOptions[key] && this.valuesOptions[key].features);
+        var parentFeaturesCopy = util.merge({}, this._features);
+        this._valuesFeatures[key] = util.merge(parentFeaturesCopy, this.valuesOptions && this.valuesOptions[key] && this.valuesOptions[key].features || {});
     });
 
     return this;

--- a/src/namespace.js
+++ b/src/namespace.js
@@ -337,6 +337,8 @@ Namespace.prototype.define = function define(path, json) {
         throw TypeError("illegal path");
     if (path && path.length && path[0] === "")
         throw Error("path must be relative");
+    if (path.length > util.recursionLimit)
+        throw Error("max depth exceeded");
 
     var ptr = this;
     while (path.length > 0) {

--- a/src/object.js
+++ b/src/object.js
@@ -213,7 +213,7 @@ ReflectionObject.prototype._resolveFeatures = function _resolveFeatures(edition)
         throw new Error("Unknown edition for " + this.fullName);
     }
 
-    var protoFeatures = Object.assign(this.options ? Object.assign({},  this.options.features) : {},
+    var protoFeatures = util.merge({}, this.options && this.options.features,
         this._inferLegacyProtoFeatures(edition));
 
     if (this._edition) {
@@ -228,7 +228,7 @@ ReflectionObject.prototype._resolveFeatures = function _resolveFeatures(edition)
         } else {
             throw new Error("Unknown edition: " + edition);
         }
-        this._features = Object.assign(defaults, protoFeatures || {});
+        this._features = util.merge(defaults, protoFeatures);
         this._featuresResolved = true;
         return;
     }
@@ -237,13 +237,13 @@ ReflectionObject.prototype._resolveFeatures = function _resolveFeatures(edition)
     // special-case it
     /* istanbul ignore else */
     if (this.partOf instanceof OneOf) {
-        var lexicalParentFeaturesCopy = Object.assign({}, this.partOf._features);
-        this._features = Object.assign(lexicalParentFeaturesCopy, protoFeatures || {});
+        var lexicalParentFeaturesCopy = util.merge({}, this.partOf._features);
+        this._features = util.merge(lexicalParentFeaturesCopy, protoFeatures);
     } else if (this.declaringField) {
         // Skip feature resolution of sister fields.
     } else if (this.parent) {
-        var parentFeaturesCopy = Object.assign({}, this.parent._features);
-        this._features = Object.assign(parentFeaturesCopy, protoFeatures || {});
+        var parentFeaturesCopy = util.merge({}, this.parent._features);
+        this._features = util.merge(parentFeaturesCopy, protoFeatures);
     } else {
         throw new Error("Unable to find a parent for " + this.fullName);
     }

--- a/src/parse.js
+++ b/src/parse.js
@@ -302,7 +302,9 @@ function parse(source, root, options) {
 
 
     function parseCommon(parent, token, depth) {
-        depth = util.checkDepth(depth);
+        if (depth === undefined)
+            depth = 0;
+        // depth is checked by dispatched functions
         switch (token) {
 
             case "option":
@@ -352,7 +354,10 @@ function parse(source, root, options) {
     }
 
     function parseType(parent, token, depth) {
-        depth = util.checkDepth(depth);
+        if (depth === undefined)
+            depth = 0;
+        if (depth > util.nestingLimit)
+            throw Error("max depth exceeded");
 
         /* istanbul ignore if */
         if (!nameRe.test(token = next()))
@@ -478,7 +483,10 @@ function parse(source, root, options) {
     }
 
     function parseGroup(parent, rule, depth) {
-        depth = util.checkDepth(depth);
+        if (depth === undefined)
+            depth = 0;
+        if (depth > util.nestingLimit)
+            throw Error("max depth exceeded");
         if (edition >= 2023) {
             throw illegal("group");
         }
@@ -697,7 +705,10 @@ function parse(source, root, options) {
     }
 
     function parseOptionValue(parent, name, depth) {
-        depth = util.checkDepth(depth);
+        if (depth === undefined)
+            depth = 0;
+        if (depth > util.recursionLimit)
+            throw Error("max depth exceeded");
         // { a: "foo" b { c: "bar" } }
         if (skip("{", true)) {
             var objectResult = {};
@@ -786,7 +797,10 @@ function parse(source, root, options) {
     }
 
     function parseService(parent, token, depth) {
-        depth = util.checkDepth(depth);
+        if (depth === undefined)
+            depth = 0;
+        if (depth > util.recursionLimit)
+            throw Error("max depth exceeded");
 
         /* istanbul ignore if */
         if (!nameRe.test(token = next()))

--- a/src/root.js
+++ b/src/root.js
@@ -138,8 +138,12 @@ Root.prototype.load = function load(filename, options, callback) {
     }
 
     // Processes a single file
-    function process(filename, source) {
+    function process(filename, source, depth) {
+        if (depth === undefined)
+            depth = 0;
         try {
+            if (depth > util.recursionLimit)
+                throw Error("max depth exceeded");
             if (util.isString(source) && source.charAt(0) === "{")
                 source = JSON.parse(source);
             if (!util.isString(source))
@@ -152,11 +156,11 @@ Root.prototype.load = function load(filename, options, callback) {
                 if (parsed.imports)
                     for (; i < parsed.imports.length; ++i)
                         if (resolved = getBundledFileName(parsed.imports[i]) || self.resolvePath(filename, parsed.imports[i]))
-                            fetch(resolved);
+                            fetch(resolved, false, depth + 1);
                 if (parsed.weakImports)
                     for (i = 0; i < parsed.weakImports.length; ++i)
                         if (resolved = getBundledFileName(parsed.weakImports[i]) || self.resolvePath(filename, parsed.weakImports[i]))
-                            fetch(resolved, true);
+                            fetch(resolved, true, depth + 1);
             }
         } catch (err) {
             finish(err);
@@ -167,7 +171,9 @@ Root.prototype.load = function load(filename, options, callback) {
     }
 
     // Fetches a single file
-    function fetch(filename, weak) {
+    function fetch(filename, weak, depth) {
+        if (depth === undefined)
+            depth = 0;
         filename = getBundledFileName(filename) || filename;
 
         // Skip if already loaded / attempted
@@ -179,12 +185,12 @@ Root.prototype.load = function load(filename, options, callback) {
         // Shortcut bundled definitions
         if (filename in common) {
             if (sync) {
-                process(filename, common[filename]);
+                process(filename, common[filename], depth);
             } else {
                 ++queued;
                 setTimeout(function() {
                     --queued;
-                    process(filename, common[filename]);
+                    process(filename, common[filename], depth);
                 });
             }
             return;
@@ -200,7 +206,7 @@ Root.prototype.load = function load(filename, options, callback) {
                     finish(err);
                 return;
             }
-            process(filename, source);
+            process(filename, source, depth);
         } else {
             ++queued;
             self.fetch(filename, function(err, source) {
@@ -217,7 +223,7 @@ Root.prototype.load = function load(filename, options, callback) {
                         finish(null, self);
                     return;
                 }
-                process(filename, source);
+                process(filename, source, depth);
             });
         }
     }

--- a/src/type.js
+++ b/src/type.js
@@ -237,7 +237,10 @@ function clearCache(type) {
  * @returns {Type} Created message type
  */
 Type.fromJSON = function fromJSON(name, json, depth) {
-    depth = util.checkDepth(depth);
+    if (depth === undefined)
+        depth = 0;
+    if (depth > util.nestingLimit)
+        throw Error("max depth exceeded");
     var type = new Type(name, json.options);
     type.extensions = json.extensions;
     type.reserved = json.reserved;
@@ -515,8 +518,8 @@ Type.prototype.setup = function setup() {
  * @param {Writer} [writer] Writer to encode to
  * @returns {Writer} writer
  */
-Type.prototype.encode = function encode_setup(message, writer) {
-    return this.setup().encode(message, writer); // overrides this method
+Type.prototype.encode = function encode_setup(message, writer) { // eslint-disable-line no-unused-vars
+    return this.setup().encode.apply(this, arguments); // overrides this method
 };
 
 /**
@@ -601,8 +604,8 @@ Type.prototype.fromObject = function fromObject(object, depth) {
  * @param {IConversionOptions} [options] Conversion options
  * @returns {Object.<string,*>} Plain object
  */
-Type.prototype.toObject = function toObject(message, options) {
-    return this.setup().toObject(message, options);
+Type.prototype.toObject = function toObject(message, options) { // eslint-disable-line no-unused-vars
+    return this.setup().toObject.apply(this, arguments);
 };
 
 /**

--- a/src/util.js
+++ b/src/util.js
@@ -16,8 +16,7 @@ util.fetch   = require("@protobufjs/fetch");
 util.path    = require("@protobufjs/path");
 util.patterns = require("./util/patterns");
 
-var reservedRe = util.patterns.reservedRe,
-    unsafePropertyRe = util.patterns.unsafePropertyRe;
+var reservedRe = util.patterns.reservedRe;
 
 /**
  * Node's fs module if available.
@@ -192,7 +191,7 @@ util.decorateEnum = function decorateEnum(object) {
 util.setProperty = function setProperty(dst, path, value, ifNotSet) {
     function setProp(dst, path, value) {
         var part = path.shift();
-        if (unsafePropertyRe.test(part))
+        if (util.isUnsafeProperty(part))
             return dst;
         if (path.length > 0) {
             dst[part] = setProp(dst[part] || {}, path, value);
@@ -213,6 +212,8 @@ util.setProperty = function setProperty(dst, path, value, ifNotSet) {
         throw TypeError("path must be specified");
 
     path = path.split(".");
+    if (path.length > util.recursionLimit)
+        throw Error("max depth exceeded");
     return setProp(dst, path, value);
 };
 

--- a/src/util/minimal.js
+++ b/src/util/minimal.js
@@ -26,6 +26,18 @@ util.pool = require("@protobufjs/pool");
 util.LongBits = require("./longbits");
 
 /**
+ * Tests if the specified key can affect object prototypes.
+ * @memberof util
+ * @param {string} key Key to test
+ * @returns {boolean} `true` if the key is unsafe
+ */
+function isUnsafeProperty(key) {
+    return key === "__proto__" || key === "prototype" || key === "constructor";
+}
+
+util.isUnsafeProperty = isUnsafeProperty;
+
+/**
  * Whether running within node or not.
  * @memberof util
  * @type {boolean}
@@ -238,26 +250,39 @@ util.longFromHash = function longFromHash(hash, unsigned) {
  * Merges the properties of the source object into the destination object.
  * @memberof util
  * @param {Object.<string,*>} dst Destination object
- * @param {Object.<string,*>} src Source object
- * @param {boolean} [ifNotSet=false] Merges only if the key is not already set
+ * @param {...(Object.<string,*>|boolean)} src Source objects, optionally followed by an `ifNotSet` flag
  * @returns {Object.<string,*>} Destination object
  */
-function merge(dst, src, ifNotSet) { // used by converters
-    for (var keys = Object.keys(src), i = 0; i < keys.length; ++i)
-        if (dst[keys[i]] === undefined || !ifNotSet)
-            if (keys[i] !== "__proto__")
+function merge(dst) { // used by converters
+    var ifNotSet = typeof arguments[arguments.length - 1] === "boolean",
+        limit = ifNotSet ? arguments.length - 1 : arguments.length;
+    ifNotSet = ifNotSet && arguments[arguments.length - 1];
+    for (var a = 1; a < limit; ++a) {
+        var src = arguments[a];
+        if (!src)
+            continue;
+        for (var keys = Object.keys(src), i = 0; i < keys.length; ++i)
+            if (!isUnsafeProperty(keys[i]) && (dst[keys[i]] === undefined || !ifNotSet))
                 dst[keys[i]] = src[keys[i]];
+    }
     return dst;
 }
 
 util.merge = merge;
 
 /**
+ * Schema declaration nesting limit.
+ * @memberof util
+ * @type {number}
+ */
+util.nestingLimit = 32; // protoc: MaxMessageDeclarationNestingDepth
+
+/**
  * Recursion limit.
  * @memberof util
  * @type {number}
  */
-util.recursionLimit = 100;
+util.recursionLimit = 100; // protoc: CodedInputStream::default_recursion_limit_
 
 /**
  * Makes a property safe for assignment as an own property.

--- a/src/util/patterns.js
+++ b/src/util/patterns.js
@@ -5,4 +5,3 @@ var patterns = exports;
 patterns.numberRe    = /^(?![eE])[0-9]*(?:\.[0-9]*)?(?:[eE][+-]?[0-9]+)?$/;
 patterns.typeRefRe   = /^(?:\.?[a-zA-Z_][a-zA-Z_0-9]*)(?:\.[a-zA-Z_][a-zA-Z_0-9]*)*$/;
 patterns.reservedRe  = /^(?:do|if|in|for|let|new|try|var|case|else|enum|eval|false|null|this|true|void|with|break|catch|class|const|super|throw|while|yield|delete|export|import|public|return|static|switch|typeof|default|extends|finally|package|private|continue|debugger|function|arguments|interface|protected|implements|instanceof)$/;
-patterns.unsafePropertyRe = /^(?:__proto__|prototype|constructor)$/;

--- a/src/wrappers.js
+++ b/src/wrappers.js
@@ -7,7 +7,8 @@
  */
 var wrappers = exports;
 
-var Message = require("./message");
+var Message = require("./message"),
+    util    = require("./util/minimal");
 
 /**
  * From object converter part of an {@link IWrapper}.
@@ -54,10 +55,9 @@ wrappers[".google.protobuf.Any"] = {
                 if (type_url.indexOf("/") === -1) {
                     type_url = "/" + type_url;
                 }
-                var nextDepth = depth === undefined ? 1 : depth + 1;
                 return this.create({
                     type_url: type_url,
-                    value: type.encode(type.fromObject(object, nextDepth)).finish()
+                    value: type.encode(type.fromObject(object, depth === undefined ? 1 : depth + 1)).finish()
                 });
             }
         }
@@ -65,7 +65,11 @@ wrappers[".google.protobuf.Any"] = {
         return this.fromObject(object, depth);
     },
 
-    toObject: function(message, options) {
+    toObject: function(message, options, depth) {
+        if (depth === undefined)
+            depth = 0;
+        if (depth > util.recursionLimit)
+            throw Error("max depth exceeded");
 
         // Default prefix
         var googleApi = "type.googleapis.com/";
@@ -81,12 +85,12 @@ wrappers[".google.protobuf.Any"] = {
             var type = this.lookup(name);
             /* istanbul ignore else */
             if (type)
-                message = type.decode(message.value);
+                message = type.decode(message.value, undefined, undefined, depth + 1);
         }
 
         // wrap value if unmapped
         if (!(message instanceof this.ctor) && message instanceof Message) {
-            var object = message.$type.toObject(message, options);
+            var object = message.$type.toObject(message, options, depth + 1);
             var messageName = message.$type.fullName[0] === "." ?
                 message.$type.fullName.slice(1) : message.$type.fullName;
             // Default to type.googleapis.com prefix if no prefix is used
@@ -98,6 +102,6 @@ wrappers[".google.protobuf.Any"] = {
             return object;
         }
 
-        return this.toObject(message, options);
+        return this.toObject(message, options, depth);
     }
 };

--- a/src/writer.js
+++ b/src/writer.js
@@ -225,7 +225,7 @@ Writer.prototype.uint32 = function write_uint32(value) {
  * @returns {Writer} `this`
  */
 Writer.prototype.int32 = function write_int32(value) {
-    return value < 0
+    return (value |= 0) < 0
         ? this._push(writeVarint64, 10, LongBits.fromNumber(value)) // 10 bytes per spec
         : this.uint32(value);
 };
@@ -240,16 +240,18 @@ Writer.prototype.sint32 = function write_sint32(value) {
 };
 
 function writeVarint64(val, buf, pos) {
-    while (val.hi) {
-        buf[pos++] = val.lo & 127 | 128;
-        val.lo = (val.lo >>> 7 | val.hi << 25) >>> 0;
-        val.hi >>>= 7;
+    var lo = val.lo,
+        hi = val.hi;
+    while (hi) {
+        buf[pos++] = lo & 127 | 128;
+        lo = (lo >>> 7 | hi << 25) >>> 0;
+        hi >>>= 7;
     }
-    while (val.lo > 127) {
-        buf[pos++] = val.lo & 127 | 128;
-        val.lo = val.lo >>> 7;
+    while (lo > 127) {
+        buf[pos++] = lo & 127 | 128;
+        lo = lo >>> 7;
     }
-    buf[pos++] = val.lo;
+    buf[pos++] = lo;
 }
 
 /**

--- a/tests/api_converters.js
+++ b/tests/api_converters.js
@@ -290,6 +290,38 @@ tape.test("converters", function(test) {
             test.end();
         });
 
+        test.test(test.name + " - Type.toObject recursion limit", function(test) {
+            var recursionLimit = protobuf.util.recursionLimit;
+            protobuf.util.recursionLimit = 3;
+            try {
+                var nestedRoot = protobuf.Root.fromJSON({
+                    nested: {
+                        Recursive: {
+                            fields: {
+                                next: {
+                                    type: "Recursive",
+                                    id: 1
+                                }
+                            }
+                        }
+                    }
+                });
+                var Recursive = nestedRoot.lookupType("Recursive");
+                var msg = Recursive.create();
+                var cursor = msg;
+                for (var i = 0; i < 5; ++i)
+                    cursor = cursor.next = Recursive.create();
+
+                test.throws(function() {
+                    Recursive.toObject(msg);
+                }, /max depth exceeded/, "should reject excessive object conversion depth");
+            } finally {
+                protobuf.util.recursionLimit = recursionLimit;
+            }
+
+            test.end();
+        });
+
         test.test(test.name + " - Message#toJSON", function(test) {
             var msg = Message.create();
             msg.$type = {

--- a/tests/api_descriptor.js
+++ b/tests/api_descriptor.js
@@ -1,0 +1,56 @@
+var tape = require("tape");
+
+var protobuf = require(".."),
+    descriptor = require("../ext/descriptor");
+
+tape.test("descriptor nesting", function(test) {
+    function nestedMessageDescriptor(depth) {
+        var root = descriptor.DescriptorProto.create({ name: "Message0" }),
+            nested = root;
+        for (var i = 1; i <= depth; ++i) {
+            var child = descriptor.DescriptorProto.create({ name: "Message" + i });
+            nested.nestedType.push(child);
+            nested = child;
+        }
+        return root;
+    }
+
+    function packageDescriptor(depth) {
+        var packageName = "a";
+        for (var i = 1; i < depth; ++i)
+            packageName += ".a";
+        return descriptor.FileDescriptorSet.create({
+            file: [ descriptor.FileDescriptorProto.create({
+                name: "test.proto",
+                "package": packageName
+            }) ]
+        });
+    }
+
+    var recursionLimit = protobuf.util.recursionLimit,
+        nestingLimit = protobuf.util.nestingLimit;
+    try {
+        protobuf.util.recursionLimit = 100;
+        protobuf.util.nestingLimit = 3;
+        test.doesNotThrow(function() {
+            protobuf.Type.fromDescriptor(nestedMessageDescriptor(3), "proto3");
+        }, "should load descriptor message nesting up to the nesting limit");
+        test.throws(function() {
+            protobuf.Type.fromDescriptor(nestedMessageDescriptor(4), "proto3");
+        }, /max depth exceeded/, "should reject excessively nested descriptor messages");
+
+        protobuf.util.recursionLimit = 3;
+        protobuf.util.nestingLimit = 100;
+        test.doesNotThrow(function() {
+            protobuf.Root.fromDescriptor(packageDescriptor(3));
+        }, "should load descriptor package paths up to the recursion limit");
+        test.throws(function() {
+            protobuf.Root.fromDescriptor(packageDescriptor(4));
+        }, /max depth exceeded/, "should reject excessively nested descriptor package paths");
+    } finally {
+        protobuf.util.recursionLimit = recursionLimit;
+        protobuf.util.nestingLimit = nestingLimit;
+    }
+
+    test.end();
+});

--- a/tests/api_enum.js
+++ b/tests/api_enum.js
@@ -136,6 +136,56 @@ tape.test("feature resolution legacy proto3", function(test) {
     test.end();
 });
 
+tape.test("feature resolution skips unsafe feature keys", function(test) {
+    var enumFeatures = { enum_type: "CLOSED" };
+    Object.defineProperty(enumFeatures, "__proto__", {
+        value: { polluted: true },
+        enumerable: true
+    });
+    enumFeatures.prototype = { polluted: true };
+    enumFeatures.constructor = { polluted: true };
+
+    var valueFeatures = { field_presence: "EXPLICIT" };
+    Object.defineProperty(valueFeatures, "__proto__", {
+        value: { polluted: true },
+        enumerable: true
+    });
+    valueFeatures.prototype = { polluted: true };
+    valueFeatures.constructor = { polluted: true };
+
+    var root = protobuf.Root.fromJSON({
+        nested: {
+            Enum: {
+                edition: "2023",
+                options: { features: enumFeatures },
+                values: {
+                    a: 0
+                },
+                valuesOptions: {
+                    a: {
+                        features: valueFeatures
+                    }
+                }
+            }
+        }
+    }).resolveAll();
+    var Enum = root.lookupEnum("Enum");
+
+    test.equal(Enum._features.enum_type, "CLOSED", "should keep regular enum features");
+    test.equal(Object.getPrototypeOf(Enum._features).polluted, undefined, "should not alter enum feature prototype");
+    test.notOk(Object.prototype.hasOwnProperty.call(Enum._features, "__proto__"), "should skip unsafe enum feature key __proto__");
+    test.notOk(Object.prototype.hasOwnProperty.call(Enum._features, "prototype"), "should skip unsafe enum feature key prototype");
+    test.notOk(Object.prototype.hasOwnProperty.call(Enum._features, "constructor"), "should skip unsafe enum feature key constructor");
+
+    test.equal(Enum._valuesFeatures.a.field_presence, "EXPLICIT", "should keep regular enum value features");
+    test.equal(Object.getPrototypeOf(Enum._valuesFeatures.a).polluted, undefined, "should not alter enum value feature prototype");
+    test.notOk(Object.prototype.hasOwnProperty.call(Enum._valuesFeatures.a, "__proto__"), "should skip unsafe enum value feature key __proto__");
+    test.notOk(Object.prototype.hasOwnProperty.call(Enum._valuesFeatures.a, "prototype"), "should skip unsafe enum value feature key prototype");
+    test.notOk(Object.prototype.hasOwnProperty.call(Enum._valuesFeatures.a, "constructor"), "should skip unsafe enum value feature key constructor");
+
+    test.end();
+});
+
 tape.test("feature resolution proto2", function(test) {
     var json = {
         edition: "proto2",

--- a/tests/api_namespace.js
+++ b/tests/api_namespace.js
@@ -86,6 +86,19 @@ tape.test("reflected namespaces", function(test) {
     var sub = ns.define("sub", {});
     test.equal(ns.lookup("sub"), sub, "should define sub namespaces");
 
+    var recursionLimit = protobuf.util.recursionLimit;
+    protobuf.util.recursionLimit = 3;
+    try {
+        test.doesNotThrow(function() {
+            ns.define("a.b.c");
+        }, "should define namespace paths up to the recursion limit");
+        test.throws(function() {
+            ns.define("a.b.c.d");
+        }, /max depth exceeded/, "should reject excessively nested namespace paths");
+    } finally {
+        protobuf.util.recursionLimit = recursionLimit;
+    }
+
     test.throws(function() {
         ns.add(new protobuf.ReflectionObject("invalid"));
     }, TypeError, "should throw when adding invalid nested objects");
@@ -188,29 +201,51 @@ tape.test("JSON descriptor nesting", function(test) {
         return root;
     }
 
-    var recursionLimit = protobuf.util.recursionLimit;
-    protobuf.util.recursionLimit = 3;
+    function nestedOptionPathDescriptor(depth) {
+        var path = "features";
+        for (var i = 0; i < depth; ++i)
+            path += ".a";
+        var descriptor = { options: {}, nested: {} };
+        descriptor.options[path] = true;
+        return descriptor;
+    }
+
+    var recursionLimit = protobuf.util.recursionLimit,
+        nestingLimit = protobuf.util.nestingLimit;
     try {
+        protobuf.util.recursionLimit = 3;
+        protobuf.util.nestingLimit = 100;
         test.doesNotThrow(function() {
             protobuf.Root.fromJSON(nestedNamespaceDescriptor(3));
         }, "should load namespace descriptors up to the recursion limit");
         test.throws(function() {
             protobuf.Root.fromJSON(nestedNamespaceDescriptor(4));
         }, /max depth exceeded/, "should reject excessively nested namespace descriptors");
+        protobuf.util.recursionLimit = 100;
+        protobuf.util.nestingLimit = 3;
         test.doesNotThrow(function() {
             protobuf.Root.fromJSON(nestedTypeDescriptor(3));
-        }, "should load type descriptors up to the recursion limit");
+        }, "should load type descriptors up to the nesting limit");
         test.throws(function() {
             protobuf.Root.fromJSON(nestedTypeDescriptor(4));
         }, /max depth exceeded/, "should reject excessively nested type descriptors");
+        protobuf.util.recursionLimit = 3;
+        protobuf.util.nestingLimit = 100;
         test.doesNotThrow(function() {
             protobuf.Root.fromJSON(nestedServiceDescriptor(3));
         }, "should load service descriptors up to the recursion limit");
         test.throws(function() {
             protobuf.Root.fromJSON(nestedServiceDescriptor(4));
         }, /max depth exceeded/, "should reject excessively nested service descriptors");
+        test.doesNotThrow(function() {
+            protobuf.Root.fromJSON(nestedOptionPathDescriptor(2));
+        }, "should load option paths up to the recursion limit");
+        test.throws(function() {
+            protobuf.Root.fromJSON(nestedOptionPathDescriptor(3));
+        }, /max depth exceeded/, "should reject excessively nested option paths");
     } finally {
         protobuf.util.recursionLimit = recursionLimit;
+        protobuf.util.nestingLimit = nestingLimit;
     }
 
     test.end();

--- a/tests/api_type.js
+++ b/tests/api_type.js
@@ -186,6 +186,89 @@ tape.test("decode nesting", function(test) {
     test.end();
 });
 
+tape.test("encode nesting", function(test) {
+    function nestedObject(depth, field) {
+        var object = { value: 42 };
+        for (var i = 0; i < depth; ++i) {
+            if (field === "child")
+                object = { child: object };
+            else if (field === "children")
+                object = { children: [ object ] };
+            else
+                object = { childMap: { child: object } };
+        }
+        return object;
+    }
+
+    var root = protobuf.Root.fromJSON({
+        nested: {
+            Node: {
+                fields: {
+                    child: { type: "Node", id: 1 },
+                    children: { rule: "repeated", type: "Node", id: 2 },
+                    childMap: { keyType: "string", type: "Node", id: 3 },
+                    value: { type: "int32", id: 4 }
+                }
+            }
+        }
+    });
+    var Node = root.lookupType("Node");
+    var recursionLimit = protobuf.util.recursionLimit;
+
+    protobuf.util.recursionLimit = 3;
+    try {
+        test.ok(Node.encode(nestedObject(2, "child")).finish().length, "should encode singular messages below the limit");
+        test.throws(function() {
+            Node.encode(nestedObject(4, "child")).finish();
+        }, /max depth exceeded/, "should reject excessive singular message nesting");
+
+        test.ok(Node.encode(nestedObject(2, "children")).finish().length, "should encode repeated messages below the limit");
+        test.throws(function() {
+            Node.encode(nestedObject(4, "children")).finish();
+        }, /max depth exceeded/, "should reject excessive repeated message nesting");
+
+        test.ok(Node.encode(nestedObject(2, "childMap")).finish().length, "should encode map message values below the limit");
+        test.throws(function() {
+            Node.encode(nestedObject(4, "childMap")).finish();
+        }, /max depth exceeded/, "should reject excessive map message value nesting");
+    } finally {
+        protobuf.util.recursionLimit = recursionLimit;
+    }
+
+    test.end();
+});
+
+tape.test("encode setup preserves nesting", function(test) {
+    var root = protobuf.Root.fromJSON({
+        nested: {
+            Parent: {
+                fields: {
+                    child: { type: "Child", id: 1 }
+                }
+            },
+            Child: {
+                fields: {
+                    next: { type: "Child", id: 1 },
+                    value: { type: "int32", id: 2 }
+                }
+            }
+        }
+    });
+    var Parent = root.lookupType("Parent");
+    var recursionLimit = protobuf.util.recursionLimit;
+
+    protobuf.util.recursionLimit = 1;
+    try {
+        test.throws(function() {
+            Parent.encode({ child: { next: { value: 42 } } }).finish();
+        }, /max depth exceeded/, "should preserve depth through nested type setup");
+    } finally {
+        protobuf.util.recursionLimit = recursionLimit;
+    }
+
+    test.end();
+});
+
 tape.test("object conversion nesting", function(test) {
     function nestedObject(depth) {
         var object = { value: 42 };

--- a/tests/api_util.js
+++ b/tests/api_util.js
@@ -16,10 +16,26 @@ tape.test("util", function(test) {
         test.same(o, { a: 2 }, "should merge existing keys");
         util.merge(o, { a: 3 }, true);
         test.same(o, { a: 2 }, "should not merge existing keys");
-        util.merge(o, JSON.parse("{\"__proto__\":{\"marker\":true}}"));
+        util.merge(o, { b: 1 }, { c: 2 });
+        test.same(o, { a: 2, b: 1, c: 2 }, "should merge multiple sources");
+        util.merge(o, { c: 3 }, { d: 4 }, true);
+        test.same(o, { a: 2, b: 1, c: 2, d: 4 }, "should merge multiple sources without overwriting existing keys");
+        util.merge(o, JSON.parse("{\"__proto__\":{\"marker\":true},\"prototype\":{\"marker\":true},\"constructor\":{\"marker\":true}}"));
         test.equal(Object.getPrototypeOf(o), Object.prototype, "should keep the target object shape");
-        test.notOk(Object.prototype.hasOwnProperty.call(o, "__proto__"), "should skip reserved keys");
+        test.notOk(Object.prototype.hasOwnProperty.call(o, "__proto__"), "should skip reserved key __proto__");
+        test.notOk(Object.prototype.hasOwnProperty.call(o, "prototype"), "should skip reserved key prototype");
+        test.notOk(Object.prototype.hasOwnProperty.call(o, "constructor"), "should skip reserved key constructor");
         test.equal(o.marker, undefined, "should not expose skipped values");
+        var guarded = {};
+        var accessed = false;
+        Object.defineProperty(guarded, "constructor", {
+            get: function() {
+                accessed = true;
+            }
+        });
+        util.merge(guarded, { constructor: 1, safe: 2 });
+        test.notOk(accessed, "should skip reserved keys before checking target values");
+        test.equal(guarded.safe, 2, "should still merge regular keys");
         test.end();
     });
 
@@ -99,7 +115,20 @@ tape.test("util", function(test) {
 
         util.setProperty(o, 'prop.subprop', { subsub2: 7});
         test.same(o, {prop1: [5, 6], prop: {subprop: [{subsub: [5,6]}, {subsub2: 7}]}}, "should convert nested properties to array");
-        
+
+        var recursionLimit = util.recursionLimit;
+        util.recursionLimit = 3;
+        try {
+            test.doesNotThrow(function() {
+                util.setProperty({}, 'a.b.c', 1);
+            }, "should set property paths up to the recursion limit");
+            test.throws(function() {
+                util.setProperty({}, 'a.b.c.d', 1);
+            }, /max depth exceeded/, "should reject excessively nested property paths");
+        } finally {
+            util.recursionLimit = recursionLimit;
+        }
+
         util.setProperty({}, "__proto__.test", "value");
         test.is({}.test, undefined);
 

--- a/tests/api_writer-reader.js
+++ b/tests/api_writer-reader.js
@@ -39,6 +39,8 @@ tape.test("writer & reader", function(test) {
     test.ok(expect("uint32", -1 >>> 0, [ 255, 255, 255, 255, 15 ]), "should write -1 as an unsigned varint of length 5");
     test.ok(expect("int32", -1, [ 255, 255, 255, 255, 255, 255, 255, 255, 255, 1 ]), "should write -1 as a signed varint of length 10");
     test.ok(expect("sint32", -1, [ 1 ]), "should write -1 as a signed zig-zag encoded varint of length 1");
+    test.ok(expectCoerced("int32", -0.1, [ 0 ], 0), "should coerce fractional signed varints before sizing");
+    test.ok(expectCoerced("int32", 2147483648, [ 128, 128, 128, 128, 248, 255, 255, 255, 255, 1 ], -2147483648), "should coerce out-of-range signed varints before sizing");
 
     // fixed32, sfixed32
 
@@ -145,6 +147,14 @@ tape.test("writer & reader", function(test) {
       MyMessage.decode(payload);
     }, /maximum nesting depth exceeded/, "limits recursion in reader");
 
+    test.test(test.name + " - repeated finish", function(test) {
+        [ "int32", "uint64", "int64", "sint64" ].forEach(function(type) {
+            var writer = Writer.create()[type](-1);
+            test.same(Array.prototype.slice.call(writer.finish()), Array.prototype.slice.call(writer.finish()), "should preserve " + type + " operation state");
+        });
+        test.end();
+    });
+
     test.end();
 });
 
@@ -189,6 +199,35 @@ function expect(type, value, expected, WriterToTest) {
     // also test browser writer if running under node
     if (WriterToTest !== protobuf.Writer) {
         if (!expect(type, value, expected, Writer)) {
+            console.error("in browser writer");
+            return false;
+        }
+    }
+    return true;
+}
+
+function expectCoerced(type, value, expected, expectedValue, WriterToTest) {
+    if (!WriterToTest)
+        WriterToTest = Writer.create().constructor;
+    var writer = new WriterToTest();
+    var actual = writer[type](value).finish();
+    if (actual.length !== expected.length) {
+        console.error("actual", Array.prototype.slice.call(actual), "!= expected", expected);
+        return false;
+    }
+    for (var i = 0; i < expected.length; ++i)
+        if (actual[i] !== expected[i]) {
+            console.error("actual", Array.prototype.slice.call(actual), "!= expected", expected);
+            return false;
+        }
+    var reader = Reader.create(actual);
+    var actualValue = reader[type]();
+    if (actualValue !== expectedValue) {
+        console.error("actual value", actualValue, "!= expected", expectedValue);
+        return false;
+    }
+    if (WriterToTest !== protobuf.Writer) {
+        if (!expectCoerced(type, value, expected, expectedValue, Writer)) {
             console.error("in browser writer");
             return false;
         }

--- a/tests/comp_google_protobuf_any.js
+++ b/tests/comp_google_protobuf_any.js
@@ -18,12 +18,21 @@ var root = new protobuf.Root().addJSON(protobuf.common["google/protobuf/any.prot
                 type: "string"
             }
         }
+    },
+    Loop: {
+        fields: {
+            next: {
+                id: 1,
+                type: "google.protobuf.Any"
+            }
+        }
     }
 }).resolveAll();
 
 var Any = root.lookupType("protobuf.Any"),
     Foo = root.lookupType(".Foo"),
-    Bar = root.lookupType(".Bar");
+    Bar = root.lookupType(".Bar"),
+    Loop = root.lookupType(".Loop");
 
 tape.test("google.protobuf.Any", function(test) {
 
@@ -59,6 +68,32 @@ tape.test("google.protobuf.Any", function(test) {
     });
     obj = Foo.toObject(baz, { json: true });
     test.same(obj.foo, { "@type": "type.someurl.com/Bar", bar: "a" }, "should keep prefix in type url");
+
+    test.end();
+});
+
+tape.test("google.protobuf.Any - toObject recursion limit", function(test) {
+
+    var recursionLimit = protobuf.util.recursionLimit;
+    protobuf.util.recursionLimit = 3;
+    try {
+        var value = Loop.encode(Loop.create()).finish();
+        for (var i = 0; i < 5; ++i)
+            value = Loop.encode(Loop.create({
+                next: Any.create({
+                    type_url: "type.googleapis.com/Loop",
+                    value: value
+                })
+            })).finish();
+
+        var message = Loop.decode(value);
+
+        test.throws(function() {
+            JSON.stringify(message);
+        }, /max depth exceeded/, "should reject excessive Any JSON expansion depth");
+    } finally {
+        protobuf.util.recursionLimit = recursionLimit;
+    }
 
     test.end();
 });

--- a/tests/comp_parse-uncommon.js
+++ b/tests/comp_parse-uncommon.js
@@ -72,29 +72,65 @@ tape.test("parser nesting", function(test) {
         return source + "}; }";
     }
 
-    var recursionLimit = protobuf.util.recursionLimit;
-    protobuf.util.recursionLimit = 3;
+    function dottedOptionPath(depth) {
+        var source = "syntax = \"proto2\"; message M { optional int32 a = 1 [(.foo)";
+        for (var i = 0; i < depth; ++i)
+            source += ".a";
+        return source + " = 1]; }";
+    }
+
+    function packagePath(depth) {
+        var source = "syntax = \"proto3\"; package a";
+        for (var i = 1; i < depth; ++i)
+            source += ".a";
+        return source + ";";
+    }
+
+    var recursionLimit = protobuf.util.recursionLimit,
+        nestingLimit = protobuf.util.nestingLimit;
     try {
+        protobuf.util.recursionLimit = 100;
+        protobuf.util.nestingLimit = 3;
         test.doesNotThrow(function() {
             protobuf.parse(nestedMessages(3));
-        }, "should parse message nesting up to the recursion limit");
+        }, "should parse message nesting up to the nesting limit");
         test.throws(function() {
             protobuf.parse(nestedMessages(4));
         }, /max depth exceeded/, "should reject excessively nested messages");
+        protobuf.util.recursionLimit = 1;
+        test.doesNotThrow(function() {
+            protobuf.parse(nestedMessages(3));
+        }, "should not apply recursion limit to message declarations");
+        protobuf.util.recursionLimit = 100;
         test.doesNotThrow(function() {
             protobuf.parse(nestedGroups(2));
-        }, "should parse group nesting up to the recursion limit");
+        }, "should parse group nesting up to the nesting limit");
         test.throws(function() {
             protobuf.parse(nestedGroups(3));
         }, /max depth exceeded/, "should reject excessively nested groups");
+        protobuf.util.recursionLimit = 3;
+        protobuf.util.nestingLimit = 100;
         test.doesNotThrow(function() {
             protobuf.parse(nestedOptionValue(3));
         }, "should parse aggregate option nesting up to the recursion limit");
         test.throws(function() {
             protobuf.parse(nestedOptionValue(4));
         }, /max depth exceeded/, "should reject excessively nested aggregate options");
+        test.doesNotThrow(function() {
+            protobuf.parse(dottedOptionPath(3));
+        }, "should parse dotted option paths up to the recursion limit");
+        test.throws(function() {
+            protobuf.parse(dottedOptionPath(4));
+        }, /max depth exceeded/, "should reject excessively nested dotted option paths");
+        test.doesNotThrow(function() {
+            protobuf.parse(packagePath(3));
+        }, "should parse package paths up to the recursion limit");
+        test.throws(function() {
+            protobuf.parse(packagePath(4));
+        }, /max depth exceeded/, "should reject excessively nested package paths");
     } finally {
         protobuf.util.recursionLimit = recursionLimit;
+        protobuf.util.nestingLimit = nestingLimit;
     }
 
     test.end();

--- a/tests/data/comments.js
+++ b/tests/data/comments.js
@@ -83,9 +83,13 @@ $root.Test1 = (function() {
      * @param {$protobuf.Writer} [writer] Writer to encode to
      * @returns {$protobuf.Writer} Writer
      */
-    Test1.encode = function encode(message, writer) {
+    Test1.encode = function encode(message, writer, q) {
         if (!writer)
             writer = $Writer.create();
+        if (q === undefined)
+            q = 0;
+        if (q > $util.recursionLimit)
+            throw Error("max depth exceeded");
         if (message.field1 != null && Object.hasOwnProperty.call(message, "field1"))
             writer.uint32(/* id 1, wireType 2 =*/10).string(message.field1);
         if (message.field2 != null && Object.hasOwnProperty.call(message, "field2"))
@@ -229,9 +233,13 @@ $root.Test1 = (function() {
      * @param {$protobuf.IConversionOptions} [options] Conversion options
      * @returns {Object.<string,*>} Plain object
      */
-    Test1.toObject = function toObject(message, options) {
+    Test1.toObject = function toObject(message, options, q) {
         if (!options)
             options = {};
+        if (q === undefined)
+            q = 0;
+        if (q > $util.recursionLimit)
+            throw Error("max depth exceeded");
         var object = {};
         if (options.defaults) {
             object.field1 = "";
@@ -320,9 +328,13 @@ $root.Test2 = (function() {
      * @param {$protobuf.Writer} [writer] Writer to encode to
      * @returns {$protobuf.Writer} Writer
      */
-    Test2.encode = function encode(message, writer) {
+    Test2.encode = function encode(message, writer, q) {
         if (!writer)
             writer = $Writer.create();
+        if (q === undefined)
+            q = 0;
+        if (q > $util.recursionLimit)
+            throw Error("max depth exceeded");
         return writer;
     };
 

--- a/tests/data/convert.js
+++ b/tests/data/convert.js
@@ -139,9 +139,13 @@ $root.Message = (function() {
      * @param {$protobuf.Writer} [writer] Writer to encode to
      * @returns {$protobuf.Writer} Writer
      */
-    Message.encode = function encode(message, writer) {
+    Message.encode = function encode(message, writer, q) {
         if (!writer)
             writer = $Writer.create();
+        if (q === undefined)
+            q = 0;
+        if (q > $util.recursionLimit)
+            throw Error("max depth exceeded");
         if (message.stringVal != null && Object.hasOwnProperty.call(message, "stringVal"))
             writer.uint32(/* id 1, wireType 2 =*/10).string(message.stringVal);
         if (message.stringRepeated != null && message.stringRepeated.length)
@@ -515,9 +519,13 @@ $root.Message = (function() {
      * @param {$protobuf.IConversionOptions} [options] Conversion options
      * @returns {Object.<string,*>} Plain object
      */
-    Message.toObject = function toObject(message, options) {
+    Message.toObject = function toObject(message, options, q) {
         if (!options)
             options = {};
+        if (q === undefined)
+            q = 0;
+        if (q > $util.recursionLimit)
+            throw Error("max depth exceeded");
         var object = {};
         if (options.arrays || options.defaults) {
             object.stringRepeated = [];

--- a/tests/data/mapbox/vector_tile.js
+++ b/tests/data/mapbox/vector_tile.js
@@ -72,12 +72,16 @@ $root.vector_tile = (function() {
          * @param {$protobuf.Writer} [writer] Writer to encode to
          * @returns {$protobuf.Writer} Writer
          */
-        Tile.encode = function encode(message, writer) {
+        Tile.encode = function encode(message, writer, q) {
             if (!writer)
                 writer = $Writer.create();
+            if (q === undefined)
+                q = 0;
+            if (q > $util.recursionLimit)
+                throw Error("max depth exceeded");
             if (message.layers != null && message.layers.length)
                 for (var i = 0; i < message.layers.length; ++i)
-                    $root.vector_tile.Tile.Layer.encode(message.layers[i], writer.uint32(/* id 3, wireType 2 =*/26).fork()).ldelim();
+                    $root.vector_tile.Tile.Layer.encode(message.layers[i], writer.uint32(/* id 3, wireType 2 =*/26).fork(), q + 1).ldelim();
             return writer;
         };
 
@@ -213,16 +217,20 @@ $root.vector_tile = (function() {
          * @param {$protobuf.IConversionOptions} [options] Conversion options
          * @returns {Object.<string,*>} Plain object
          */
-        Tile.toObject = function toObject(message, options) {
+        Tile.toObject = function toObject(message, options, q) {
             if (!options)
                 options = {};
+            if (q === undefined)
+                q = 0;
+            if (q > $util.recursionLimit)
+                throw Error("max depth exceeded");
             var object = {};
             if (options.arrays || options.defaults)
                 object.layers = [];
             if (message.layers && message.layers.length) {
                 object.layers = [];
                 for (var j = 0; j < message.layers.length; ++j)
-                    object.layers[j] = $root.vector_tile.Tile.Layer.toObject(message.layers[j], options);
+                    object.layers[j] = $root.vector_tile.Tile.Layer.toObject(message.layers[j], options, q + 1);
             }
             return object;
         };
@@ -378,9 +386,13 @@ $root.vector_tile = (function() {
              * @param {$protobuf.Writer} [writer] Writer to encode to
              * @returns {$protobuf.Writer} Writer
              */
-            Value.encode = function encode(message, writer) {
+            Value.encode = function encode(message, writer, q) {
                 if (!writer)
                     writer = $Writer.create();
+                if (q === undefined)
+                    q = 0;
+                if (q > $util.recursionLimit)
+                    throw Error("max depth exceeded");
                 if (message.stringValue != null && Object.hasOwnProperty.call(message, "stringValue"))
                     writer.uint32(/* id 1, wireType 2 =*/10).string(message.stringValue);
                 if (message.floatValue != null && Object.hasOwnProperty.call(message, "floatValue"))
@@ -589,9 +601,13 @@ $root.vector_tile = (function() {
              * @param {$protobuf.IConversionOptions} [options] Conversion options
              * @returns {Object.<string,*>} Plain object
              */
-            Value.toObject = function toObject(message, options) {
+            Value.toObject = function toObject(message, options, q) {
                 if (!options)
                     options = {};
+                if (q === undefined)
+                    q = 0;
+                if (q > $util.recursionLimit)
+                    throw Error("max depth exceeded");
                 var object = {};
                 if (options.defaults) {
                     object.stringValue = "";
@@ -757,9 +773,13 @@ $root.vector_tile = (function() {
              * @param {$protobuf.Writer} [writer] Writer to encode to
              * @returns {$protobuf.Writer} Writer
              */
-            Feature.encode = function encode(message, writer) {
+            Feature.encode = function encode(message, writer, q) {
                 if (!writer)
                     writer = $Writer.create();
+                if (q === undefined)
+                    q = 0;
+                if (q > $util.recursionLimit)
+                    throw Error("max depth exceeded");
                 if (message.id != null && Object.hasOwnProperty.call(message, "id"))
                     writer.uint32(/* id 1, wireType 0 =*/8).uint64(message.id);
                 if (message.tags != null && message.tags.length) {
@@ -990,9 +1010,13 @@ $root.vector_tile = (function() {
              * @param {$protobuf.IConversionOptions} [options] Conversion options
              * @returns {Object.<string,*>} Plain object
              */
-            Feature.toObject = function toObject(message, options) {
+            Feature.toObject = function toObject(message, options, q) {
                 if (!options)
                     options = {};
+                if (q === undefined)
+                    q = 0;
+                if (q > $util.recursionLimit)
+                    throw Error("max depth exceeded");
                 var object = {};
                 if (options.arrays || options.defaults) {
                     object.tags = [];
@@ -1158,19 +1182,23 @@ $root.vector_tile = (function() {
              * @param {$protobuf.Writer} [writer] Writer to encode to
              * @returns {$protobuf.Writer} Writer
              */
-            Layer.encode = function encode(message, writer) {
+            Layer.encode = function encode(message, writer, q) {
                 if (!writer)
                     writer = $Writer.create();
+                if (q === undefined)
+                    q = 0;
+                if (q > $util.recursionLimit)
+                    throw Error("max depth exceeded");
                 writer.uint32(/* id 1, wireType 2 =*/10).string(message.name);
                 if (message.features != null && message.features.length)
                     for (var i = 0; i < message.features.length; ++i)
-                        $root.vector_tile.Tile.Feature.encode(message.features[i], writer.uint32(/* id 2, wireType 2 =*/18).fork()).ldelim();
+                        $root.vector_tile.Tile.Feature.encode(message.features[i], writer.uint32(/* id 2, wireType 2 =*/18).fork(), q + 1).ldelim();
                 if (message.keys != null && message.keys.length)
                     for (var i = 0; i < message.keys.length; ++i)
                         writer.uint32(/* id 3, wireType 2 =*/26).string(message.keys[i]);
                 if (message.values != null && message.values.length)
                     for (var i = 0; i < message.values.length; ++i)
-                        $root.vector_tile.Tile.Value.encode(message.values[i], writer.uint32(/* id 4, wireType 2 =*/34).fork()).ldelim();
+                        $root.vector_tile.Tile.Value.encode(message.values[i], writer.uint32(/* id 4, wireType 2 =*/34).fork(), q + 1).ldelim();
                 if (message.extent != null && Object.hasOwnProperty.call(message, "extent"))
                     writer.uint32(/* id 5, wireType 0 =*/40).uint32(message.extent);
                 writer.uint32(/* id 15, wireType 0 =*/120).uint32(message.version);
@@ -1383,9 +1411,13 @@ $root.vector_tile = (function() {
              * @param {$protobuf.IConversionOptions} [options] Conversion options
              * @returns {Object.<string,*>} Plain object
              */
-            Layer.toObject = function toObject(message, options) {
+            Layer.toObject = function toObject(message, options, q) {
                 if (!options)
                     options = {};
+                if (q === undefined)
+                    q = 0;
+                if (q > $util.recursionLimit)
+                    throw Error("max depth exceeded");
                 var object = {};
                 if (options.arrays || options.defaults) {
                     object.features = [];
@@ -1402,7 +1434,7 @@ $root.vector_tile = (function() {
                 if (message.features && message.features.length) {
                     object.features = [];
                     for (var j = 0; j < message.features.length; ++j)
-                        object.features[j] = $root.vector_tile.Tile.Feature.toObject(message.features[j], options);
+                        object.features[j] = $root.vector_tile.Tile.Feature.toObject(message.features[j], options, q + 1);
                 }
                 if (message.keys && message.keys.length) {
                     object.keys = [];
@@ -1412,7 +1444,7 @@ $root.vector_tile = (function() {
                 if (message.values && message.values.length) {
                     object.values = [];
                     for (var j = 0; j < message.values.length; ++j)
-                        object.values[j] = $root.vector_tile.Tile.Value.toObject(message.values[j], options);
+                        object.values[j] = $root.vector_tile.Tile.Value.toObject(message.values[j], options, q + 1);
                 }
                 if (message.extent != null && message.hasOwnProperty("extent"))
                     object.extent = message.extent;

--- a/tests/data/package.js
+++ b/tests/data/package.js
@@ -212,9 +212,13 @@ $root.Package = (function() {
      * @param {$protobuf.Writer} [writer] Writer to encode to
      * @returns {$protobuf.Writer} Writer
      */
-    Package.encode = function encode(message, writer) {
+    Package.encode = function encode(message, writer, q) {
         if (!writer)
             writer = $Writer.create();
+        if (q === undefined)
+            q = 0;
+        if (q > $util.recursionLimit)
+            throw Error("max depth exceeded");
         if (message.name != null && Object.hasOwnProperty.call(message, "name"))
             writer.uint32(/* id 1, wireType 2 =*/10).string(message.name);
         if (message.version != null && Object.hasOwnProperty.call(message, "version"))
@@ -226,7 +230,7 @@ $root.Package = (function() {
         if (message.license != null && Object.hasOwnProperty.call(message, "license"))
             writer.uint32(/* id 5, wireType 2 =*/42).string(message.license);
         if (message.repository != null && Object.hasOwnProperty.call(message, "repository"))
-            $root.Package.Repository.encode(message.repository, writer.uint32(/* id 6, wireType 2 =*/50).fork()).ldelim();
+            $root.Package.Repository.encode(message.repository, writer.uint32(/* id 6, wireType 2 =*/50).fork(), q + 1).ldelim();
         if (message.bugs != null && Object.hasOwnProperty.call(message, "bugs"))
             writer.uint32(/* id 7, wireType 2 =*/58).string(message.bugs);
         if (message.homepage != null && Object.hasOwnProperty.call(message, "homepage"))
@@ -681,9 +685,13 @@ $root.Package = (function() {
      * @param {$protobuf.IConversionOptions} [options] Conversion options
      * @returns {Object.<string,*>} Plain object
      */
-    Package.toObject = function toObject(message, options) {
+    Package.toObject = function toObject(message, options, q) {
         if (!options)
             options = {};
+        if (q === undefined)
+            q = 0;
+        if (q > $util.recursionLimit)
+            throw Error("max depth exceeded");
         var object = {};
         if (options.arrays || options.defaults) {
             object.keywords = [];
@@ -719,7 +727,7 @@ $root.Package = (function() {
         if (message.license != null && message.hasOwnProperty("license"))
             object.license = message.license;
         if (message.repository != null && message.hasOwnProperty("repository"))
-            object.repository = $root.Package.Repository.toObject(message.repository, options);
+            object.repository = $root.Package.Repository.toObject(message.repository, options, q + 1);
         if (message.bugs != null && message.hasOwnProperty("bugs"))
             object.bugs = message.bugs;
         if (message.homepage != null && message.hasOwnProperty("homepage"))
@@ -864,9 +872,13 @@ $root.Package = (function() {
          * @param {$protobuf.Writer} [writer] Writer to encode to
          * @returns {$protobuf.Writer} Writer
          */
-        Repository.encode = function encode(message, writer) {
+        Repository.encode = function encode(message, writer, q) {
             if (!writer)
                 writer = $Writer.create();
+            if (q === undefined)
+                q = 0;
+            if (q > $util.recursionLimit)
+                throw Error("max depth exceeded");
             if (message.type != null && Object.hasOwnProperty.call(message, "type"))
                 writer.uint32(/* id 1, wireType 2 =*/10).string(message.type);
             if (message.url != null && Object.hasOwnProperty.call(message, "url"))
@@ -999,9 +1011,13 @@ $root.Package = (function() {
          * @param {$protobuf.IConversionOptions} [options] Conversion options
          * @returns {Object.<string,*>} Plain object
          */
-        Repository.toObject = function toObject(message, options) {
+        Repository.toObject = function toObject(message, options, q) {
             if (!options)
                 options = {};
+            if (q === undefined)
+                q = 0;
+            if (q > $util.recursionLimit)
+                throw Error("max depth exceeded");
             var object = {};
             if (options.defaults) {
                 object.type = "";

--- a/tests/data/rpc-es6.js
+++ b/tests/data/rpc-es6.js
@@ -128,9 +128,13 @@ export const MyRequest = $root.MyRequest = (() => {
      * @param {$protobuf.Writer} [writer] Writer to encode to
      * @returns {$protobuf.Writer} Writer
      */
-    MyRequest.encode = function encode(message, writer) {
+    MyRequest.encode = function encode(message, writer, q) {
         if (!writer)
             writer = $Writer.create();
+        if (q === undefined)
+            q = 0;
+        if (q > $util.recursionLimit)
+            throw Error("max depth exceeded");
         if (message.path != null && Object.hasOwnProperty.call(message, "path"))
             writer.uint32(/* id 1, wireType 2 =*/10).string(message.path);
         return writer;
@@ -252,9 +256,13 @@ export const MyRequest = $root.MyRequest = (() => {
      * @param {$protobuf.IConversionOptions} [options] Conversion options
      * @returns {Object.<string,*>} Plain object
      */
-    MyRequest.toObject = function toObject(message, options) {
+    MyRequest.toObject = function toObject(message, options, q) {
         if (!options)
             options = {};
+        if (q === undefined)
+            q = 0;
+        if (q > $util.recursionLimit)
+            throw Error("max depth exceeded");
         let object = {};
         if (options.defaults)
             object.path = "";
@@ -345,9 +353,13 @@ export const MyResponse = $root.MyResponse = (() => {
      * @param {$protobuf.Writer} [writer] Writer to encode to
      * @returns {$protobuf.Writer} Writer
      */
-    MyResponse.encode = function encode(message, writer) {
+    MyResponse.encode = function encode(message, writer, q) {
         if (!writer)
             writer = $Writer.create();
+        if (q === undefined)
+            q = 0;
+        if (q > $util.recursionLimit)
+            throw Error("max depth exceeded");
         if (message.status != null && Object.hasOwnProperty.call(message, "status"))
             writer.uint32(/* id 2, wireType 0 =*/16).int32(message.status);
         return writer;
@@ -469,9 +481,13 @@ export const MyResponse = $root.MyResponse = (() => {
      * @param {$protobuf.IConversionOptions} [options] Conversion options
      * @returns {Object.<string,*>} Plain object
      */
-    MyResponse.toObject = function toObject(message, options) {
+    MyResponse.toObject = function toObject(message, options, q) {
         if (!options)
             options = {};
+        if (q === undefined)
+            q = 0;
+        if (q > $util.recursionLimit)
+            throw Error("max depth exceeded");
         let object = {};
         if (options.defaults)
             object.status = 0;

--- a/tests/data/rpc-reserved.js
+++ b/tests/data/rpc-reserved.js
@@ -130,9 +130,13 @@ $root.MyRequest = (function() {
      * @param {$protobuf.Writer} [writer] Writer to encode to
      * @returns {$protobuf.Writer} Writer
      */
-    MyRequest.encode = function encode(message, writer) {
+    MyRequest.encode = function encode(message, writer, q) {
         if (!writer)
             writer = $Writer.create();
+        if (q === undefined)
+            q = 0;
+        if (q > $util.recursionLimit)
+            throw Error("max depth exceeded");
         if (message.path != null && Object.hasOwnProperty.call(message, "path"))
             writer.uint32(/* id 1, wireType 2 =*/10).string(message.path);
         return writer;
@@ -254,9 +258,13 @@ $root.MyRequest = (function() {
      * @param {$protobuf.IConversionOptions} [options] Conversion options
      * @returns {Object.<string,*>} Plain object
      */
-    MyRequest.toObject = function toObject(message, options) {
+    MyRequest.toObject = function toObject(message, options, q) {
         if (!options)
             options = {};
+        if (q === undefined)
+            q = 0;
+        if (q > $util.recursionLimit)
+            throw Error("max depth exceeded");
         var object = {};
         if (options.defaults)
             object.path = "";
@@ -347,9 +355,13 @@ $root.MyResponse = (function() {
      * @param {$protobuf.Writer} [writer] Writer to encode to
      * @returns {$protobuf.Writer} Writer
      */
-    MyResponse.encode = function encode(message, writer) {
+    MyResponse.encode = function encode(message, writer, q) {
         if (!writer)
             writer = $Writer.create();
+        if (q === undefined)
+            q = 0;
+        if (q > $util.recursionLimit)
+            throw Error("max depth exceeded");
         if (message.status != null && Object.hasOwnProperty.call(message, "status"))
             writer.uint32(/* id 2, wireType 0 =*/16).int32(message.status);
         return writer;
@@ -471,9 +483,13 @@ $root.MyResponse = (function() {
      * @param {$protobuf.IConversionOptions} [options] Conversion options
      * @returns {Object.<string,*>} Plain object
      */
-    MyResponse.toObject = function toObject(message, options) {
+    MyResponse.toObject = function toObject(message, options, q) {
         if (!options)
             options = {};
+        if (q === undefined)
+            q = 0;
+        if (q > $util.recursionLimit)
+            throw Error("max depth exceeded");
         var object = {};
         if (options.defaults)
             object.status = 0;

--- a/tests/data/rpc.js
+++ b/tests/data/rpc.js
@@ -130,9 +130,13 @@ $root.MyRequest = (function() {
      * @param {$protobuf.Writer} [writer] Writer to encode to
      * @returns {$protobuf.Writer} Writer
      */
-    MyRequest.encode = function encode(message, writer) {
+    MyRequest.encode = function encode(message, writer, q) {
         if (!writer)
             writer = $Writer.create();
+        if (q === undefined)
+            q = 0;
+        if (q > $util.recursionLimit)
+            throw Error("max depth exceeded");
         if (message.path != null && Object.hasOwnProperty.call(message, "path"))
             writer.uint32(/* id 1, wireType 2 =*/10).string(message.path);
         return writer;
@@ -254,9 +258,13 @@ $root.MyRequest = (function() {
      * @param {$protobuf.IConversionOptions} [options] Conversion options
      * @returns {Object.<string,*>} Plain object
      */
-    MyRequest.toObject = function toObject(message, options) {
+    MyRequest.toObject = function toObject(message, options, q) {
         if (!options)
             options = {};
+        if (q === undefined)
+            q = 0;
+        if (q > $util.recursionLimit)
+            throw Error("max depth exceeded");
         var object = {};
         if (options.defaults)
             object.path = "";
@@ -347,9 +355,13 @@ $root.MyResponse = (function() {
      * @param {$protobuf.Writer} [writer] Writer to encode to
      * @returns {$protobuf.Writer} Writer
      */
-    MyResponse.encode = function encode(message, writer) {
+    MyResponse.encode = function encode(message, writer, q) {
         if (!writer)
             writer = $Writer.create();
+        if (q === undefined)
+            q = 0;
+        if (q > $util.recursionLimit)
+            throw Error("max depth exceeded");
         if (message.status != null && Object.hasOwnProperty.call(message, "status"))
             writer.uint32(/* id 2, wireType 0 =*/16).int32(message.status);
         return writer;
@@ -471,9 +483,13 @@ $root.MyResponse = (function() {
      * @param {$protobuf.IConversionOptions} [options] Conversion options
      * @returns {Object.<string,*>} Plain object
      */
-    MyResponse.toObject = function toObject(message, options) {
+    MyResponse.toObject = function toObject(message, options, q) {
         if (!options)
             options = {};
+        if (q === undefined)
+            q = 0;
+        if (q > $util.recursionLimit)
+            throw Error("max depth exceeded");
         var object = {};
         if (options.defaults)
             object.status = 0;

--- a/tests/data/test.js
+++ b/tests/data/test.js
@@ -71,9 +71,13 @@ $root.jspb = (function() {
              * @param {$protobuf.Writer} [writer] Writer to encode to
              * @returns {$protobuf.Writer} Writer
              */
-            Empty.encode = function encode(message, writer) {
+            Empty.encode = function encode(message, writer, q) {
                 if (!writer)
                     writer = $Writer.create();
+                if (q === undefined)
+                    q = 0;
+                if (q > $util.recursionLimit)
+                    throw Error("max depth exceeded");
                 return writer;
             };
 
@@ -283,9 +287,13 @@ $root.jspb = (function() {
              * @param {$protobuf.Writer} [writer] Writer to encode to
              * @returns {$protobuf.Writer} Writer
              */
-            EnumContainer.encode = function encode(message, writer) {
+            EnumContainer.encode = function encode(message, writer, q) {
                 if (!writer)
                     writer = $Writer.create();
+                if (q === undefined)
+                    q = 0;
+                if (q > $util.recursionLimit)
+                    throw Error("max depth exceeded");
                 if (message.outerEnum != null && Object.hasOwnProperty.call(message, "outerEnum"))
                     writer.uint32(/* id 1, wireType 0 =*/8).int32(message.outerEnum);
                 return writer;
@@ -426,9 +434,13 @@ $root.jspb = (function() {
              * @param {$protobuf.IConversionOptions} [options] Conversion options
              * @returns {Object.<string,*>} Plain object
              */
-            EnumContainer.toObject = function toObject(message, options) {
+            EnumContainer.toObject = function toObject(message, options, q) {
                 if (!options)
                     options = {};
+                if (q === undefined)
+                    q = 0;
+                if (q > $util.recursionLimit)
+                    throw Error("max depth exceeded");
                 var object = {};
                 if (options.defaults)
                     object.outerEnum = options.enums === String ? "FOO" : 1;
@@ -538,9 +550,13 @@ $root.jspb = (function() {
              * @param {$protobuf.Writer} [writer] Writer to encode to
              * @returns {$protobuf.Writer} Writer
              */
-            Simple1.encode = function encode(message, writer) {
+            Simple1.encode = function encode(message, writer, q) {
                 if (!writer)
                     writer = $Writer.create();
+                if (q === undefined)
+                    q = 0;
+                if (q > $util.recursionLimit)
+                    throw Error("max depth exceeded");
                 writer.uint32(/* id 1, wireType 2 =*/10).string(message.aString);
                 if (message.aRepeatedString != null && message.aRepeatedString.length)
                     for (var i = 0; i < message.aRepeatedString.length; ++i)
@@ -696,9 +712,13 @@ $root.jspb = (function() {
              * @param {$protobuf.IConversionOptions} [options] Conversion options
              * @returns {Object.<string,*>} Plain object
              */
-            Simple1.toObject = function toObject(message, options) {
+            Simple1.toObject = function toObject(message, options, q) {
                 if (!options)
                     options = {};
+                if (q === undefined)
+                    q = 0;
+                if (q > $util.recursionLimit)
+                    throw Error("max depth exceeded");
                 var object = {};
                 if (options.arrays || options.defaults)
                     object.aRepeatedString = [];
@@ -810,9 +830,13 @@ $root.jspb = (function() {
              * @param {$protobuf.Writer} [writer] Writer to encode to
              * @returns {$protobuf.Writer} Writer
              */
-            Simple2.encode = function encode(message, writer) {
+            Simple2.encode = function encode(message, writer, q) {
                 if (!writer)
                     writer = $Writer.create();
+                if (q === undefined)
+                    q = 0;
+                if (q > $util.recursionLimit)
+                    throw Error("max depth exceeded");
                 writer.uint32(/* id 1, wireType 2 =*/10).string(message.aString);
                 if (message.aRepeatedString != null && message.aRepeatedString.length)
                     for (var i = 0; i < message.aRepeatedString.length; ++i)
@@ -957,9 +981,13 @@ $root.jspb = (function() {
              * @param {$protobuf.IConversionOptions} [options] Conversion options
              * @returns {Object.<string,*>} Plain object
              */
-            Simple2.toObject = function toObject(message, options) {
+            Simple2.toObject = function toObject(message, options, q) {
                 if (!options)
                     options = {};
+                if (q === undefined)
+                    q = 0;
+                if (q > $util.recursionLimit)
+                    throw Error("max depth exceeded");
                 var object = {};
                 if (options.arrays || options.defaults)
                     object.aRepeatedString = [];
@@ -1084,9 +1112,13 @@ $root.jspb = (function() {
              * @param {$protobuf.Writer} [writer] Writer to encode to
              * @returns {$protobuf.Writer} Writer
              */
-            SpecialCases.encode = function encode(message, writer) {
+            SpecialCases.encode = function encode(message, writer, q) {
                 if (!writer)
                     writer = $Writer.create();
+                if (q === undefined)
+                    q = 0;
+                if (q > $util.recursionLimit)
+                    throw Error("max depth exceeded");
                 writer.uint32(/* id 1, wireType 2 =*/10).string(message.normal);
                 writer.uint32(/* id 2, wireType 2 =*/18).string(message["default"]);
                 writer.uint32(/* id 3, wireType 2 =*/26).string(message["function"]);
@@ -1241,9 +1273,13 @@ $root.jspb = (function() {
              * @param {$protobuf.IConversionOptions} [options] Conversion options
              * @returns {Object.<string,*>} Plain object
              */
-            SpecialCases.toObject = function toObject(message, options) {
+            SpecialCases.toObject = function toObject(message, options, q) {
                 if (!options)
                     options = {};
+                if (q === undefined)
+                    q = 0;
+                if (q > $util.recursionLimit)
+                    throw Error("max depth exceeded");
                 var object = {};
                 if (options.defaults) {
                     object.normal = "";
@@ -1382,17 +1418,21 @@ $root.jspb = (function() {
              * @param {$protobuf.Writer} [writer] Writer to encode to
              * @returns {$protobuf.Writer} Writer
              */
-            OptionalFields.encode = function encode(message, writer) {
+            OptionalFields.encode = function encode(message, writer, q) {
                 if (!writer)
                     writer = $Writer.create();
+                if (q === undefined)
+                    q = 0;
+                if (q > $util.recursionLimit)
+                    throw Error("max depth exceeded");
                 if (message.aString != null && Object.hasOwnProperty.call(message, "aString"))
                     writer.uint32(/* id 1, wireType 2 =*/10).string(message.aString);
                 writer.uint32(/* id 2, wireType 0 =*/16).bool(message.aBool);
                 if (message.aNestedMessage != null && Object.hasOwnProperty.call(message, "aNestedMessage"))
-                    $root.jspb.test.OptionalFields.Nested.encode(message.aNestedMessage, writer.uint32(/* id 3, wireType 2 =*/26).fork()).ldelim();
+                    $root.jspb.test.OptionalFields.Nested.encode(message.aNestedMessage, writer.uint32(/* id 3, wireType 2 =*/26).fork(), q + 1).ldelim();
                 if (message.aRepeatedMessage != null && message.aRepeatedMessage.length)
                     for (var i = 0; i < message.aRepeatedMessage.length; ++i)
-                        $root.jspb.test.OptionalFields.Nested.encode(message.aRepeatedMessage[i], writer.uint32(/* id 4, wireType 2 =*/34).fork()).ldelim();
+                        $root.jspb.test.OptionalFields.Nested.encode(message.aRepeatedMessage[i], writer.uint32(/* id 4, wireType 2 =*/34).fork(), q + 1).ldelim();
                 if (message.aRepeatedString != null && message.aRepeatedString.length)
                     for (var i = 0; i < message.aRepeatedString.length; ++i)
                         writer.uint32(/* id 5, wireType 2 =*/42).string(message.aRepeatedString[i]);
@@ -1584,9 +1624,13 @@ $root.jspb = (function() {
              * @param {$protobuf.IConversionOptions} [options] Conversion options
              * @returns {Object.<string,*>} Plain object
              */
-            OptionalFields.toObject = function toObject(message, options) {
+            OptionalFields.toObject = function toObject(message, options, q) {
                 if (!options)
                     options = {};
+                if (q === undefined)
+                    q = 0;
+                if (q > $util.recursionLimit)
+                    throw Error("max depth exceeded");
                 var object = {};
                 if (options.arrays || options.defaults) {
                     object.aRepeatedMessage = [];
@@ -1602,11 +1646,11 @@ $root.jspb = (function() {
                 if (message.aBool != null && message.hasOwnProperty("aBool"))
                     object.aBool = message.aBool;
                 if (message.aNestedMessage != null && message.hasOwnProperty("aNestedMessage"))
-                    object.aNestedMessage = $root.jspb.test.OptionalFields.Nested.toObject(message.aNestedMessage, options);
+                    object.aNestedMessage = $root.jspb.test.OptionalFields.Nested.toObject(message.aNestedMessage, options, q + 1);
                 if (message.aRepeatedMessage && message.aRepeatedMessage.length) {
                     object.aRepeatedMessage = [];
                     for (var j = 0; j < message.aRepeatedMessage.length; ++j)
-                        object.aRepeatedMessage[j] = $root.jspb.test.OptionalFields.Nested.toObject(message.aRepeatedMessage[j], options);
+                        object.aRepeatedMessage[j] = $root.jspb.test.OptionalFields.Nested.toObject(message.aRepeatedMessage[j], options, q + 1);
                 }
                 if (message.aRepeatedString && message.aRepeatedString.length) {
                     object.aRepeatedString = [];
@@ -1695,9 +1739,13 @@ $root.jspb = (function() {
                  * @param {$protobuf.Writer} [writer] Writer to encode to
                  * @returns {$protobuf.Writer} Writer
                  */
-                Nested.encode = function encode(message, writer) {
+                Nested.encode = function encode(message, writer, q) {
                     if (!writer)
                         writer = $Writer.create();
+                    if (q === undefined)
+                        q = 0;
+                    if (q > $util.recursionLimit)
+                        throw Error("max depth exceeded");
                     if (message.anInt != null && Object.hasOwnProperty.call(message, "anInt"))
                         writer.uint32(/* id 1, wireType 0 =*/8).int32(message.anInt);
                     return writer;
@@ -1819,9 +1867,13 @@ $root.jspb = (function() {
                  * @param {$protobuf.IConversionOptions} [options] Conversion options
                  * @returns {Object.<string,*>} Plain object
                  */
-                Nested.toObject = function toObject(message, options) {
+                Nested.toObject = function toObject(message, options, q) {
                     if (!options)
                         options = {};
+                    if (q === undefined)
+                        q = 0;
+                    if (q > $util.recursionLimit)
+                        throw Error("max depth exceeded");
                     var object = {};
                     if (options.defaults)
                         object.anInt = 0;
@@ -1989,9 +2041,13 @@ $root.jspb = (function() {
              * @param {$protobuf.Writer} [writer] Writer to encode to
              * @returns {$protobuf.Writer} Writer
              */
-            HasExtensions.encode = function encode(message, writer) {
+            HasExtensions.encode = function encode(message, writer, q) {
                 if (!writer)
                     writer = $Writer.create();
+                if (q === undefined)
+                    q = 0;
+                if (q > $util.recursionLimit)
+                    throw Error("max depth exceeded");
                 if (message.str1 != null && Object.hasOwnProperty.call(message, "str1"))
                     writer.uint32(/* id 1, wireType 2 =*/10).string(message.str1);
                 if (message.str2 != null && Object.hasOwnProperty.call(message, "str2"))
@@ -1999,9 +2055,9 @@ $root.jspb = (function() {
                 if (message.str3 != null && Object.hasOwnProperty.call(message, "str3"))
                     writer.uint32(/* id 3, wireType 2 =*/26).string(message.str3);
                 if (message[".jspb.test.IsExtension.extField"] != null && Object.hasOwnProperty.call(message, ".jspb.test.IsExtension.extField"))
-                    $root.jspb.test.IsExtension.encode(message[".jspb.test.IsExtension.extField"], writer.uint32(/* id 100, wireType 2 =*/802).fork()).ldelim();
+                    $root.jspb.test.IsExtension.encode(message[".jspb.test.IsExtension.extField"], writer.uint32(/* id 100, wireType 2 =*/802).fork(), q + 1).ldelim();
                 if (message[".jspb.test.IndirectExtension.simple"] != null && Object.hasOwnProperty.call(message, ".jspb.test.IndirectExtension.simple"))
-                    $root.jspb.test.Simple1.encode(message[".jspb.test.IndirectExtension.simple"], writer.uint32(/* id 101, wireType 2 =*/810).fork()).ldelim();
+                    $root.jspb.test.Simple1.encode(message[".jspb.test.IndirectExtension.simple"], writer.uint32(/* id 101, wireType 2 =*/810).fork(), q + 1).ldelim();
                 if (message[".jspb.test.IndirectExtension.str"] != null && Object.hasOwnProperty.call(message, ".jspb.test.IndirectExtension.str"))
                     writer.uint32(/* id 102, wireType 2 =*/818).string(message[".jspb.test.IndirectExtension.str"]);
                 if (message[".jspb.test.IndirectExtension.repeatedStr"] != null && message[".jspb.test.IndirectExtension.repeatedStr"].length)
@@ -2009,9 +2065,9 @@ $root.jspb = (function() {
                         writer.uint32(/* id 103, wireType 2 =*/826).string(message[".jspb.test.IndirectExtension.repeatedStr"][i]);
                 if (message[".jspb.test.IndirectExtension.repeatedSimple"] != null && message[".jspb.test.IndirectExtension.repeatedSimple"].length)
                     for (var i = 0; i < message[".jspb.test.IndirectExtension.repeatedSimple"].length; ++i)
-                        $root.jspb.test.Simple1.encode(message[".jspb.test.IndirectExtension.repeatedSimple"][i], writer.uint32(/* id 104, wireType 2 =*/834).fork()).ldelim();
+                        $root.jspb.test.Simple1.encode(message[".jspb.test.IndirectExtension.repeatedSimple"][i], writer.uint32(/* id 104, wireType 2 =*/834).fork(), q + 1).ldelim();
                 if (message[".jspb.test.simple1"] != null && Object.hasOwnProperty.call(message, ".jspb.test.simple1"))
-                    $root.jspb.test.Simple1.encode(message[".jspb.test.simple1"], writer.uint32(/* id 105, wireType 2 =*/842).fork()).ldelim();
+                    $root.jspb.test.Simple1.encode(message[".jspb.test.simple1"], writer.uint32(/* id 105, wireType 2 =*/842).fork(), q + 1).ldelim();
                 return writer;
             };
 
@@ -2245,9 +2301,13 @@ $root.jspb = (function() {
              * @param {$protobuf.IConversionOptions} [options] Conversion options
              * @returns {Object.<string,*>} Plain object
              */
-            HasExtensions.toObject = function toObject(message, options) {
+            HasExtensions.toObject = function toObject(message, options, q) {
                 if (!options)
                     options = {};
+                if (q === undefined)
+                    q = 0;
+                if (q > $util.recursionLimit)
+                    throw Error("max depth exceeded");
                 var object = {};
                 if (options.arrays || options.defaults) {
                     object[".jspb.test.IndirectExtension.repeatedStr"] = [];
@@ -2269,9 +2329,9 @@ $root.jspb = (function() {
                 if (message.str3 != null && message.hasOwnProperty("str3"))
                     object.str3 = message.str3;
                 if (message[".jspb.test.IsExtension.extField"] != null && message.hasOwnProperty(".jspb.test.IsExtension.extField"))
-                    object[".jspb.test.IsExtension.extField"] = $root.jspb.test.IsExtension.toObject(message[".jspb.test.IsExtension.extField"], options);
+                    object[".jspb.test.IsExtension.extField"] = $root.jspb.test.IsExtension.toObject(message[".jspb.test.IsExtension.extField"], options, q + 1);
                 if (message[".jspb.test.IndirectExtension.simple"] != null && message.hasOwnProperty(".jspb.test.IndirectExtension.simple"))
-                    object[".jspb.test.IndirectExtension.simple"] = $root.jspb.test.Simple1.toObject(message[".jspb.test.IndirectExtension.simple"], options);
+                    object[".jspb.test.IndirectExtension.simple"] = $root.jspb.test.Simple1.toObject(message[".jspb.test.IndirectExtension.simple"], options, q + 1);
                 if (message[".jspb.test.IndirectExtension.str"] != null && message.hasOwnProperty(".jspb.test.IndirectExtension.str"))
                     object[".jspb.test.IndirectExtension.str"] = message[".jspb.test.IndirectExtension.str"];
                 if (message[".jspb.test.IndirectExtension.repeatedStr"] && message[".jspb.test.IndirectExtension.repeatedStr"].length) {
@@ -2282,10 +2342,10 @@ $root.jspb = (function() {
                 if (message[".jspb.test.IndirectExtension.repeatedSimple"] && message[".jspb.test.IndirectExtension.repeatedSimple"].length) {
                     object[".jspb.test.IndirectExtension.repeatedSimple"] = [];
                     for (var j = 0; j < message[".jspb.test.IndirectExtension.repeatedSimple"].length; ++j)
-                        object[".jspb.test.IndirectExtension.repeatedSimple"][j] = $root.jspb.test.Simple1.toObject(message[".jspb.test.IndirectExtension.repeatedSimple"][j], options);
+                        object[".jspb.test.IndirectExtension.repeatedSimple"][j] = $root.jspb.test.Simple1.toObject(message[".jspb.test.IndirectExtension.repeatedSimple"][j], options, q + 1);
                 }
                 if (message[".jspb.test.simple1"] != null && message.hasOwnProperty(".jspb.test.simple1"))
-                    object[".jspb.test.simple1"] = $root.jspb.test.Simple1.toObject(message[".jspb.test.simple1"], options);
+                    object[".jspb.test.simple1"] = $root.jspb.test.Simple1.toObject(message[".jspb.test.simple1"], options, q + 1);
                 return object;
             };
 
@@ -2409,15 +2469,19 @@ $root.jspb = (function() {
              * @param {$protobuf.Writer} [writer] Writer to encode to
              * @returns {$protobuf.Writer} Writer
              */
-            Complex.encode = function encode(message, writer) {
+            Complex.encode = function encode(message, writer, q) {
                 if (!writer)
                     writer = $Writer.create();
+                if (q === undefined)
+                    q = 0;
+                if (q > $util.recursionLimit)
+                    throw Error("max depth exceeded");
                 writer.uint32(/* id 1, wireType 2 =*/10).string(message.aString);
                 if (message.aNestedMessage != null && Object.hasOwnProperty.call(message, "aNestedMessage"))
-                    $root.jspb.test.Complex.Nested.encode(message.aNestedMessage, writer.uint32(/* id 4, wireType 2 =*/34).fork()).ldelim();
+                    $root.jspb.test.Complex.Nested.encode(message.aNestedMessage, writer.uint32(/* id 4, wireType 2 =*/34).fork(), q + 1).ldelim();
                 if (message.aRepeatedMessage != null && message.aRepeatedMessage.length)
                     for (var i = 0; i < message.aRepeatedMessage.length; ++i)
-                        $root.jspb.test.Complex.Nested.encode(message.aRepeatedMessage[i], writer.uint32(/* id 5, wireType 2 =*/42).fork()).ldelim();
+                        $root.jspb.test.Complex.Nested.encode(message.aRepeatedMessage[i], writer.uint32(/* id 5, wireType 2 =*/42).fork(), q + 1).ldelim();
                 if (message.aRepeatedString != null && message.aRepeatedString.length)
                     for (var i = 0; i < message.aRepeatedString.length; ++i)
                         writer.uint32(/* id 7, wireType 2 =*/58).string(message.aRepeatedString[i]);
@@ -2611,9 +2675,13 @@ $root.jspb = (function() {
              * @param {$protobuf.IConversionOptions} [options] Conversion options
              * @returns {Object.<string,*>} Plain object
              */
-            Complex.toObject = function toObject(message, options) {
+            Complex.toObject = function toObject(message, options, q) {
                 if (!options)
                     options = {};
+                if (q === undefined)
+                    q = 0;
+                if (q > $util.recursionLimit)
+                    throw Error("max depth exceeded");
                 var object = {};
                 if (options.arrays || options.defaults) {
                     object.aRepeatedMessage = [];
@@ -2627,11 +2695,11 @@ $root.jspb = (function() {
                 if (message.aString != null && message.hasOwnProperty("aString"))
                     object.aString = message.aString;
                 if (message.aNestedMessage != null && message.hasOwnProperty("aNestedMessage"))
-                    object.aNestedMessage = $root.jspb.test.Complex.Nested.toObject(message.aNestedMessage, options);
+                    object.aNestedMessage = $root.jspb.test.Complex.Nested.toObject(message.aNestedMessage, options, q + 1);
                 if (message.aRepeatedMessage && message.aRepeatedMessage.length) {
                     object.aRepeatedMessage = [];
                     for (var j = 0; j < message.aRepeatedMessage.length; ++j)
-                        object.aRepeatedMessage[j] = $root.jspb.test.Complex.Nested.toObject(message.aRepeatedMessage[j], options);
+                        object.aRepeatedMessage[j] = $root.jspb.test.Complex.Nested.toObject(message.aRepeatedMessage[j], options, q + 1);
                 }
                 if (message.aRepeatedString && message.aRepeatedString.length) {
                     object.aRepeatedString = [];
@@ -2722,9 +2790,13 @@ $root.jspb = (function() {
                  * @param {$protobuf.Writer} [writer] Writer to encode to
                  * @returns {$protobuf.Writer} Writer
                  */
-                Nested.encode = function encode(message, writer) {
+                Nested.encode = function encode(message, writer, q) {
                     if (!writer)
                         writer = $Writer.create();
+                    if (q === undefined)
+                        q = 0;
+                    if (q > $util.recursionLimit)
+                        throw Error("max depth exceeded");
                     writer.uint32(/* id 2, wireType 0 =*/16).int32(message.anInt);
                     return writer;
                 };
@@ -2846,9 +2918,13 @@ $root.jspb = (function() {
                  * @param {$protobuf.IConversionOptions} [options] Conversion options
                  * @returns {Object.<string,*>} Plain object
                  */
-                Nested.toObject = function toObject(message, options) {
+                Nested.toObject = function toObject(message, options, q) {
                     if (!options)
                         options = {};
+                    if (q === undefined)
+                        q = 0;
+                    if (q > $util.recursionLimit)
+                        throw Error("max depth exceeded");
                     var object = {};
                     if (options.defaults)
                         object.anInt = 0;
@@ -2933,9 +3009,13 @@ $root.jspb = (function() {
              * @param {$protobuf.Writer} [writer] Writer to encode to
              * @returns {$protobuf.Writer} Writer
              */
-            OuterMessage.encode = function encode(message, writer) {
+            OuterMessage.encode = function encode(message, writer, q) {
                 if (!writer)
                     writer = $Writer.create();
+                if (q === undefined)
+                    q = 0;
+                if (q > $util.recursionLimit)
+                    throw Error("max depth exceeded");
                 return writer;
             };
 
@@ -3128,9 +3208,13 @@ $root.jspb = (function() {
                  * @param {$protobuf.Writer} [writer] Writer to encode to
                  * @returns {$protobuf.Writer} Writer
                  */
-                Complex.encode = function encode(message, writer) {
+                Complex.encode = function encode(message, writer, q) {
                     if (!writer)
                         writer = $Writer.create();
+                    if (q === undefined)
+                        q = 0;
+                    if (q > $util.recursionLimit)
+                        throw Error("max depth exceeded");
                     if (message.innerComplexField != null && Object.hasOwnProperty.call(message, "innerComplexField"))
                         writer.uint32(/* id 1, wireType 0 =*/8).int32(message.innerComplexField);
                     return writer;
@@ -3252,9 +3336,13 @@ $root.jspb = (function() {
                  * @param {$protobuf.IConversionOptions} [options] Conversion options
                  * @returns {Object.<string,*>} Plain object
                  */
-                Complex.toObject = function toObject(message, options) {
+                Complex.toObject = function toObject(message, options, q) {
                     if (!options)
                         options = {};
+                    if (q === undefined)
+                        q = 0;
+                    if (q > $util.recursionLimit)
+                        throw Error("max depth exceeded");
                     var object = {};
                     if (options.defaults)
                         object.innerComplexField = 0;
@@ -3348,9 +3436,13 @@ $root.jspb = (function() {
              * @param {$protobuf.Writer} [writer] Writer to encode to
              * @returns {$protobuf.Writer} Writer
              */
-            IsExtension.encode = function encode(message, writer) {
+            IsExtension.encode = function encode(message, writer, q) {
                 if (!writer)
                     writer = $Writer.create();
+                if (q === undefined)
+                    q = 0;
+                if (q > $util.recursionLimit)
+                    throw Error("max depth exceeded");
                 if (message.ext1 != null && Object.hasOwnProperty.call(message, "ext1"))
                     writer.uint32(/* id 1, wireType 2 =*/10).string(message.ext1);
                 return writer;
@@ -3472,9 +3564,13 @@ $root.jspb = (function() {
              * @param {$protobuf.IConversionOptions} [options] Conversion options
              * @returns {Object.<string,*>} Plain object
              */
-            IsExtension.toObject = function toObject(message, options) {
+            IsExtension.toObject = function toObject(message, options, q) {
                 if (!options)
                     options = {};
+                if (q === undefined)
+                    q = 0;
+                if (q > $util.recursionLimit)
+                    throw Error("max depth exceeded");
                 var object = {};
                 if (options.defaults)
                     object.ext1 = "";
@@ -3556,9 +3652,13 @@ $root.jspb = (function() {
              * @param {$protobuf.Writer} [writer] Writer to encode to
              * @returns {$protobuf.Writer} Writer
              */
-            IndirectExtension.encode = function encode(message, writer) {
+            IndirectExtension.encode = function encode(message, writer, q) {
                 if (!writer)
                     writer = $Writer.create();
+                if (q === undefined)
+                    q = 0;
+                if (q > $util.recursionLimit)
+                    throw Error("max depth exceeded");
                 return writer;
             };
 
@@ -3799,9 +3899,13 @@ $root.jspb = (function() {
              * @param {$protobuf.Writer} [writer] Writer to encode to
              * @returns {$protobuf.Writer} Writer
              */
-            DefaultValues.encode = function encode(message, writer) {
+            DefaultValues.encode = function encode(message, writer, q) {
                 if (!writer)
                     writer = $Writer.create();
+                if (q === undefined)
+                    q = 0;
+                if (q > $util.recursionLimit)
+                    throw Error("max depth exceeded");
                 if (message.stringField != null && Object.hasOwnProperty.call(message, "stringField"))
                     writer.uint32(/* id 1, wireType 2 =*/10).string(message.stringField);
                 if (message.boolField != null && Object.hasOwnProperty.call(message, "boolField"))
@@ -4007,9 +4111,13 @@ $root.jspb = (function() {
              * @param {$protobuf.IConversionOptions} [options] Conversion options
              * @returns {Object.<string,*>} Plain object
              */
-            DefaultValues.toObject = function toObject(message, options) {
+            DefaultValues.toObject = function toObject(message, options, q) {
                 if (!options)
                     options = {};
+                if (q === undefined)
+                    q = 0;
+                if (q > $util.recursionLimit)
+                    throw Error("max depth exceeded");
                 var object = {};
                 if (options.defaults) {
                     object.stringField = "default<>abc";
@@ -4214,9 +4322,13 @@ $root.jspb = (function() {
              * @param {$protobuf.Writer} [writer] Writer to encode to
              * @returns {$protobuf.Writer} Writer
              */
-            FloatingPointFields.encode = function encode(message, writer) {
+            FloatingPointFields.encode = function encode(message, writer, q) {
                 if (!writer)
                     writer = $Writer.create();
+                if (q === undefined)
+                    q = 0;
+                if (q > $util.recursionLimit)
+                    throw Error("max depth exceeded");
                 if (message.optionalFloatField != null && Object.hasOwnProperty.call(message, "optionalFloatField"))
                     writer.uint32(/* id 1, wireType 5 =*/13).float(message.optionalFloatField);
                 writer.uint32(/* id 2, wireType 5 =*/21).float(message.requiredFloatField);
@@ -4449,9 +4561,13 @@ $root.jspb = (function() {
              * @param {$protobuf.IConversionOptions} [options] Conversion options
              * @returns {Object.<string,*>} Plain object
              */
-            FloatingPointFields.toObject = function toObject(message, options) {
+            FloatingPointFields.toObject = function toObject(message, options, q) {
                 if (!options)
                     options = {};
+                if (q === undefined)
+                    q = 0;
+                if (q > $util.recursionLimit)
+                    throw Error("max depth exceeded");
                 var object = {};
                 if (options.arrays || options.defaults) {
                     object.repeatedFloatField = [];
@@ -4618,22 +4734,26 @@ $root.jspb = (function() {
              * @param {$protobuf.Writer} [writer] Writer to encode to
              * @returns {$protobuf.Writer} Writer
              */
-            TestClone.encode = function encode(message, writer) {
+            TestClone.encode = function encode(message, writer, q) {
                 if (!writer)
                     writer = $Writer.create();
+                if (q === undefined)
+                    q = 0;
+                if (q > $util.recursionLimit)
+                    throw Error("max depth exceeded");
                 if (message.str != null && Object.hasOwnProperty.call(message, "str"))
                     writer.uint32(/* id 1, wireType 2 =*/10).string(message.str);
                 if (message.simple1 != null && Object.hasOwnProperty.call(message, "simple1"))
-                    $root.jspb.test.Simple1.encode(message.simple1, writer.uint32(/* id 3, wireType 2 =*/26).fork()).ldelim();
+                    $root.jspb.test.Simple1.encode(message.simple1, writer.uint32(/* id 3, wireType 2 =*/26).fork(), q + 1).ldelim();
                 if (message.simple2 != null && message.simple2.length)
                     for (var i = 0; i < message.simple2.length; ++i)
-                        $root.jspb.test.Simple1.encode(message.simple2[i], writer.uint32(/* id 5, wireType 2 =*/42).fork()).ldelim();
+                        $root.jspb.test.Simple1.encode(message.simple2[i], writer.uint32(/* id 5, wireType 2 =*/42).fork(), q + 1).ldelim();
                 if (message.bytesField != null && Object.hasOwnProperty.call(message, "bytesField"))
                     writer.uint32(/* id 6, wireType 2 =*/50).bytes(message.bytesField);
                 if (message.unused != null && Object.hasOwnProperty.call(message, "unused"))
                     writer.uint32(/* id 7, wireType 2 =*/58).string(message.unused);
                 if (message[".jspb.test.CloneExtension.extField"] != null && Object.hasOwnProperty.call(message, ".jspb.test.CloneExtension.extField"))
-                    $root.jspb.test.CloneExtension.encode(message[".jspb.test.CloneExtension.extField"], writer.uint32(/* id 100, wireType 2 =*/802).fork()).ldelim();
+                    $root.jspb.test.CloneExtension.encode(message[".jspb.test.CloneExtension.extField"], writer.uint32(/* id 100, wireType 2 =*/802).fork(), q + 1).ldelim();
                 return writer;
             };
 
@@ -4827,9 +4947,13 @@ $root.jspb = (function() {
              * @param {$protobuf.IConversionOptions} [options] Conversion options
              * @returns {Object.<string,*>} Plain object
              */
-            TestClone.toObject = function toObject(message, options) {
+            TestClone.toObject = function toObject(message, options, q) {
                 if (!options)
                     options = {};
+                if (q === undefined)
+                    q = 0;
+                if (q > $util.recursionLimit)
+                    throw Error("max depth exceeded");
                 var object = {};
                 if (options.arrays || options.defaults)
                     object.simple2 = [];
@@ -4849,18 +4973,18 @@ $root.jspb = (function() {
                 if (message.str != null && message.hasOwnProperty("str"))
                     object.str = message.str;
                 if (message.simple1 != null && message.hasOwnProperty("simple1"))
-                    object.simple1 = $root.jspb.test.Simple1.toObject(message.simple1, options);
+                    object.simple1 = $root.jspb.test.Simple1.toObject(message.simple1, options, q + 1);
                 if (message.simple2 && message.simple2.length) {
                     object.simple2 = [];
                     for (var j = 0; j < message.simple2.length; ++j)
-                        object.simple2[j] = $root.jspb.test.Simple1.toObject(message.simple2[j], options);
+                        object.simple2[j] = $root.jspb.test.Simple1.toObject(message.simple2[j], options, q + 1);
                 }
                 if (message.bytesField != null && message.hasOwnProperty("bytesField"))
                     object.bytesField = options.bytes === String ? $util.base64.encode(message.bytesField, 0, message.bytesField.length) : options.bytes === Array ? Array.prototype.slice.call(message.bytesField) : message.bytesField;
                 if (message.unused != null && message.hasOwnProperty("unused"))
                     object.unused = message.unused;
                 if (message[".jspb.test.CloneExtension.extField"] != null && message.hasOwnProperty(".jspb.test.CloneExtension.extField"))
-                    object[".jspb.test.CloneExtension.extField"] = $root.jspb.test.CloneExtension.toObject(message[".jspb.test.CloneExtension.extField"], options);
+                    object[".jspb.test.CloneExtension.extField"] = $root.jspb.test.CloneExtension.toObject(message[".jspb.test.CloneExtension.extField"], options, q + 1);
                 return object;
             };
 
@@ -4946,9 +5070,13 @@ $root.jspb = (function() {
              * @param {$protobuf.Writer} [writer] Writer to encode to
              * @returns {$protobuf.Writer} Writer
              */
-            CloneExtension.encode = function encode(message, writer) {
+            CloneExtension.encode = function encode(message, writer, q) {
                 if (!writer)
                     writer = $Writer.create();
+                if (q === undefined)
+                    q = 0;
+                if (q > $util.recursionLimit)
+                    throw Error("max depth exceeded");
                 if (message.ext != null && Object.hasOwnProperty.call(message, "ext"))
                     writer.uint32(/* id 2, wireType 2 =*/18).string(message.ext);
                 return writer;
@@ -5070,9 +5198,13 @@ $root.jspb = (function() {
              * @param {$protobuf.IConversionOptions} [options] Conversion options
              * @returns {Object.<string,*>} Plain object
              */
-            CloneExtension.toObject = function toObject(message, options) {
+            CloneExtension.toObject = function toObject(message, options, q) {
                 if (!options)
                     options = {};
+                if (q === undefined)
+                    q = 0;
+                if (q > $util.recursionLimit)
+                    throw Error("max depth exceeded");
                 var object = {};
                 if (options.defaults)
                     object.ext = "";
@@ -5227,24 +5359,28 @@ $root.jspb = (function() {
              * @param {$protobuf.Writer} [writer] Writer to encode to
              * @returns {$protobuf.Writer} Writer
              */
-            TestGroup.encode = function encode(message, writer) {
+            TestGroup.encode = function encode(message, writer, q) {
                 if (!writer)
                     writer = $Writer.create();
+                if (q === undefined)
+                    q = 0;
+                if (q > $util.recursionLimit)
+                    throw Error("max depth exceeded");
                 if (message.repeatedGroup != null && message.repeatedGroup.length)
                     for (var i = 0; i < message.repeatedGroup.length; ++i)
-                        $root.jspb.test.TestGroup.RepeatedGroup.encode(message.repeatedGroup[i], writer.uint32(/* id 1, wireType 3 =*/11)).uint32(/* id 1, wireType 4 =*/12);
-                $root.jspb.test.TestGroup.RequiredGroup.encode(message.requiredGroup, writer.uint32(/* id 2, wireType 3 =*/19)).uint32(/* id 2, wireType 4 =*/20);
+                        $root.jspb.test.TestGroup.RepeatedGroup.encode(message.repeatedGroup[i], writer.uint32(/* id 1, wireType 3 =*/11), q + 1).uint32(/* id 1, wireType 4 =*/12);
+                $root.jspb.test.TestGroup.RequiredGroup.encode(message.requiredGroup, writer.uint32(/* id 2, wireType 3 =*/19), q + 1).uint32(/* id 2, wireType 4 =*/20);
                 if (message.optionalGroup != null && Object.hasOwnProperty.call(message, "optionalGroup"))
-                    $root.jspb.test.TestGroup.OptionalGroup.encode(message.optionalGroup, writer.uint32(/* id 3, wireType 3 =*/27)).uint32(/* id 3, wireType 4 =*/28);
+                    $root.jspb.test.TestGroup.OptionalGroup.encode(message.optionalGroup, writer.uint32(/* id 3, wireType 3 =*/27), q + 1).uint32(/* id 3, wireType 4 =*/28);
                 if (message.messageInGroup != null && Object.hasOwnProperty.call(message, "messageInGroup"))
-                    $root.jspb.test.TestGroup.MessageInGroup.encode(message.messageInGroup, writer.uint32(/* id 4, wireType 3 =*/35)).uint32(/* id 4, wireType 4 =*/36);
+                    $root.jspb.test.TestGroup.MessageInGroup.encode(message.messageInGroup, writer.uint32(/* id 4, wireType 3 =*/35), q + 1).uint32(/* id 4, wireType 4 =*/36);
                 if (message.enumInGroup != null && Object.hasOwnProperty.call(message, "enumInGroup"))
-                    $root.jspb.test.TestGroup.EnumInGroup.encode(message.enumInGroup, writer.uint32(/* id 5, wireType 3 =*/43)).uint32(/* id 5, wireType 4 =*/44);
+                    $root.jspb.test.TestGroup.EnumInGroup.encode(message.enumInGroup, writer.uint32(/* id 5, wireType 3 =*/43), q + 1).uint32(/* id 5, wireType 4 =*/44);
                 if (message.id != null && Object.hasOwnProperty.call(message, "id"))
                     writer.uint32(/* id 6, wireType 2 =*/50).string(message.id);
-                $root.jspb.test.Simple2.encode(message.requiredSimple, writer.uint32(/* id 7, wireType 2 =*/58).fork()).ldelim();
+                $root.jspb.test.Simple2.encode(message.requiredSimple, writer.uint32(/* id 7, wireType 2 =*/58).fork(), q + 1).ldelim();
                 if (message.optionalSimple != null && Object.hasOwnProperty.call(message, "optionalSimple"))
-                    $root.jspb.test.Simple2.encode(message.optionalSimple, writer.uint32(/* id 8, wireType 2 =*/66).fork()).ldelim();
+                    $root.jspb.test.Simple2.encode(message.optionalSimple, writer.uint32(/* id 8, wireType 2 =*/66).fork(), q + 1).ldelim();
                 return writer;
             };
 
@@ -5477,9 +5613,13 @@ $root.jspb = (function() {
              * @param {$protobuf.IConversionOptions} [options] Conversion options
              * @returns {Object.<string,*>} Plain object
              */
-            TestGroup.toObject = function toObject(message, options) {
+            TestGroup.toObject = function toObject(message, options, q) {
                 if (!options)
                     options = {};
+                if (q === undefined)
+                    q = 0;
+                if (q > $util.recursionLimit)
+                    throw Error("max depth exceeded");
                 var object = {};
                 if (options.arrays || options.defaults)
                     object.repeatedGroup = [];
@@ -5495,22 +5635,22 @@ $root.jspb = (function() {
                 if (message.repeatedGroup && message.repeatedGroup.length) {
                     object.repeatedGroup = [];
                     for (var j = 0; j < message.repeatedGroup.length; ++j)
-                        object.repeatedGroup[j] = $root.jspb.test.TestGroup.RepeatedGroup.toObject(message.repeatedGroup[j], options);
+                        object.repeatedGroup[j] = $root.jspb.test.TestGroup.RepeatedGroup.toObject(message.repeatedGroup[j], options, q + 1);
                 }
                 if (message.requiredGroup != null && message.hasOwnProperty("requiredGroup"))
-                    object.requiredGroup = $root.jspb.test.TestGroup.RequiredGroup.toObject(message.requiredGroup, options);
+                    object.requiredGroup = $root.jspb.test.TestGroup.RequiredGroup.toObject(message.requiredGroup, options, q + 1);
                 if (message.optionalGroup != null && message.hasOwnProperty("optionalGroup"))
-                    object.optionalGroup = $root.jspb.test.TestGroup.OptionalGroup.toObject(message.optionalGroup, options);
+                    object.optionalGroup = $root.jspb.test.TestGroup.OptionalGroup.toObject(message.optionalGroup, options, q + 1);
                 if (message.messageInGroup != null && message.hasOwnProperty("messageInGroup"))
-                    object.messageInGroup = $root.jspb.test.TestGroup.MessageInGroup.toObject(message.messageInGroup, options);
+                    object.messageInGroup = $root.jspb.test.TestGroup.MessageInGroup.toObject(message.messageInGroup, options, q + 1);
                 if (message.enumInGroup != null && message.hasOwnProperty("enumInGroup"))
-                    object.enumInGroup = $root.jspb.test.TestGroup.EnumInGroup.toObject(message.enumInGroup, options);
+                    object.enumInGroup = $root.jspb.test.TestGroup.EnumInGroup.toObject(message.enumInGroup, options, q + 1);
                 if (message.id != null && message.hasOwnProperty("id"))
                     object.id = message.id;
                 if (message.requiredSimple != null && message.hasOwnProperty("requiredSimple"))
-                    object.requiredSimple = $root.jspb.test.Simple2.toObject(message.requiredSimple, options);
+                    object.requiredSimple = $root.jspb.test.Simple2.toObject(message.requiredSimple, options, q + 1);
                 if (message.optionalSimple != null && message.hasOwnProperty("optionalSimple"))
-                    object.optionalSimple = $root.jspb.test.Simple2.toObject(message.optionalSimple, options);
+                    object.optionalSimple = $root.jspb.test.Simple2.toObject(message.optionalSimple, options, q + 1);
                 return object;
             };
 
@@ -5603,9 +5743,13 @@ $root.jspb = (function() {
                  * @param {$protobuf.Writer} [writer] Writer to encode to
                  * @returns {$protobuf.Writer} Writer
                  */
-                RepeatedGroup.encode = function encode(message, writer) {
+                RepeatedGroup.encode = function encode(message, writer, q) {
                     if (!writer)
                         writer = $Writer.create();
+                    if (q === undefined)
+                        q = 0;
+                    if (q > $util.recursionLimit)
+                        throw Error("max depth exceeded");
                     writer.uint32(/* id 1, wireType 2 =*/10).string(message.id);
                     if (message.someBool != null && message.someBool.length)
                         for (var i = 0; i < message.someBool.length; ++i)
@@ -5755,9 +5899,13 @@ $root.jspb = (function() {
                  * @param {$protobuf.IConversionOptions} [options] Conversion options
                  * @returns {Object.<string,*>} Plain object
                  */
-                RepeatedGroup.toObject = function toObject(message, options) {
+                RepeatedGroup.toObject = function toObject(message, options, q) {
                     if (!options)
                         options = {};
+                    if (q === undefined)
+                        q = 0;
+                    if (q > $util.recursionLimit)
+                        throw Error("max depth exceeded");
                     var object = {};
                     if (options.arrays || options.defaults)
                         object.someBool = [];
@@ -5855,9 +6003,13 @@ $root.jspb = (function() {
                  * @param {$protobuf.Writer} [writer] Writer to encode to
                  * @returns {$protobuf.Writer} Writer
                  */
-                RequiredGroup.encode = function encode(message, writer) {
+                RequiredGroup.encode = function encode(message, writer, q) {
                     if (!writer)
                         writer = $Writer.create();
+                    if (q === undefined)
+                        q = 0;
+                    if (q > $util.recursionLimit)
+                        throw Error("max depth exceeded");
                     writer.uint32(/* id 1, wireType 2 =*/10).string(message.id);
                     return writer;
                 };
@@ -5979,9 +6131,13 @@ $root.jspb = (function() {
                  * @param {$protobuf.IConversionOptions} [options] Conversion options
                  * @returns {Object.<string,*>} Plain object
                  */
-                RequiredGroup.toObject = function toObject(message, options) {
+                RequiredGroup.toObject = function toObject(message, options, q) {
                     if (!options)
                         options = {};
+                    if (q === undefined)
+                        q = 0;
+                    if (q > $util.recursionLimit)
+                        throw Error("max depth exceeded");
                     var object = {};
                     if (options.defaults)
                         object.id = "";
@@ -6072,9 +6228,13 @@ $root.jspb = (function() {
                  * @param {$protobuf.Writer} [writer] Writer to encode to
                  * @returns {$protobuf.Writer} Writer
                  */
-                OptionalGroup.encode = function encode(message, writer) {
+                OptionalGroup.encode = function encode(message, writer, q) {
                     if (!writer)
                         writer = $Writer.create();
+                    if (q === undefined)
+                        q = 0;
+                    if (q > $util.recursionLimit)
+                        throw Error("max depth exceeded");
                     writer.uint32(/* id 1, wireType 2 =*/10).string(message.id);
                     return writer;
                 };
@@ -6196,9 +6356,13 @@ $root.jspb = (function() {
                  * @param {$protobuf.IConversionOptions} [options] Conversion options
                  * @returns {Object.<string,*>} Plain object
                  */
-                OptionalGroup.toObject = function toObject(message, options) {
+                OptionalGroup.toObject = function toObject(message, options, q) {
                     if (!options)
                         options = {};
+                    if (q === undefined)
+                        q = 0;
+                    if (q > $util.recursionLimit)
+                        throw Error("max depth exceeded");
                     var object = {};
                     if (options.defaults)
                         object.id = "";
@@ -6289,10 +6453,14 @@ $root.jspb = (function() {
                  * @param {$protobuf.Writer} [writer] Writer to encode to
                  * @returns {$protobuf.Writer} Writer
                  */
-                MessageInGroup.encode = function encode(message, writer) {
+                MessageInGroup.encode = function encode(message, writer, q) {
                     if (!writer)
                         writer = $Writer.create();
-                    $root.jspb.test.TestGroup.MessageInGroup.NestedMessage.encode(message.id, writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
+                    if (q === undefined)
+                        q = 0;
+                    if (q > $util.recursionLimit)
+                        throw Error("max depth exceeded");
+                    $root.jspb.test.TestGroup.MessageInGroup.NestedMessage.encode(message.id, writer.uint32(/* id 1, wireType 2 =*/10).fork(), q + 1).ldelim();
                     return writer;
                 };
 
@@ -6419,14 +6587,18 @@ $root.jspb = (function() {
                  * @param {$protobuf.IConversionOptions} [options] Conversion options
                  * @returns {Object.<string,*>} Plain object
                  */
-                MessageInGroup.toObject = function toObject(message, options) {
+                MessageInGroup.toObject = function toObject(message, options, q) {
                     if (!options)
                         options = {};
+                    if (q === undefined)
+                        q = 0;
+                    if (q > $util.recursionLimit)
+                        throw Error("max depth exceeded");
                     var object = {};
                     if (options.defaults)
                         object.id = null;
                     if (message.id != null && message.hasOwnProperty("id"))
-                        object.id = $root.jspb.test.TestGroup.MessageInGroup.NestedMessage.toObject(message.id, options);
+                        object.id = $root.jspb.test.TestGroup.MessageInGroup.NestedMessage.toObject(message.id, options, q + 1);
                     return object;
                 };
 
@@ -6509,9 +6681,13 @@ $root.jspb = (function() {
                      * @param {$protobuf.Writer} [writer] Writer to encode to
                      * @returns {$protobuf.Writer} Writer
                      */
-                    NestedMessage.encode = function encode(message, writer) {
+                    NestedMessage.encode = function encode(message, writer, q) {
                         if (!writer)
                             writer = $Writer.create();
+                        if (q === undefined)
+                            q = 0;
+                        if (q > $util.recursionLimit)
+                            throw Error("max depth exceeded");
                         if (message.id != null && Object.hasOwnProperty.call(message, "id"))
                             writer.uint32(/* id 1, wireType 2 =*/10).string(message.id);
                         return writer;
@@ -6633,9 +6809,13 @@ $root.jspb = (function() {
                      * @param {$protobuf.IConversionOptions} [options] Conversion options
                      * @returns {Object.<string,*>} Plain object
                      */
-                    NestedMessage.toObject = function toObject(message, options) {
+                    NestedMessage.toObject = function toObject(message, options, q) {
                         if (!options)
                             options = {};
+                        if (q === undefined)
+                            q = 0;
+                        if (q > $util.recursionLimit)
+                            throw Error("max depth exceeded");
                         var object = {};
                         if (options.defaults)
                             object.id = "";
@@ -6729,9 +6909,13 @@ $root.jspb = (function() {
                  * @param {$protobuf.Writer} [writer] Writer to encode to
                  * @returns {$protobuf.Writer} Writer
                  */
-                EnumInGroup.encode = function encode(message, writer) {
+                EnumInGroup.encode = function encode(message, writer, q) {
                     if (!writer)
                         writer = $Writer.create();
+                    if (q === undefined)
+                        q = 0;
+                    if (q > $util.recursionLimit)
+                        throw Error("max depth exceeded");
                     writer.uint32(/* id 1, wireType 0 =*/8).int32(message.id);
                     return writer;
                 };
@@ -6872,9 +7056,13 @@ $root.jspb = (function() {
                  * @param {$protobuf.IConversionOptions} [options] Conversion options
                  * @returns {Object.<string,*>} Plain object
                  */
-                EnumInGroup.toObject = function toObject(message, options) {
+                EnumInGroup.toObject = function toObject(message, options, q) {
                     if (!options)
                         options = {};
+                    if (q === undefined)
+                        q = 0;
+                    if (q > $util.recursionLimit)
+                        throw Error("max depth exceeded");
                     var object = {};
                     if (options.defaults)
                         object.id = options.enums === String ? "first" : 0;
@@ -6982,11 +7170,15 @@ $root.jspb = (function() {
              * @param {$protobuf.Writer} [writer] Writer to encode to
              * @returns {$protobuf.Writer} Writer
              */
-            TestGroup1.encode = function encode(message, writer) {
+            TestGroup1.encode = function encode(message, writer, q) {
                 if (!writer)
                     writer = $Writer.create();
+                if (q === undefined)
+                    q = 0;
+                if (q > $util.recursionLimit)
+                    throw Error("max depth exceeded");
                 if (message.group != null && Object.hasOwnProperty.call(message, "group"))
-                    $root.jspb.test.TestGroup.RepeatedGroup.encode(message.group, writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
+                    $root.jspb.test.TestGroup.RepeatedGroup.encode(message.group, writer.uint32(/* id 1, wireType 2 =*/10).fork(), q + 1).ldelim();
                 return writer;
             };
 
@@ -7111,14 +7303,18 @@ $root.jspb = (function() {
              * @param {$protobuf.IConversionOptions} [options] Conversion options
              * @returns {Object.<string,*>} Plain object
              */
-            TestGroup1.toObject = function toObject(message, options) {
+            TestGroup1.toObject = function toObject(message, options, q) {
                 if (!options)
                     options = {};
+                if (q === undefined)
+                    q = 0;
+                if (q > $util.recursionLimit)
+                    throw Error("max depth exceeded");
                 var object = {};
                 if (options.defaults)
                     object.group = null;
                 if (message.group != null && message.hasOwnProperty("group"))
-                    object.group = $root.jspb.test.TestGroup.RepeatedGroup.toObject(message.group, options);
+                    object.group = $root.jspb.test.TestGroup.RepeatedGroup.toObject(message.group, options, q + 1);
                 return object;
             };
 
@@ -7213,9 +7409,13 @@ $root.jspb = (function() {
              * @param {$protobuf.Writer} [writer] Writer to encode to
              * @returns {$protobuf.Writer} Writer
              */
-            TestReservedNames.encode = function encode(message, writer) {
+            TestReservedNames.encode = function encode(message, writer, q) {
                 if (!writer)
                     writer = $Writer.create();
+                if (q === undefined)
+                    q = 0;
+                if (q > $util.recursionLimit)
+                    throw Error("max depth exceeded");
                 if (message.extension != null && Object.hasOwnProperty.call(message, "extension"))
                     writer.uint32(/* id 1, wireType 0 =*/8).int32(message.extension);
                 if (message[".jspb.test.TestReservedNamesExtension.foo"] != null && Object.hasOwnProperty.call(message, ".jspb.test.TestReservedNamesExtension.foo"))
@@ -7348,9 +7548,13 @@ $root.jspb = (function() {
              * @param {$protobuf.IConversionOptions} [options] Conversion options
              * @returns {Object.<string,*>} Plain object
              */
-            TestReservedNames.toObject = function toObject(message, options) {
+            TestReservedNames.toObject = function toObject(message, options, q) {
                 if (!options)
                     options = {};
+                if (q === undefined)
+                    q = 0;
+                if (q > $util.recursionLimit)
+                    throw Error("max depth exceeded");
                 var object = {};
                 if (options.defaults) {
                     object.extension = 0;
@@ -7436,9 +7640,13 @@ $root.jspb = (function() {
              * @param {$protobuf.Writer} [writer] Writer to encode to
              * @returns {$protobuf.Writer} Writer
              */
-            TestReservedNamesExtension.encode = function encode(message, writer) {
+            TestReservedNamesExtension.encode = function encode(message, writer, q) {
                 if (!writer)
                     writer = $Writer.create();
+                if (q === undefined)
+                    q = 0;
+                if (q > $util.recursionLimit)
+                    throw Error("max depth exceeded");
                 return writer;
             };
 
@@ -7763,15 +7971,19 @@ $root.jspb = (function() {
              * @param {$protobuf.Writer} [writer] Writer to encode to
              * @returns {$protobuf.Writer} Writer
              */
-            TestMessageWithOneof.encode = function encode(message, writer) {
+            TestMessageWithOneof.encode = function encode(message, writer, q) {
                 if (!writer)
                     writer = $Writer.create();
+                if (q === undefined)
+                    q = 0;
+                if (q > $util.recursionLimit)
+                    throw Error("max depth exceeded");
                 if (message.pone != null && Object.hasOwnProperty.call(message, "pone"))
                     writer.uint32(/* id 3, wireType 2 =*/26).string(message.pone);
                 if (message.pthree != null && Object.hasOwnProperty.call(message, "pthree"))
                     writer.uint32(/* id 5, wireType 2 =*/42).string(message.pthree);
                 if (message.rone != null && Object.hasOwnProperty.call(message, "rone"))
-                    $root.jspb.test.TestMessageWithOneof.encode(message.rone, writer.uint32(/* id 6, wireType 2 =*/50).fork()).ldelim();
+                    $root.jspb.test.TestMessageWithOneof.encode(message.rone, writer.uint32(/* id 6, wireType 2 =*/50).fork(), q + 1).ldelim();
                 if (message.rtwo != null && Object.hasOwnProperty.call(message, "rtwo"))
                     writer.uint32(/* id 7, wireType 2 =*/58).string(message.rtwo);
                 if (message.normalField != null && Object.hasOwnProperty.call(message, "normalField"))
@@ -8029,9 +8241,13 @@ $root.jspb = (function() {
              * @param {$protobuf.IConversionOptions} [options] Conversion options
              * @returns {Object.<string,*>} Plain object
              */
-            TestMessageWithOneof.toObject = function toObject(message, options) {
+            TestMessageWithOneof.toObject = function toObject(message, options, q) {
                 if (!options)
                     options = {};
+                if (q === undefined)
+                    q = 0;
+                if (q > $util.recursionLimit)
+                    throw Error("max depth exceeded");
                 var object = {};
                 if (options.arrays || options.defaults)
                     object.repeatedField = [];
@@ -8048,7 +8264,7 @@ $root.jspb = (function() {
                         object.partialOneof = "pthree";
                 }
                 if (message.rone != null && message.hasOwnProperty("rone")) {
-                    object.rone = $root.jspb.test.TestMessageWithOneof.toObject(message.rone, options);
+                    object.rone = $root.jspb.test.TestMessageWithOneof.toObject(message.rone, options, q + 1);
                     if (options.oneofs)
                         object.recursiveOneof = "rone";
                 }
@@ -8178,9 +8394,13 @@ $root.jspb = (function() {
              * @param {$protobuf.Writer} [writer] Writer to encode to
              * @returns {$protobuf.Writer} Writer
              */
-            TestEndsWithBytes.encode = function encode(message, writer) {
+            TestEndsWithBytes.encode = function encode(message, writer, q) {
                 if (!writer)
                     writer = $Writer.create();
+                if (q === undefined)
+                    q = 0;
+                if (q > $util.recursionLimit)
+                    throw Error("max depth exceeded");
                 if (message.value != null && Object.hasOwnProperty.call(message, "value"))
                     writer.uint32(/* id 1, wireType 0 =*/8).int32(message.value);
                 if (message.data != null && Object.hasOwnProperty.call(message, "data"))
@@ -8316,9 +8536,13 @@ $root.jspb = (function() {
              * @param {$protobuf.IConversionOptions} [options] Conversion options
              * @returns {Object.<string,*>} Plain object
              */
-            TestEndsWithBytes.toObject = function toObject(message, options) {
+            TestEndsWithBytes.toObject = function toObject(message, options, q) {
                 if (!options)
                     options = {};
+                if (q === undefined)
+                    q = 0;
+                if (q > $util.recursionLimit)
+                    throw Error("max depth exceeded");
                 var object = {};
                 if (options.defaults) {
                     object.value = 0;
@@ -8529,9 +8753,13 @@ $root.jspb = (function() {
              * @param {$protobuf.Writer} [writer] Writer to encode to
              * @returns {$protobuf.Writer} Writer
              */
-            TestMapFieldsNoBinary.encode = function encode(message, writer) {
+            TestMapFieldsNoBinary.encode = function encode(message, writer, q) {
                 if (!writer)
                     writer = $Writer.create();
+                if (q === undefined)
+                    q = 0;
+                if (q > $util.recursionLimit)
+                    throw Error("max depth exceeded");
                 if (message.mapStringString != null && Object.hasOwnProperty.call(message, "mapStringString"))
                     for (var keys = Object.keys(message.mapStringString), i = 0; i < keys.length; ++i)
                         writer.uint32(/* id 1, wireType 2 =*/10).fork().uint32(/* id 1, wireType 2 =*/10).string(keys[i]).uint32(/* id 2, wireType 2 =*/18).string(message.mapStringString[keys[i]]).ldelim();
@@ -8553,7 +8781,7 @@ $root.jspb = (function() {
                 if (message.mapStringMsg != null && Object.hasOwnProperty.call(message, "mapStringMsg"))
                     for (var keys = Object.keys(message.mapStringMsg), i = 0; i < keys.length; ++i) {
                         writer.uint32(/* id 7, wireType 2 =*/58).fork().uint32(/* id 1, wireType 2 =*/10).string(keys[i]);
-                        $root.jspb.test.MapValueMessageNoBinary.encode(message.mapStringMsg[keys[i]], writer.uint32(/* id 2, wireType 2 =*/18).fork()).ldelim().ldelim();
+                        $root.jspb.test.MapValueMessageNoBinary.encode(message.mapStringMsg[keys[i]], writer.uint32(/* id 2, wireType 2 =*/18).fork(), q + 1).ldelim().ldelim();
                     }
                 if (message.mapInt32String != null && Object.hasOwnProperty.call(message, "mapInt32String"))
                     for (var keys = Object.keys(message.mapInt32String), i = 0; i < keys.length; ++i)
@@ -8565,11 +8793,11 @@ $root.jspb = (function() {
                     for (var keys = Object.keys(message.mapBoolString), i = 0; i < keys.length; ++i)
                         writer.uint32(/* id 10, wireType 2 =*/82).fork().uint32(/* id 1, wireType 0 =*/8).bool(keys[i]).uint32(/* id 2, wireType 2 =*/18).string(message.mapBoolString[keys[i]]).ldelim();
                 if (message.testMapFields != null && Object.hasOwnProperty.call(message, "testMapFields"))
-                    $root.jspb.test.TestMapFieldsNoBinary.encode(message.testMapFields, writer.uint32(/* id 11, wireType 2 =*/90).fork()).ldelim();
+                    $root.jspb.test.TestMapFieldsNoBinary.encode(message.testMapFields, writer.uint32(/* id 11, wireType 2 =*/90).fork(), q + 1).ldelim();
                 if (message.mapStringTestmapfields != null && Object.hasOwnProperty.call(message, "mapStringTestmapfields"))
                     for (var keys = Object.keys(message.mapStringTestmapfields), i = 0; i < keys.length; ++i) {
                         writer.uint32(/* id 12, wireType 2 =*/98).fork().uint32(/* id 1, wireType 2 =*/10).string(keys[i]);
-                        $root.jspb.test.TestMapFieldsNoBinary.encode(message.mapStringTestmapfields[keys[i]], writer.uint32(/* id 2, wireType 2 =*/18).fork()).ldelim().ldelim();
+                        $root.jspb.test.TestMapFieldsNoBinary.encode(message.mapStringTestmapfields[keys[i]], writer.uint32(/* id 2, wireType 2 =*/18).fork(), q + 1).ldelim().ldelim();
                     }
                 return writer;
             };
@@ -9211,9 +9439,13 @@ $root.jspb = (function() {
              * @param {$protobuf.IConversionOptions} [options] Conversion options
              * @returns {Object.<string,*>} Plain object
              */
-            TestMapFieldsNoBinary.toObject = function toObject(message, options) {
+            TestMapFieldsNoBinary.toObject = function toObject(message, options, q) {
                 if (!options)
                     options = {};
+                if (q === undefined)
+                    q = 0;
+                if (q > $util.recursionLimit)
+                    throw Error("max depth exceeded");
                 var object = {};
                 if (options.objects || options.defaults) {
                     object.mapStringString = {};
@@ -9289,7 +9521,7 @@ $root.jspb = (function() {
                     for (var j = 0; j < keys2.length; ++j) {
                         if (keys2[j] === "__proto__")
                             $util.makeProp(object.mapStringMsg, keys2[j]);
-                        object.mapStringMsg[keys2[j]] = $root.jspb.test.MapValueMessageNoBinary.toObject(message.mapStringMsg[keys2[j]], options);
+                        object.mapStringMsg[keys2[j]] = $root.jspb.test.MapValueMessageNoBinary.toObject(message.mapStringMsg[keys2[j]], options, q + 1);
                     }
                 }
                 if (message.mapInt32String && (keys2 = Object.keys(message.mapInt32String)).length) {
@@ -9317,13 +9549,13 @@ $root.jspb = (function() {
                     }
                 }
                 if (message.testMapFields != null && message.hasOwnProperty("testMapFields"))
-                    object.testMapFields = $root.jspb.test.TestMapFieldsNoBinary.toObject(message.testMapFields, options);
+                    object.testMapFields = $root.jspb.test.TestMapFieldsNoBinary.toObject(message.testMapFields, options, q + 1);
                 if (message.mapStringTestmapfields && (keys2 = Object.keys(message.mapStringTestmapfields)).length) {
                     object.mapStringTestmapfields = {};
                     for (var j = 0; j < keys2.length; ++j) {
                         if (keys2[j] === "__proto__")
                             $util.makeProp(object.mapStringTestmapfields, keys2[j]);
-                        object.mapStringTestmapfields[keys2[j]] = $root.jspb.test.TestMapFieldsNoBinary.toObject(message.mapStringTestmapfields[keys2[j]], options);
+                        object.mapStringTestmapfields[keys2[j]] = $root.jspb.test.TestMapFieldsNoBinary.toObject(message.mapStringTestmapfields[keys2[j]], options, q + 1);
                     }
                 }
                 return object;
@@ -9427,9 +9659,13 @@ $root.jspb = (function() {
              * @param {$protobuf.Writer} [writer] Writer to encode to
              * @returns {$protobuf.Writer} Writer
              */
-            MapValueMessageNoBinary.encode = function encode(message, writer) {
+            MapValueMessageNoBinary.encode = function encode(message, writer, q) {
                 if (!writer)
                     writer = $Writer.create();
+                if (q === undefined)
+                    q = 0;
+                if (q > $util.recursionLimit)
+                    throw Error("max depth exceeded");
                 if (message.foo != null && Object.hasOwnProperty.call(message, "foo"))
                     writer.uint32(/* id 1, wireType 0 =*/8).int32(message.foo);
                 return writer;
@@ -9551,9 +9787,13 @@ $root.jspb = (function() {
              * @param {$protobuf.IConversionOptions} [options] Conversion options
              * @returns {Object.<string,*>} Plain object
              */
-            MapValueMessageNoBinary.toObject = function toObject(message, options) {
+            MapValueMessageNoBinary.toObject = function toObject(message, options, q) {
                 if (!options)
                     options = {};
+                if (q === undefined)
+                    q = 0;
+                if (q > $util.recursionLimit)
+                    throw Error("max depth exceeded");
                 var object = {};
                 if (options.defaults)
                     object.foo = 0;
@@ -9635,9 +9875,13 @@ $root.jspb = (function() {
              * @param {$protobuf.Writer} [writer] Writer to encode to
              * @returns {$protobuf.Writer} Writer
              */
-            Deeply.encode = function encode(message, writer) {
+            Deeply.encode = function encode(message, writer, q) {
                 if (!writer)
                     writer = $Writer.create();
+                if (q === undefined)
+                    q = 0;
+                if (q > $util.recursionLimit)
+                    throw Error("max depth exceeded");
                 return writer;
             };
 
@@ -9821,9 +10065,13 @@ $root.jspb = (function() {
                  * @param {$protobuf.Writer} [writer] Writer to encode to
                  * @returns {$protobuf.Writer} Writer
                  */
-                Nested.encode = function encode(message, writer) {
+                Nested.encode = function encode(message, writer, q) {
                     if (!writer)
                         writer = $Writer.create();
+                    if (q === undefined)
+                        q = 0;
+                    if (q > $util.recursionLimit)
+                        throw Error("max depth exceeded");
                     return writer;
                 };
 
@@ -10016,9 +10264,13 @@ $root.jspb = (function() {
                      * @param {$protobuf.Writer} [writer] Writer to encode to
                      * @returns {$protobuf.Writer} Writer
                      */
-                    Message.encode = function encode(message, writer) {
+                    Message.encode = function encode(message, writer, q) {
                         if (!writer)
                             writer = $Writer.create();
+                        if (q === undefined)
+                            q = 0;
+                        if (q > $util.recursionLimit)
+                            throw Error("max depth exceeded");
                         if (message.count != null && Object.hasOwnProperty.call(message, "count"))
                             writer.uint32(/* id 1, wireType 0 =*/8).int32(message.count);
                         return writer;
@@ -10140,9 +10392,13 @@ $root.jspb = (function() {
                      * @param {$protobuf.IConversionOptions} [options] Conversion options
                      * @returns {Object.<string,*>} Plain object
                      */
-                    Message.toObject = function toObject(message, options) {
+                    Message.toObject = function toObject(message, options, q) {
                         if (!options)
                             options = {};
+                        if (q === undefined)
+                            q = 0;
+                        if (q > $util.recursionLimit)
+                            throw Error("max depth exceeded");
                         var object = {};
                         if (options.defaults)
                             object.count = 0;
@@ -10264,12 +10520,16 @@ $root.google = (function() {
              * @param {$protobuf.Writer} [writer] Writer to encode to
              * @returns {$protobuf.Writer} Writer
              */
-            FileDescriptorSet.encode = function encode(message, writer) {
+            FileDescriptorSet.encode = function encode(message, writer, q) {
                 if (!writer)
                     writer = $Writer.create();
+                if (q === undefined)
+                    q = 0;
+                if (q > $util.recursionLimit)
+                    throw Error("max depth exceeded");
                 if (message.file != null && message.file.length)
                     for (var i = 0; i < message.file.length; ++i)
-                        $root.google.protobuf.FileDescriptorProto.encode(message.file[i], writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
+                        $root.google.protobuf.FileDescriptorProto.encode(message.file[i], writer.uint32(/* id 1, wireType 2 =*/10).fork(), q + 1).ldelim();
                 return writer;
             };
 
@@ -10405,16 +10665,20 @@ $root.google = (function() {
              * @param {$protobuf.IConversionOptions} [options] Conversion options
              * @returns {Object.<string,*>} Plain object
              */
-            FileDescriptorSet.toObject = function toObject(message, options) {
+            FileDescriptorSet.toObject = function toObject(message, options, q) {
                 if (!options)
                     options = {};
+                if (q === undefined)
+                    q = 0;
+                if (q > $util.recursionLimit)
+                    throw Error("max depth exceeded");
                 var object = {};
                 if (options.arrays || options.defaults)
                     object.file = [];
                 if (message.file && message.file.length) {
                     object.file = [];
                     for (var j = 0; j < message.file.length; ++j)
-                        object.file[j] = $root.google.protobuf.FileDescriptorProto.toObject(message.file[j], options);
+                        object.file[j] = $root.google.protobuf.FileDescriptorProto.toObject(message.file[j], options, q + 1);
                 }
                 return object;
             };
@@ -10660,9 +10924,13 @@ $root.google = (function() {
              * @param {$protobuf.Writer} [writer] Writer to encode to
              * @returns {$protobuf.Writer} Writer
              */
-            FileDescriptorProto.encode = function encode(message, writer) {
+            FileDescriptorProto.encode = function encode(message, writer, q) {
                 if (!writer)
                     writer = $Writer.create();
+                if (q === undefined)
+                    q = 0;
+                if (q > $util.recursionLimit)
+                    throw Error("max depth exceeded");
                 if (message.name != null && Object.hasOwnProperty.call(message, "name"))
                     writer.uint32(/* id 1, wireType 2 =*/10).string(message.name);
                 if (message["package"] != null && Object.hasOwnProperty.call(message, "package"))
@@ -10672,20 +10940,20 @@ $root.google = (function() {
                         writer.uint32(/* id 3, wireType 2 =*/26).string(message.dependency[i]);
                 if (message.messageType != null && message.messageType.length)
                     for (var i = 0; i < message.messageType.length; ++i)
-                        $root.google.protobuf.DescriptorProto.encode(message.messageType[i], writer.uint32(/* id 4, wireType 2 =*/34).fork()).ldelim();
+                        $root.google.protobuf.DescriptorProto.encode(message.messageType[i], writer.uint32(/* id 4, wireType 2 =*/34).fork(), q + 1).ldelim();
                 if (message.enumType != null && message.enumType.length)
                     for (var i = 0; i < message.enumType.length; ++i)
-                        $root.google.protobuf.EnumDescriptorProto.encode(message.enumType[i], writer.uint32(/* id 5, wireType 2 =*/42).fork()).ldelim();
+                        $root.google.protobuf.EnumDescriptorProto.encode(message.enumType[i], writer.uint32(/* id 5, wireType 2 =*/42).fork(), q + 1).ldelim();
                 if (message.service != null && message.service.length)
                     for (var i = 0; i < message.service.length; ++i)
-                        $root.google.protobuf.ServiceDescriptorProto.encode(message.service[i], writer.uint32(/* id 6, wireType 2 =*/50).fork()).ldelim();
+                        $root.google.protobuf.ServiceDescriptorProto.encode(message.service[i], writer.uint32(/* id 6, wireType 2 =*/50).fork(), q + 1).ldelim();
                 if (message.extension != null && message.extension.length)
                     for (var i = 0; i < message.extension.length; ++i)
-                        $root.google.protobuf.FieldDescriptorProto.encode(message.extension[i], writer.uint32(/* id 7, wireType 2 =*/58).fork()).ldelim();
+                        $root.google.protobuf.FieldDescriptorProto.encode(message.extension[i], writer.uint32(/* id 7, wireType 2 =*/58).fork(), q + 1).ldelim();
                 if (message.options != null && Object.hasOwnProperty.call(message, "options"))
-                    $root.google.protobuf.FileOptions.encode(message.options, writer.uint32(/* id 8, wireType 2 =*/66).fork()).ldelim();
+                    $root.google.protobuf.FileOptions.encode(message.options, writer.uint32(/* id 8, wireType 2 =*/66).fork(), q + 1).ldelim();
                 if (message.sourceCodeInfo != null && Object.hasOwnProperty.call(message, "sourceCodeInfo"))
-                    $root.google.protobuf.SourceCodeInfo.encode(message.sourceCodeInfo, writer.uint32(/* id 9, wireType 2 =*/74).fork()).ldelim();
+                    $root.google.protobuf.SourceCodeInfo.encode(message.sourceCodeInfo, writer.uint32(/* id 9, wireType 2 =*/74).fork(), q + 1).ldelim();
                 if (message.publicDependency != null && message.publicDependency.length)
                     for (var i = 0; i < message.publicDependency.length; ++i)
                         writer.uint32(/* id 10, wireType 0 =*/80).int32(message.publicDependency[i]);
@@ -11132,9 +11400,13 @@ $root.google = (function() {
              * @param {$protobuf.IConversionOptions} [options] Conversion options
              * @returns {Object.<string,*>} Plain object
              */
-            FileDescriptorProto.toObject = function toObject(message, options) {
+            FileDescriptorProto.toObject = function toObject(message, options, q) {
                 if (!options)
                     options = {};
+                if (q === undefined)
+                    q = 0;
+                if (q > $util.recursionLimit)
+                    throw Error("max depth exceeded");
                 var object = {};
                 if (options.arrays || options.defaults) {
                     object.dependency = [];
@@ -11166,27 +11438,27 @@ $root.google = (function() {
                 if (message.messageType && message.messageType.length) {
                     object.messageType = [];
                     for (var j = 0; j < message.messageType.length; ++j)
-                        object.messageType[j] = $root.google.protobuf.DescriptorProto.toObject(message.messageType[j], options);
+                        object.messageType[j] = $root.google.protobuf.DescriptorProto.toObject(message.messageType[j], options, q + 1);
                 }
                 if (message.enumType && message.enumType.length) {
                     object.enumType = [];
                     for (var j = 0; j < message.enumType.length; ++j)
-                        object.enumType[j] = $root.google.protobuf.EnumDescriptorProto.toObject(message.enumType[j], options);
+                        object.enumType[j] = $root.google.protobuf.EnumDescriptorProto.toObject(message.enumType[j], options, q + 1);
                 }
                 if (message.service && message.service.length) {
                     object.service = [];
                     for (var j = 0; j < message.service.length; ++j)
-                        object.service[j] = $root.google.protobuf.ServiceDescriptorProto.toObject(message.service[j], options);
+                        object.service[j] = $root.google.protobuf.ServiceDescriptorProto.toObject(message.service[j], options, q + 1);
                 }
                 if (message.extension && message.extension.length) {
                     object.extension = [];
                     for (var j = 0; j < message.extension.length; ++j)
-                        object.extension[j] = $root.google.protobuf.FieldDescriptorProto.toObject(message.extension[j], options);
+                        object.extension[j] = $root.google.protobuf.FieldDescriptorProto.toObject(message.extension[j], options, q + 1);
                 }
                 if (message.options != null && message.hasOwnProperty("options"))
-                    object.options = $root.google.protobuf.FileOptions.toObject(message.options, options);
+                    object.options = $root.google.protobuf.FileOptions.toObject(message.options, options, q + 1);
                 if (message.sourceCodeInfo != null && message.hasOwnProperty("sourceCodeInfo"))
-                    object.sourceCodeInfo = $root.google.protobuf.SourceCodeInfo.toObject(message.sourceCodeInfo, options);
+                    object.sourceCodeInfo = $root.google.protobuf.SourceCodeInfo.toObject(message.sourceCodeInfo, options, q + 1);
                 if (message.publicDependency && message.publicDependency.length) {
                     object.publicDependency = [];
                     for (var j = 0; j < message.publicDependency.length; ++j)
@@ -11389,34 +11661,38 @@ $root.google = (function() {
              * @param {$protobuf.Writer} [writer] Writer to encode to
              * @returns {$protobuf.Writer} Writer
              */
-            DescriptorProto.encode = function encode(message, writer) {
+            DescriptorProto.encode = function encode(message, writer, q) {
                 if (!writer)
                     writer = $Writer.create();
+                if (q === undefined)
+                    q = 0;
+                if (q > $util.recursionLimit)
+                    throw Error("max depth exceeded");
                 if (message.name != null && Object.hasOwnProperty.call(message, "name"))
                     writer.uint32(/* id 1, wireType 2 =*/10).string(message.name);
                 if (message.field != null && message.field.length)
                     for (var i = 0; i < message.field.length; ++i)
-                        $root.google.protobuf.FieldDescriptorProto.encode(message.field[i], writer.uint32(/* id 2, wireType 2 =*/18).fork()).ldelim();
+                        $root.google.protobuf.FieldDescriptorProto.encode(message.field[i], writer.uint32(/* id 2, wireType 2 =*/18).fork(), q + 1).ldelim();
                 if (message.nestedType != null && message.nestedType.length)
                     for (var i = 0; i < message.nestedType.length; ++i)
-                        $root.google.protobuf.DescriptorProto.encode(message.nestedType[i], writer.uint32(/* id 3, wireType 2 =*/26).fork()).ldelim();
+                        $root.google.protobuf.DescriptorProto.encode(message.nestedType[i], writer.uint32(/* id 3, wireType 2 =*/26).fork(), q + 1).ldelim();
                 if (message.enumType != null && message.enumType.length)
                     for (var i = 0; i < message.enumType.length; ++i)
-                        $root.google.protobuf.EnumDescriptorProto.encode(message.enumType[i], writer.uint32(/* id 4, wireType 2 =*/34).fork()).ldelim();
+                        $root.google.protobuf.EnumDescriptorProto.encode(message.enumType[i], writer.uint32(/* id 4, wireType 2 =*/34).fork(), q + 1).ldelim();
                 if (message.extensionRange != null && message.extensionRange.length)
                     for (var i = 0; i < message.extensionRange.length; ++i)
-                        $root.google.protobuf.DescriptorProto.ExtensionRange.encode(message.extensionRange[i], writer.uint32(/* id 5, wireType 2 =*/42).fork()).ldelim();
+                        $root.google.protobuf.DescriptorProto.ExtensionRange.encode(message.extensionRange[i], writer.uint32(/* id 5, wireType 2 =*/42).fork(), q + 1).ldelim();
                 if (message.extension != null && message.extension.length)
                     for (var i = 0; i < message.extension.length; ++i)
-                        $root.google.protobuf.FieldDescriptorProto.encode(message.extension[i], writer.uint32(/* id 6, wireType 2 =*/50).fork()).ldelim();
+                        $root.google.protobuf.FieldDescriptorProto.encode(message.extension[i], writer.uint32(/* id 6, wireType 2 =*/50).fork(), q + 1).ldelim();
                 if (message.options != null && Object.hasOwnProperty.call(message, "options"))
-                    $root.google.protobuf.MessageOptions.encode(message.options, writer.uint32(/* id 7, wireType 2 =*/58).fork()).ldelim();
+                    $root.google.protobuf.MessageOptions.encode(message.options, writer.uint32(/* id 7, wireType 2 =*/58).fork(), q + 1).ldelim();
                 if (message.oneofDecl != null && message.oneofDecl.length)
                     for (var i = 0; i < message.oneofDecl.length; ++i)
-                        $root.google.protobuf.OneofDescriptorProto.encode(message.oneofDecl[i], writer.uint32(/* id 8, wireType 2 =*/66).fork()).ldelim();
+                        $root.google.protobuf.OneofDescriptorProto.encode(message.oneofDecl[i], writer.uint32(/* id 8, wireType 2 =*/66).fork(), q + 1).ldelim();
                 if (message.reservedRange != null && message.reservedRange.length)
                     for (var i = 0; i < message.reservedRange.length; ++i)
-                        $root.google.protobuf.DescriptorProto.ReservedRange.encode(message.reservedRange[i], writer.uint32(/* id 9, wireType 2 =*/74).fork()).ldelim();
+                        $root.google.protobuf.DescriptorProto.ReservedRange.encode(message.reservedRange[i], writer.uint32(/* id 9, wireType 2 =*/74).fork(), q + 1).ldelim();
                 if (message.reservedName != null && message.reservedName.length)
                     for (var i = 0; i < message.reservedName.length; ++i)
                         writer.uint32(/* id 10, wireType 2 =*/82).string(message.reservedName[i]);
@@ -11783,9 +12059,13 @@ $root.google = (function() {
              * @param {$protobuf.IConversionOptions} [options] Conversion options
              * @returns {Object.<string,*>} Plain object
              */
-            DescriptorProto.toObject = function toObject(message, options) {
+            DescriptorProto.toObject = function toObject(message, options, q) {
                 if (!options)
                     options = {};
+                if (q === undefined)
+                    q = 0;
+                if (q > $util.recursionLimit)
+                    throw Error("max depth exceeded");
                 var object = {};
                 if (options.arrays || options.defaults) {
                     object.field = [];
@@ -11807,39 +12087,39 @@ $root.google = (function() {
                 if (message.field && message.field.length) {
                     object.field = [];
                     for (var j = 0; j < message.field.length; ++j)
-                        object.field[j] = $root.google.protobuf.FieldDescriptorProto.toObject(message.field[j], options);
+                        object.field[j] = $root.google.protobuf.FieldDescriptorProto.toObject(message.field[j], options, q + 1);
                 }
                 if (message.nestedType && message.nestedType.length) {
                     object.nestedType = [];
                     for (var j = 0; j < message.nestedType.length; ++j)
-                        object.nestedType[j] = $root.google.protobuf.DescriptorProto.toObject(message.nestedType[j], options);
+                        object.nestedType[j] = $root.google.protobuf.DescriptorProto.toObject(message.nestedType[j], options, q + 1);
                 }
                 if (message.enumType && message.enumType.length) {
                     object.enumType = [];
                     for (var j = 0; j < message.enumType.length; ++j)
-                        object.enumType[j] = $root.google.protobuf.EnumDescriptorProto.toObject(message.enumType[j], options);
+                        object.enumType[j] = $root.google.protobuf.EnumDescriptorProto.toObject(message.enumType[j], options, q + 1);
                 }
                 if (message.extensionRange && message.extensionRange.length) {
                     object.extensionRange = [];
                     for (var j = 0; j < message.extensionRange.length; ++j)
-                        object.extensionRange[j] = $root.google.protobuf.DescriptorProto.ExtensionRange.toObject(message.extensionRange[j], options);
+                        object.extensionRange[j] = $root.google.protobuf.DescriptorProto.ExtensionRange.toObject(message.extensionRange[j], options, q + 1);
                 }
                 if (message.extension && message.extension.length) {
                     object.extension = [];
                     for (var j = 0; j < message.extension.length; ++j)
-                        object.extension[j] = $root.google.protobuf.FieldDescriptorProto.toObject(message.extension[j], options);
+                        object.extension[j] = $root.google.protobuf.FieldDescriptorProto.toObject(message.extension[j], options, q + 1);
                 }
                 if (message.options != null && message.hasOwnProperty("options"))
-                    object.options = $root.google.protobuf.MessageOptions.toObject(message.options, options);
+                    object.options = $root.google.protobuf.MessageOptions.toObject(message.options, options, q + 1);
                 if (message.oneofDecl && message.oneofDecl.length) {
                     object.oneofDecl = [];
                     for (var j = 0; j < message.oneofDecl.length; ++j)
-                        object.oneofDecl[j] = $root.google.protobuf.OneofDescriptorProto.toObject(message.oneofDecl[j], options);
+                        object.oneofDecl[j] = $root.google.protobuf.OneofDescriptorProto.toObject(message.oneofDecl[j], options, q + 1);
                 }
                 if (message.reservedRange && message.reservedRange.length) {
                     object.reservedRange = [];
                     for (var j = 0; j < message.reservedRange.length; ++j)
-                        object.reservedRange[j] = $root.google.protobuf.DescriptorProto.ReservedRange.toObject(message.reservedRange[j], options);
+                        object.reservedRange[j] = $root.google.protobuf.DescriptorProto.ReservedRange.toObject(message.reservedRange[j], options, q + 1);
                 }
                 if (message.reservedName && message.reservedName.length) {
                     object.reservedName = [];
@@ -11948,15 +12228,19 @@ $root.google = (function() {
                  * @param {$protobuf.Writer} [writer] Writer to encode to
                  * @returns {$protobuf.Writer} Writer
                  */
-                ExtensionRange.encode = function encode(message, writer) {
+                ExtensionRange.encode = function encode(message, writer, q) {
                     if (!writer)
                         writer = $Writer.create();
+                    if (q === undefined)
+                        q = 0;
+                    if (q > $util.recursionLimit)
+                        throw Error("max depth exceeded");
                     if (message.start != null && Object.hasOwnProperty.call(message, "start"))
                         writer.uint32(/* id 1, wireType 0 =*/8).int32(message.start);
                     if (message.end != null && Object.hasOwnProperty.call(message, "end"))
                         writer.uint32(/* id 2, wireType 0 =*/16).int32(message.end);
                     if (message.options != null && Object.hasOwnProperty.call(message, "options"))
-                        $root.google.protobuf.ExtensionRangeOptions.encode(message.options, writer.uint32(/* id 3, wireType 2 =*/26).fork()).ldelim();
+                        $root.google.protobuf.ExtensionRangeOptions.encode(message.options, writer.uint32(/* id 3, wireType 2 =*/26).fork(), q + 1).ldelim();
                     return writer;
                 };
 
@@ -12099,9 +12383,13 @@ $root.google = (function() {
                  * @param {$protobuf.IConversionOptions} [options] Conversion options
                  * @returns {Object.<string,*>} Plain object
                  */
-                ExtensionRange.toObject = function toObject(message, options) {
+                ExtensionRange.toObject = function toObject(message, options, q) {
                     if (!options)
                         options = {};
+                    if (q === undefined)
+                        q = 0;
+                    if (q > $util.recursionLimit)
+                        throw Error("max depth exceeded");
                     var object = {};
                     if (options.defaults) {
                         object.start = 0;
@@ -12113,7 +12401,7 @@ $root.google = (function() {
                     if (message.end != null && message.hasOwnProperty("end"))
                         object.end = message.end;
                     if (message.options != null && message.hasOwnProperty("options"))
-                        object.options = $root.google.protobuf.ExtensionRangeOptions.toObject(message.options, options);
+                        object.options = $root.google.protobuf.ExtensionRangeOptions.toObject(message.options, options, q + 1);
                     return object;
                 };
 
@@ -12208,9 +12496,13 @@ $root.google = (function() {
                  * @param {$protobuf.Writer} [writer] Writer to encode to
                  * @returns {$protobuf.Writer} Writer
                  */
-                ReservedRange.encode = function encode(message, writer) {
+                ReservedRange.encode = function encode(message, writer, q) {
                     if (!writer)
                         writer = $Writer.create();
+                    if (q === undefined)
+                        q = 0;
+                    if (q > $util.recursionLimit)
+                        throw Error("max depth exceeded");
                     if (message.start != null && Object.hasOwnProperty.call(message, "start"))
                         writer.uint32(/* id 1, wireType 0 =*/8).int32(message.start);
                     if (message.end != null && Object.hasOwnProperty.call(message, "end"))
@@ -12343,9 +12635,13 @@ $root.google = (function() {
                  * @param {$protobuf.IConversionOptions} [options] Conversion options
                  * @returns {Object.<string,*>} Plain object
                  */
-                ReservedRange.toObject = function toObject(message, options) {
+                ReservedRange.toObject = function toObject(message, options, q) {
                     if (!options)
                         options = {};
+                    if (q === undefined)
+                        q = 0;
+                    if (q > $util.recursionLimit)
+                        throw Error("max depth exceeded");
                     var object = {};
                     if (options.defaults) {
                         object.start = 0;
@@ -12472,19 +12768,23 @@ $root.google = (function() {
              * @param {$protobuf.Writer} [writer] Writer to encode to
              * @returns {$protobuf.Writer} Writer
              */
-            ExtensionRangeOptions.encode = function encode(message, writer) {
+            ExtensionRangeOptions.encode = function encode(message, writer, q) {
                 if (!writer)
                     writer = $Writer.create();
+                if (q === undefined)
+                    q = 0;
+                if (q > $util.recursionLimit)
+                    throw Error("max depth exceeded");
                 if (message.declaration != null && message.declaration.length)
                     for (var i = 0; i < message.declaration.length; ++i)
-                        $root.google.protobuf.ExtensionRangeOptions.Declaration.encode(message.declaration[i], writer.uint32(/* id 2, wireType 2 =*/18).fork()).ldelim();
+                        $root.google.protobuf.ExtensionRangeOptions.Declaration.encode(message.declaration[i], writer.uint32(/* id 2, wireType 2 =*/18).fork(), q + 1).ldelim();
                 if (message.verification != null && Object.hasOwnProperty.call(message, "verification"))
                     writer.uint32(/* id 3, wireType 0 =*/24).int32(message.verification);
                 if (message.features != null && Object.hasOwnProperty.call(message, "features"))
-                    $root.google.protobuf.FeatureSet.encode(message.features, writer.uint32(/* id 50, wireType 2 =*/402).fork()).ldelim();
+                    $root.google.protobuf.FeatureSet.encode(message.features, writer.uint32(/* id 50, wireType 2 =*/402).fork(), q + 1).ldelim();
                 if (message.uninterpretedOption != null && message.uninterpretedOption.length)
                     for (var i = 0; i < message.uninterpretedOption.length; ++i)
-                        $root.google.protobuf.UninterpretedOption.encode(message.uninterpretedOption[i], writer.uint32(/* id 999, wireType 2 =*/7994).fork()).ldelim();
+                        $root.google.protobuf.UninterpretedOption.encode(message.uninterpretedOption[i], writer.uint32(/* id 999, wireType 2 =*/7994).fork(), q + 1).ldelim();
                 return writer;
             };
 
@@ -12687,9 +12987,13 @@ $root.google = (function() {
              * @param {$protobuf.IConversionOptions} [options] Conversion options
              * @returns {Object.<string,*>} Plain object
              */
-            ExtensionRangeOptions.toObject = function toObject(message, options) {
+            ExtensionRangeOptions.toObject = function toObject(message, options, q) {
                 if (!options)
                     options = {};
+                if (q === undefined)
+                    q = 0;
+                if (q > $util.recursionLimit)
+                    throw Error("max depth exceeded");
                 var object = {};
                 if (options.arrays || options.defaults) {
                     object.declaration = [];
@@ -12702,16 +13006,16 @@ $root.google = (function() {
                 if (message.declaration && message.declaration.length) {
                     object.declaration = [];
                     for (var j = 0; j < message.declaration.length; ++j)
-                        object.declaration[j] = $root.google.protobuf.ExtensionRangeOptions.Declaration.toObject(message.declaration[j], options);
+                        object.declaration[j] = $root.google.protobuf.ExtensionRangeOptions.Declaration.toObject(message.declaration[j], options, q + 1);
                 }
                 if (message.verification != null && message.hasOwnProperty("verification"))
                     object.verification = options.enums === String ? $root.google.protobuf.ExtensionRangeOptions.VerificationState[message.verification] === undefined ? message.verification : $root.google.protobuf.ExtensionRangeOptions.VerificationState[message.verification] : message.verification;
                 if (message.features != null && message.hasOwnProperty("features"))
-                    object.features = $root.google.protobuf.FeatureSet.toObject(message.features, options);
+                    object.features = $root.google.protobuf.FeatureSet.toObject(message.features, options, q + 1);
                 if (message.uninterpretedOption && message.uninterpretedOption.length) {
                     object.uninterpretedOption = [];
                     for (var j = 0; j < message.uninterpretedOption.length; ++j)
-                        object.uninterpretedOption[j] = $root.google.protobuf.UninterpretedOption.toObject(message.uninterpretedOption[j], options);
+                        object.uninterpretedOption[j] = $root.google.protobuf.UninterpretedOption.toObject(message.uninterpretedOption[j], options, q + 1);
                 }
                 return object;
             };
@@ -12831,9 +13135,13 @@ $root.google = (function() {
                  * @param {$protobuf.Writer} [writer] Writer to encode to
                  * @returns {$protobuf.Writer} Writer
                  */
-                Declaration.encode = function encode(message, writer) {
+                Declaration.encode = function encode(message, writer, q) {
                     if (!writer)
                         writer = $Writer.create();
+                    if (q === undefined)
+                        q = 0;
+                    if (q > $util.recursionLimit)
+                        throw Error("max depth exceeded");
                     if (message.number != null && Object.hasOwnProperty.call(message, "number"))
                         writer.uint32(/* id 1, wireType 0 =*/8).int32(message.number);
                     if (message.fullName != null && Object.hasOwnProperty.call(message, "fullName"))
@@ -12999,9 +13307,13 @@ $root.google = (function() {
                  * @param {$protobuf.IConversionOptions} [options] Conversion options
                  * @returns {Object.<string,*>} Plain object
                  */
-                Declaration.toObject = function toObject(message, options) {
+                Declaration.toObject = function toObject(message, options, q) {
                     if (!options)
                         options = {};
+                    if (q === undefined)
+                        q = 0;
+                    if (q > $util.recursionLimit)
+                        throw Error("max depth exceeded");
                     var object = {};
                     if (options.defaults) {
                         object.number = 0;
@@ -13212,9 +13524,13 @@ $root.google = (function() {
              * @param {$protobuf.Writer} [writer] Writer to encode to
              * @returns {$protobuf.Writer} Writer
              */
-            FieldDescriptorProto.encode = function encode(message, writer) {
+            FieldDescriptorProto.encode = function encode(message, writer, q) {
                 if (!writer)
                     writer = $Writer.create();
+                if (q === undefined)
+                    q = 0;
+                if (q > $util.recursionLimit)
+                    throw Error("max depth exceeded");
                 if (message.name != null && Object.hasOwnProperty.call(message, "name"))
                     writer.uint32(/* id 1, wireType 2 =*/10).string(message.name);
                 if (message.extendee != null && Object.hasOwnProperty.call(message, "extendee"))
@@ -13230,7 +13546,7 @@ $root.google = (function() {
                 if (message.defaultValue != null && Object.hasOwnProperty.call(message, "defaultValue"))
                     writer.uint32(/* id 7, wireType 2 =*/58).string(message.defaultValue);
                 if (message.options != null && Object.hasOwnProperty.call(message, "options"))
-                    $root.google.protobuf.FieldOptions.encode(message.options, writer.uint32(/* id 8, wireType 2 =*/66).fork()).ldelim();
+                    $root.google.protobuf.FieldOptions.encode(message.options, writer.uint32(/* id 8, wireType 2 =*/66).fork(), q + 1).ldelim();
                 if (message.oneofIndex != null && Object.hasOwnProperty.call(message, "oneofIndex"))
                     writer.uint32(/* id 9, wireType 0 =*/72).int32(message.oneofIndex);
                 if (message.jsonName != null && Object.hasOwnProperty.call(message, "jsonName"))
@@ -13574,9 +13890,13 @@ $root.google = (function() {
              * @param {$protobuf.IConversionOptions} [options] Conversion options
              * @returns {Object.<string,*>} Plain object
              */
-            FieldDescriptorProto.toObject = function toObject(message, options) {
+            FieldDescriptorProto.toObject = function toObject(message, options, q) {
                 if (!options)
                     options = {};
+                if (q === undefined)
+                    q = 0;
+                if (q > $util.recursionLimit)
+                    throw Error("max depth exceeded");
                 var object = {};
                 if (options.defaults) {
                     object.name = "";
@@ -13606,7 +13926,7 @@ $root.google = (function() {
                 if (message.defaultValue != null && message.hasOwnProperty("defaultValue"))
                     object.defaultValue = message.defaultValue;
                 if (message.options != null && message.hasOwnProperty("options"))
-                    object.options = $root.google.protobuf.FieldOptions.toObject(message.options, options);
+                    object.options = $root.google.protobuf.FieldOptions.toObject(message.options, options, q + 1);
                 if (message.oneofIndex != null && message.hasOwnProperty("oneofIndex"))
                     object.oneofIndex = message.oneofIndex;
                 if (message.jsonName != null && message.hasOwnProperty("jsonName"))
@@ -13769,13 +14089,17 @@ $root.google = (function() {
              * @param {$protobuf.Writer} [writer] Writer to encode to
              * @returns {$protobuf.Writer} Writer
              */
-            OneofDescriptorProto.encode = function encode(message, writer) {
+            OneofDescriptorProto.encode = function encode(message, writer, q) {
                 if (!writer)
                     writer = $Writer.create();
+                if (q === undefined)
+                    q = 0;
+                if (q > $util.recursionLimit)
+                    throw Error("max depth exceeded");
                 if (message.name != null && Object.hasOwnProperty.call(message, "name"))
                     writer.uint32(/* id 1, wireType 2 =*/10).string(message.name);
                 if (message.options != null && Object.hasOwnProperty.call(message, "options"))
-                    $root.google.protobuf.OneofOptions.encode(message.options, writer.uint32(/* id 2, wireType 2 =*/18).fork()).ldelim();
+                    $root.google.protobuf.OneofOptions.encode(message.options, writer.uint32(/* id 2, wireType 2 =*/18).fork(), q + 1).ldelim();
                 return writer;
             };
 
@@ -13909,9 +14233,13 @@ $root.google = (function() {
              * @param {$protobuf.IConversionOptions} [options] Conversion options
              * @returns {Object.<string,*>} Plain object
              */
-            OneofDescriptorProto.toObject = function toObject(message, options) {
+            OneofDescriptorProto.toObject = function toObject(message, options, q) {
                 if (!options)
                     options = {};
+                if (q === undefined)
+                    q = 0;
+                if (q > $util.recursionLimit)
+                    throw Error("max depth exceeded");
                 var object = {};
                 if (options.defaults) {
                     object.name = "";
@@ -13920,7 +14248,7 @@ $root.google = (function() {
                 if (message.name != null && message.hasOwnProperty("name"))
                     object.name = message.name;
                 if (message.options != null && message.hasOwnProperty("options"))
-                    object.options = $root.google.protobuf.OneofOptions.toObject(message.options, options);
+                    object.options = $root.google.protobuf.OneofOptions.toObject(message.options, options, q + 1);
                 return object;
             };
 
@@ -14054,19 +14382,23 @@ $root.google = (function() {
              * @param {$protobuf.Writer} [writer] Writer to encode to
              * @returns {$protobuf.Writer} Writer
              */
-            EnumDescriptorProto.encode = function encode(message, writer) {
+            EnumDescriptorProto.encode = function encode(message, writer, q) {
                 if (!writer)
                     writer = $Writer.create();
+                if (q === undefined)
+                    q = 0;
+                if (q > $util.recursionLimit)
+                    throw Error("max depth exceeded");
                 if (message.name != null && Object.hasOwnProperty.call(message, "name"))
                     writer.uint32(/* id 1, wireType 2 =*/10).string(message.name);
                 if (message.value != null && message.value.length)
                     for (var i = 0; i < message.value.length; ++i)
-                        $root.google.protobuf.EnumValueDescriptorProto.encode(message.value[i], writer.uint32(/* id 2, wireType 2 =*/18).fork()).ldelim();
+                        $root.google.protobuf.EnumValueDescriptorProto.encode(message.value[i], writer.uint32(/* id 2, wireType 2 =*/18).fork(), q + 1).ldelim();
                 if (message.options != null && Object.hasOwnProperty.call(message, "options"))
-                    $root.google.protobuf.EnumOptions.encode(message.options, writer.uint32(/* id 3, wireType 2 =*/26).fork()).ldelim();
+                    $root.google.protobuf.EnumOptions.encode(message.options, writer.uint32(/* id 3, wireType 2 =*/26).fork(), q + 1).ldelim();
                 if (message.reservedRange != null && message.reservedRange.length)
                     for (var i = 0; i < message.reservedRange.length; ++i)
-                        $root.google.protobuf.EnumDescriptorProto.EnumReservedRange.encode(message.reservedRange[i], writer.uint32(/* id 4, wireType 2 =*/34).fork()).ldelim();
+                        $root.google.protobuf.EnumDescriptorProto.EnumReservedRange.encode(message.reservedRange[i], writer.uint32(/* id 4, wireType 2 =*/34).fork(), q + 1).ldelim();
                 if (message.reservedName != null && message.reservedName.length)
                     for (var i = 0; i < message.reservedName.length; ++i)
                         writer.uint32(/* id 5, wireType 2 =*/42).string(message.reservedName[i]);
@@ -14308,9 +14640,13 @@ $root.google = (function() {
              * @param {$protobuf.IConversionOptions} [options] Conversion options
              * @returns {Object.<string,*>} Plain object
              */
-            EnumDescriptorProto.toObject = function toObject(message, options) {
+            EnumDescriptorProto.toObject = function toObject(message, options, q) {
                 if (!options)
                     options = {};
+                if (q === undefined)
+                    q = 0;
+                if (q > $util.recursionLimit)
+                    throw Error("max depth exceeded");
                 var object = {};
                 if (options.arrays || options.defaults) {
                     object.value = [];
@@ -14327,14 +14663,14 @@ $root.google = (function() {
                 if (message.value && message.value.length) {
                     object.value = [];
                     for (var j = 0; j < message.value.length; ++j)
-                        object.value[j] = $root.google.protobuf.EnumValueDescriptorProto.toObject(message.value[j], options);
+                        object.value[j] = $root.google.protobuf.EnumValueDescriptorProto.toObject(message.value[j], options, q + 1);
                 }
                 if (message.options != null && message.hasOwnProperty("options"))
-                    object.options = $root.google.protobuf.EnumOptions.toObject(message.options, options);
+                    object.options = $root.google.protobuf.EnumOptions.toObject(message.options, options, q + 1);
                 if (message.reservedRange && message.reservedRange.length) {
                     object.reservedRange = [];
                     for (var j = 0; j < message.reservedRange.length; ++j)
-                        object.reservedRange[j] = $root.google.protobuf.EnumDescriptorProto.EnumReservedRange.toObject(message.reservedRange[j], options);
+                        object.reservedRange[j] = $root.google.protobuf.EnumDescriptorProto.EnumReservedRange.toObject(message.reservedRange[j], options, q + 1);
                 }
                 if (message.reservedName && message.reservedName.length) {
                     object.reservedName = [];
@@ -14434,9 +14770,13 @@ $root.google = (function() {
                  * @param {$protobuf.Writer} [writer] Writer to encode to
                  * @returns {$protobuf.Writer} Writer
                  */
-                EnumReservedRange.encode = function encode(message, writer) {
+                EnumReservedRange.encode = function encode(message, writer, q) {
                     if (!writer)
                         writer = $Writer.create();
+                    if (q === undefined)
+                        q = 0;
+                    if (q > $util.recursionLimit)
+                        throw Error("max depth exceeded");
                     if (message.start != null && Object.hasOwnProperty.call(message, "start"))
                         writer.uint32(/* id 1, wireType 0 =*/8).int32(message.start);
                     if (message.end != null && Object.hasOwnProperty.call(message, "end"))
@@ -14569,9 +14909,13 @@ $root.google = (function() {
                  * @param {$protobuf.IConversionOptions} [options] Conversion options
                  * @returns {Object.<string,*>} Plain object
                  */
-                EnumReservedRange.toObject = function toObject(message, options) {
+                EnumReservedRange.toObject = function toObject(message, options, q) {
                     if (!options)
                         options = {};
+                    if (q === undefined)
+                        q = 0;
+                    if (q > $util.recursionLimit)
+                        throw Error("max depth exceeded");
                     var object = {};
                     if (options.defaults) {
                         object.start = 0;
@@ -14687,15 +15031,19 @@ $root.google = (function() {
              * @param {$protobuf.Writer} [writer] Writer to encode to
              * @returns {$protobuf.Writer} Writer
              */
-            EnumValueDescriptorProto.encode = function encode(message, writer) {
+            EnumValueDescriptorProto.encode = function encode(message, writer, q) {
                 if (!writer)
                     writer = $Writer.create();
+                if (q === undefined)
+                    q = 0;
+                if (q > $util.recursionLimit)
+                    throw Error("max depth exceeded");
                 if (message.name != null && Object.hasOwnProperty.call(message, "name"))
                     writer.uint32(/* id 1, wireType 2 =*/10).string(message.name);
                 if (message.number != null && Object.hasOwnProperty.call(message, "number"))
                     writer.uint32(/* id 2, wireType 0 =*/16).int32(message.number);
                 if (message.options != null && Object.hasOwnProperty.call(message, "options"))
-                    $root.google.protobuf.EnumValueOptions.encode(message.options, writer.uint32(/* id 3, wireType 2 =*/26).fork()).ldelim();
+                    $root.google.protobuf.EnumValueOptions.encode(message.options, writer.uint32(/* id 3, wireType 2 =*/26).fork(), q + 1).ldelim();
                 return writer;
             };
 
@@ -14838,9 +15186,13 @@ $root.google = (function() {
              * @param {$protobuf.IConversionOptions} [options] Conversion options
              * @returns {Object.<string,*>} Plain object
              */
-            EnumValueDescriptorProto.toObject = function toObject(message, options) {
+            EnumValueDescriptorProto.toObject = function toObject(message, options, q) {
                 if (!options)
                     options = {};
+                if (q === undefined)
+                    q = 0;
+                if (q > $util.recursionLimit)
+                    throw Error("max depth exceeded");
                 var object = {};
                 if (options.defaults) {
                     object.name = "";
@@ -14852,7 +15204,7 @@ $root.google = (function() {
                 if (message.number != null && message.hasOwnProperty("number"))
                     object.number = message.number;
                 if (message.options != null && message.hasOwnProperty("options"))
-                    object.options = $root.google.protobuf.EnumValueOptions.toObject(message.options, options);
+                    object.options = $root.google.protobuf.EnumValueOptions.toObject(message.options, options, q + 1);
                 return object;
             };
 
@@ -14957,16 +15309,20 @@ $root.google = (function() {
              * @param {$protobuf.Writer} [writer] Writer to encode to
              * @returns {$protobuf.Writer} Writer
              */
-            ServiceDescriptorProto.encode = function encode(message, writer) {
+            ServiceDescriptorProto.encode = function encode(message, writer, q) {
                 if (!writer)
                     writer = $Writer.create();
+                if (q === undefined)
+                    q = 0;
+                if (q > $util.recursionLimit)
+                    throw Error("max depth exceeded");
                 if (message.name != null && Object.hasOwnProperty.call(message, "name"))
                     writer.uint32(/* id 1, wireType 2 =*/10).string(message.name);
                 if (message.method != null && message.method.length)
                     for (var i = 0; i < message.method.length; ++i)
-                        $root.google.protobuf.MethodDescriptorProto.encode(message.method[i], writer.uint32(/* id 2, wireType 2 =*/18).fork()).ldelim();
+                        $root.google.protobuf.MethodDescriptorProto.encode(message.method[i], writer.uint32(/* id 2, wireType 2 =*/18).fork(), q + 1).ldelim();
                 if (message.options != null && Object.hasOwnProperty.call(message, "options"))
-                    $root.google.protobuf.ServiceOptions.encode(message.options, writer.uint32(/* id 3, wireType 2 =*/26).fork()).ldelim();
+                    $root.google.protobuf.ServiceOptions.encode(message.options, writer.uint32(/* id 3, wireType 2 =*/26).fork(), q + 1).ldelim();
                 return writer;
             };
 
@@ -15125,9 +15481,13 @@ $root.google = (function() {
              * @param {$protobuf.IConversionOptions} [options] Conversion options
              * @returns {Object.<string,*>} Plain object
              */
-            ServiceDescriptorProto.toObject = function toObject(message, options) {
+            ServiceDescriptorProto.toObject = function toObject(message, options, q) {
                 if (!options)
                     options = {};
+                if (q === undefined)
+                    q = 0;
+                if (q > $util.recursionLimit)
+                    throw Error("max depth exceeded");
                 var object = {};
                 if (options.arrays || options.defaults)
                     object.method = [];
@@ -15140,10 +15500,10 @@ $root.google = (function() {
                 if (message.method && message.method.length) {
                     object.method = [];
                     for (var j = 0; j < message.method.length; ++j)
-                        object.method[j] = $root.google.protobuf.MethodDescriptorProto.toObject(message.method[j], options);
+                        object.method[j] = $root.google.protobuf.MethodDescriptorProto.toObject(message.method[j], options, q + 1);
                 }
                 if (message.options != null && message.hasOwnProperty("options"))
-                    object.options = $root.google.protobuf.ServiceOptions.toObject(message.options, options);
+                    object.options = $root.google.protobuf.ServiceOptions.toObject(message.options, options, q + 1);
                 return object;
             };
 
@@ -15274,9 +15634,13 @@ $root.google = (function() {
              * @param {$protobuf.Writer} [writer] Writer to encode to
              * @returns {$protobuf.Writer} Writer
              */
-            MethodDescriptorProto.encode = function encode(message, writer) {
+            MethodDescriptorProto.encode = function encode(message, writer, q) {
                 if (!writer)
                     writer = $Writer.create();
+                if (q === undefined)
+                    q = 0;
+                if (q > $util.recursionLimit)
+                    throw Error("max depth exceeded");
                 if (message.name != null && Object.hasOwnProperty.call(message, "name"))
                     writer.uint32(/* id 1, wireType 2 =*/10).string(message.name);
                 if (message.inputType != null && Object.hasOwnProperty.call(message, "inputType"))
@@ -15284,7 +15648,7 @@ $root.google = (function() {
                 if (message.outputType != null && Object.hasOwnProperty.call(message, "outputType"))
                     writer.uint32(/* id 3, wireType 2 =*/26).string(message.outputType);
                 if (message.options != null && Object.hasOwnProperty.call(message, "options"))
-                    $root.google.protobuf.MethodOptions.encode(message.options, writer.uint32(/* id 4, wireType 2 =*/34).fork()).ldelim();
+                    $root.google.protobuf.MethodOptions.encode(message.options, writer.uint32(/* id 4, wireType 2 =*/34).fork(), q + 1).ldelim();
                 if (message.clientStreaming != null && Object.hasOwnProperty.call(message, "clientStreaming"))
                     writer.uint32(/* id 5, wireType 0 =*/40).bool(message.clientStreaming);
                 if (message.serverStreaming != null && Object.hasOwnProperty.call(message, "serverStreaming"))
@@ -15458,9 +15822,13 @@ $root.google = (function() {
              * @param {$protobuf.IConversionOptions} [options] Conversion options
              * @returns {Object.<string,*>} Plain object
              */
-            MethodDescriptorProto.toObject = function toObject(message, options) {
+            MethodDescriptorProto.toObject = function toObject(message, options, q) {
                 if (!options)
                     options = {};
+                if (q === undefined)
+                    q = 0;
+                if (q > $util.recursionLimit)
+                    throw Error("max depth exceeded");
                 var object = {};
                 if (options.defaults) {
                     object.name = "";
@@ -15477,7 +15845,7 @@ $root.google = (function() {
                 if (message.outputType != null && message.hasOwnProperty("outputType"))
                     object.outputType = message.outputType;
                 if (message.options != null && message.hasOwnProperty("options"))
-                    object.options = $root.google.protobuf.MethodOptions.toObject(message.options, options);
+                    object.options = $root.google.protobuf.MethodOptions.toObject(message.options, options, q + 1);
                 if (message.clientStreaming != null && message.hasOwnProperty("clientStreaming"))
                     object.clientStreaming = message.clientStreaming;
                 if (message.serverStreaming != null && message.hasOwnProperty("serverStreaming"))
@@ -15748,9 +16116,13 @@ $root.google = (function() {
              * @param {$protobuf.Writer} [writer] Writer to encode to
              * @returns {$protobuf.Writer} Writer
              */
-            FileOptions.encode = function encode(message, writer) {
+            FileOptions.encode = function encode(message, writer, q) {
                 if (!writer)
                     writer = $Writer.create();
+                if (q === undefined)
+                    q = 0;
+                if (q > $util.recursionLimit)
+                    throw Error("max depth exceeded");
                 if (message.javaPackage != null && Object.hasOwnProperty.call(message, "javaPackage"))
                     writer.uint32(/* id 1, wireType 2 =*/10).string(message.javaPackage);
                 if (message.javaOuterClassname != null && Object.hasOwnProperty.call(message, "javaOuterClassname"))
@@ -15790,10 +16162,10 @@ $root.google = (function() {
                 if (message.rubyPackage != null && Object.hasOwnProperty.call(message, "rubyPackage"))
                     writer.uint32(/* id 45, wireType 2 =*/362).string(message.rubyPackage);
                 if (message.features != null && Object.hasOwnProperty.call(message, "features"))
-                    $root.google.protobuf.FeatureSet.encode(message.features, writer.uint32(/* id 50, wireType 2 =*/402).fork()).ldelim();
+                    $root.google.protobuf.FeatureSet.encode(message.features, writer.uint32(/* id 50, wireType 2 =*/402).fork(), q + 1).ldelim();
                 if (message.uninterpretedOption != null && message.uninterpretedOption.length)
                     for (var i = 0; i < message.uninterpretedOption.length; ++i)
-                        $root.google.protobuf.UninterpretedOption.encode(message.uninterpretedOption[i], writer.uint32(/* id 999, wireType 2 =*/7994).fork()).ldelim();
+                        $root.google.protobuf.UninterpretedOption.encode(message.uninterpretedOption[i], writer.uint32(/* id 999, wireType 2 =*/7994).fork(), q + 1).ldelim();
                 return writer;
             };
 
@@ -16138,9 +16510,13 @@ $root.google = (function() {
              * @param {$protobuf.IConversionOptions} [options] Conversion options
              * @returns {Object.<string,*>} Plain object
              */
-            FileOptions.toObject = function toObject(message, options) {
+            FileOptions.toObject = function toObject(message, options, q) {
                 if (!options)
                     options = {};
+                if (q === undefined)
+                    q = 0;
+                if (q > $util.recursionLimit)
+                    throw Error("max depth exceeded");
                 var object = {};
                 if (options.arrays || options.defaults)
                     object.uninterpretedOption = [];
@@ -16205,11 +16581,11 @@ $root.google = (function() {
                 if (message.rubyPackage != null && message.hasOwnProperty("rubyPackage"))
                     object.rubyPackage = message.rubyPackage;
                 if (message.features != null && message.hasOwnProperty("features"))
-                    object.features = $root.google.protobuf.FeatureSet.toObject(message.features, options);
+                    object.features = $root.google.protobuf.FeatureSet.toObject(message.features, options, q + 1);
                 if (message.uninterpretedOption && message.uninterpretedOption.length) {
                     object.uninterpretedOption = [];
                     for (var j = 0; j < message.uninterpretedOption.length; ++j)
-                        object.uninterpretedOption[j] = $root.google.protobuf.UninterpretedOption.toObject(message.uninterpretedOption[j], options);
+                        object.uninterpretedOption[j] = $root.google.protobuf.UninterpretedOption.toObject(message.uninterpretedOption[j], options, q + 1);
                 }
                 return object;
             };
@@ -16367,9 +16743,13 @@ $root.google = (function() {
              * @param {$protobuf.Writer} [writer] Writer to encode to
              * @returns {$protobuf.Writer} Writer
              */
-            MessageOptions.encode = function encode(message, writer) {
+            MessageOptions.encode = function encode(message, writer, q) {
                 if (!writer)
                     writer = $Writer.create();
+                if (q === undefined)
+                    q = 0;
+                if (q > $util.recursionLimit)
+                    throw Error("max depth exceeded");
                 if (message.messageSetWireFormat != null && Object.hasOwnProperty.call(message, "messageSetWireFormat"))
                     writer.uint32(/* id 1, wireType 0 =*/8).bool(message.messageSetWireFormat);
                 if (message.noStandardDescriptorAccessor != null && Object.hasOwnProperty.call(message, "noStandardDescriptorAccessor"))
@@ -16381,10 +16761,10 @@ $root.google = (function() {
                 if (message.deprecatedLegacyJsonFieldConflicts != null && Object.hasOwnProperty.call(message, "deprecatedLegacyJsonFieldConflicts"))
                     writer.uint32(/* id 11, wireType 0 =*/88).bool(message.deprecatedLegacyJsonFieldConflicts);
                 if (message.features != null && Object.hasOwnProperty.call(message, "features"))
-                    $root.google.protobuf.FeatureSet.encode(message.features, writer.uint32(/* id 12, wireType 2 =*/98).fork()).ldelim();
+                    $root.google.protobuf.FeatureSet.encode(message.features, writer.uint32(/* id 12, wireType 2 =*/98).fork(), q + 1).ldelim();
                 if (message.uninterpretedOption != null && message.uninterpretedOption.length)
                     for (var i = 0; i < message.uninterpretedOption.length; ++i)
-                        $root.google.protobuf.UninterpretedOption.encode(message.uninterpretedOption[i], writer.uint32(/* id 999, wireType 2 =*/7994).fork()).ldelim();
+                        $root.google.protobuf.UninterpretedOption.encode(message.uninterpretedOption[i], writer.uint32(/* id 999, wireType 2 =*/7994).fork(), q + 1).ldelim();
                 return writer;
             };
 
@@ -16579,9 +16959,13 @@ $root.google = (function() {
              * @param {$protobuf.IConversionOptions} [options] Conversion options
              * @returns {Object.<string,*>} Plain object
              */
-            MessageOptions.toObject = function toObject(message, options) {
+            MessageOptions.toObject = function toObject(message, options, q) {
                 if (!options)
                     options = {};
+                if (q === undefined)
+                    q = 0;
+                if (q > $util.recursionLimit)
+                    throw Error("max depth exceeded");
                 var object = {};
                 if (options.arrays || options.defaults)
                     object.uninterpretedOption = [];
@@ -16604,11 +16988,11 @@ $root.google = (function() {
                 if (message.deprecatedLegacyJsonFieldConflicts != null && message.hasOwnProperty("deprecatedLegacyJsonFieldConflicts"))
                     object.deprecatedLegacyJsonFieldConflicts = message.deprecatedLegacyJsonFieldConflicts;
                 if (message.features != null && message.hasOwnProperty("features"))
-                    object.features = $root.google.protobuf.FeatureSet.toObject(message.features, options);
+                    object.features = $root.google.protobuf.FeatureSet.toObject(message.features, options, q + 1);
                 if (message.uninterpretedOption && message.uninterpretedOption.length) {
                     object.uninterpretedOption = [];
                     for (var j = 0; j < message.uninterpretedOption.length; ++j)
-                        object.uninterpretedOption[j] = $root.google.protobuf.UninterpretedOption.toObject(message.uninterpretedOption[j], options);
+                        object.uninterpretedOption[j] = $root.google.protobuf.UninterpretedOption.toObject(message.uninterpretedOption[j], options, q + 1);
                 }
                 return object;
             };
@@ -16815,9 +17199,13 @@ $root.google = (function() {
              * @param {$protobuf.Writer} [writer] Writer to encode to
              * @returns {$protobuf.Writer} Writer
              */
-            FieldOptions.encode = function encode(message, writer) {
+            FieldOptions.encode = function encode(message, writer, q) {
                 if (!writer)
                     writer = $Writer.create();
+                if (q === undefined)
+                    q = 0;
+                if (q > $util.recursionLimit)
+                    throw Error("max depth exceeded");
                 if (message.ctype != null && Object.hasOwnProperty.call(message, "ctype"))
                     writer.uint32(/* id 1, wireType 0 =*/8).int32(message.ctype);
                 if (message.packed != null && Object.hasOwnProperty.call(message, "packed"))
@@ -16841,14 +17229,14 @@ $root.google = (function() {
                         writer.uint32(/* id 19, wireType 0 =*/152).int32(message.targets[i]);
                 if (message.editionDefaults != null && message.editionDefaults.length)
                     for (var i = 0; i < message.editionDefaults.length; ++i)
-                        $root.google.protobuf.FieldOptions.EditionDefault.encode(message.editionDefaults[i], writer.uint32(/* id 20, wireType 2 =*/162).fork()).ldelim();
+                        $root.google.protobuf.FieldOptions.EditionDefault.encode(message.editionDefaults[i], writer.uint32(/* id 20, wireType 2 =*/162).fork(), q + 1).ldelim();
                 if (message.features != null && Object.hasOwnProperty.call(message, "features"))
-                    $root.google.protobuf.FeatureSet.encode(message.features, writer.uint32(/* id 21, wireType 2 =*/170).fork()).ldelim();
+                    $root.google.protobuf.FeatureSet.encode(message.features, writer.uint32(/* id 21, wireType 2 =*/170).fork(), q + 1).ldelim();
                 if (message.featureSupport != null && Object.hasOwnProperty.call(message, "featureSupport"))
-                    $root.google.protobuf.FieldOptions.FeatureSupport.encode(message.featureSupport, writer.uint32(/* id 22, wireType 2 =*/178).fork()).ldelim();
+                    $root.google.protobuf.FieldOptions.FeatureSupport.encode(message.featureSupport, writer.uint32(/* id 22, wireType 2 =*/178).fork(), q + 1).ldelim();
                 if (message.uninterpretedOption != null && message.uninterpretedOption.length)
                     for (var i = 0; i < message.uninterpretedOption.length; ++i)
-                        $root.google.protobuf.UninterpretedOption.encode(message.uninterpretedOption[i], writer.uint32(/* id 999, wireType 2 =*/7994).fork()).ldelim();
+                        $root.google.protobuf.UninterpretedOption.encode(message.uninterpretedOption[i], writer.uint32(/* id 999, wireType 2 =*/7994).fork(), q + 1).ldelim();
                 return writer;
             };
 
@@ -17274,9 +17662,13 @@ $root.google = (function() {
              * @param {$protobuf.IConversionOptions} [options] Conversion options
              * @returns {Object.<string,*>} Plain object
              */
-            FieldOptions.toObject = function toObject(message, options) {
+            FieldOptions.toObject = function toObject(message, options, q) {
                 if (!options)
                     options = {};
+                if (q === undefined)
+                    q = 0;
+                if (q > $util.recursionLimit)
+                    throw Error("max depth exceeded");
                 var object = {};
                 if (options.arrays || options.defaults) {
                     object.targets = [];
@@ -17322,16 +17714,16 @@ $root.google = (function() {
                 if (message.editionDefaults && message.editionDefaults.length) {
                     object.editionDefaults = [];
                     for (var j = 0; j < message.editionDefaults.length; ++j)
-                        object.editionDefaults[j] = $root.google.protobuf.FieldOptions.EditionDefault.toObject(message.editionDefaults[j], options);
+                        object.editionDefaults[j] = $root.google.protobuf.FieldOptions.EditionDefault.toObject(message.editionDefaults[j], options, q + 1);
                 }
                 if (message.features != null && message.hasOwnProperty("features"))
-                    object.features = $root.google.protobuf.FeatureSet.toObject(message.features, options);
+                    object.features = $root.google.protobuf.FeatureSet.toObject(message.features, options, q + 1);
                 if (message.featureSupport != null && message.hasOwnProperty("featureSupport"))
-                    object.featureSupport = $root.google.protobuf.FieldOptions.FeatureSupport.toObject(message.featureSupport, options);
+                    object.featureSupport = $root.google.protobuf.FieldOptions.FeatureSupport.toObject(message.featureSupport, options, q + 1);
                 if (message.uninterpretedOption && message.uninterpretedOption.length) {
                     object.uninterpretedOption = [];
                     for (var j = 0; j < message.uninterpretedOption.length; ++j)
-                        object.uninterpretedOption[j] = $root.google.protobuf.UninterpretedOption.toObject(message.uninterpretedOption[j], options);
+                        object.uninterpretedOption[j] = $root.google.protobuf.UninterpretedOption.toObject(message.uninterpretedOption[j], options, q + 1);
                 }
                 return object;
             };
@@ -17502,9 +17894,13 @@ $root.google = (function() {
                  * @param {$protobuf.Writer} [writer] Writer to encode to
                  * @returns {$protobuf.Writer} Writer
                  */
-                EditionDefault.encode = function encode(message, writer) {
+                EditionDefault.encode = function encode(message, writer, q) {
                     if (!writer)
                         writer = $Writer.create();
+                    if (q === undefined)
+                        q = 0;
+                    if (q > $util.recursionLimit)
+                        throw Error("max depth exceeded");
                     if (message.value != null && Object.hasOwnProperty.call(message, "value"))
                         writer.uint32(/* id 2, wireType 2 =*/18).string(message.value);
                     if (message.edition != null && Object.hasOwnProperty.call(message, "edition"))
@@ -17706,9 +18102,13 @@ $root.google = (function() {
                  * @param {$protobuf.IConversionOptions} [options] Conversion options
                  * @returns {Object.<string,*>} Plain object
                  */
-                EditionDefault.toObject = function toObject(message, options) {
+                EditionDefault.toObject = function toObject(message, options, q) {
                     if (!options)
                         options = {};
+                    if (q === undefined)
+                        q = 0;
+                    if (q > $util.recursionLimit)
+                        throw Error("max depth exceeded");
                     var object = {};
                     if (options.defaults) {
                         object.value = "";
@@ -17830,9 +18230,13 @@ $root.google = (function() {
                  * @param {$protobuf.Writer} [writer] Writer to encode to
                  * @returns {$protobuf.Writer} Writer
                  */
-                FeatureSupport.encode = function encode(message, writer) {
+                FeatureSupport.encode = function encode(message, writer, q) {
                     if (!writer)
                         writer = $Writer.create();
+                    if (q === undefined)
+                        q = 0;
+                    if (q > $util.recursionLimit)
+                        throw Error("max depth exceeded");
                     if (message.editionIntroduced != null && Object.hasOwnProperty.call(message, "editionIntroduced"))
                         writer.uint32(/* id 1, wireType 0 =*/8).int32(message.editionIntroduced);
                     if (message.editionDeprecated != null && Object.hasOwnProperty.call(message, "editionDeprecated"))
@@ -18194,9 +18598,13 @@ $root.google = (function() {
                  * @param {$protobuf.IConversionOptions} [options] Conversion options
                  * @returns {Object.<string,*>} Plain object
                  */
-                FeatureSupport.toObject = function toObject(message, options) {
+                FeatureSupport.toObject = function toObject(message, options, q) {
                     if (!options)
                         options = {};
+                    if (q === undefined)
+                        q = 0;
+                    if (q > $util.recursionLimit)
+                        throw Error("max depth exceeded");
                     var object = {};
                     if (options.defaults) {
                         object.editionIntroduced = options.enums === String ? "EDITION_UNKNOWN" : 0;
@@ -18310,14 +18718,18 @@ $root.google = (function() {
              * @param {$protobuf.Writer} [writer] Writer to encode to
              * @returns {$protobuf.Writer} Writer
              */
-            OneofOptions.encode = function encode(message, writer) {
+            OneofOptions.encode = function encode(message, writer, q) {
                 if (!writer)
                     writer = $Writer.create();
+                if (q === undefined)
+                    q = 0;
+                if (q > $util.recursionLimit)
+                    throw Error("max depth exceeded");
                 if (message.features != null && Object.hasOwnProperty.call(message, "features"))
-                    $root.google.protobuf.FeatureSet.encode(message.features, writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
+                    $root.google.protobuf.FeatureSet.encode(message.features, writer.uint32(/* id 1, wireType 2 =*/10).fork(), q + 1).ldelim();
                 if (message.uninterpretedOption != null && message.uninterpretedOption.length)
                     for (var i = 0; i < message.uninterpretedOption.length; ++i)
-                        $root.google.protobuf.UninterpretedOption.encode(message.uninterpretedOption[i], writer.uint32(/* id 999, wireType 2 =*/7994).fork()).ldelim();
+                        $root.google.protobuf.UninterpretedOption.encode(message.uninterpretedOption[i], writer.uint32(/* id 999, wireType 2 =*/7994).fork(), q + 1).ldelim();
                 return writer;
             };
 
@@ -18467,20 +18879,24 @@ $root.google = (function() {
              * @param {$protobuf.IConversionOptions} [options] Conversion options
              * @returns {Object.<string,*>} Plain object
              */
-            OneofOptions.toObject = function toObject(message, options) {
+            OneofOptions.toObject = function toObject(message, options, q) {
                 if (!options)
                     options = {};
+                if (q === undefined)
+                    q = 0;
+                if (q > $util.recursionLimit)
+                    throw Error("max depth exceeded");
                 var object = {};
                 if (options.arrays || options.defaults)
                     object.uninterpretedOption = [];
                 if (options.defaults)
                     object.features = null;
                 if (message.features != null && message.hasOwnProperty("features"))
-                    object.features = $root.google.protobuf.FeatureSet.toObject(message.features, options);
+                    object.features = $root.google.protobuf.FeatureSet.toObject(message.features, options, q + 1);
                 if (message.uninterpretedOption && message.uninterpretedOption.length) {
                     object.uninterpretedOption = [];
                     for (var j = 0; j < message.uninterpretedOption.length; ++j)
-                        object.uninterpretedOption[j] = $root.google.protobuf.UninterpretedOption.toObject(message.uninterpretedOption[j], options);
+                        object.uninterpretedOption[j] = $root.google.protobuf.UninterpretedOption.toObject(message.uninterpretedOption[j], options, q + 1);
                 }
                 return object;
             };
@@ -18613,9 +19029,13 @@ $root.google = (function() {
              * @param {$protobuf.Writer} [writer] Writer to encode to
              * @returns {$protobuf.Writer} Writer
              */
-            EnumOptions.encode = function encode(message, writer) {
+            EnumOptions.encode = function encode(message, writer, q) {
                 if (!writer)
                     writer = $Writer.create();
+                if (q === undefined)
+                    q = 0;
+                if (q > $util.recursionLimit)
+                    throw Error("max depth exceeded");
                 if (message.allowAlias != null && Object.hasOwnProperty.call(message, "allowAlias"))
                     writer.uint32(/* id 2, wireType 0 =*/16).bool(message.allowAlias);
                 if (message.deprecated != null && Object.hasOwnProperty.call(message, "deprecated"))
@@ -18623,10 +19043,10 @@ $root.google = (function() {
                 if (message.deprecatedLegacyJsonFieldConflicts != null && Object.hasOwnProperty.call(message, "deprecatedLegacyJsonFieldConflicts"))
                     writer.uint32(/* id 6, wireType 0 =*/48).bool(message.deprecatedLegacyJsonFieldConflicts);
                 if (message.features != null && Object.hasOwnProperty.call(message, "features"))
-                    $root.google.protobuf.FeatureSet.encode(message.features, writer.uint32(/* id 7, wireType 2 =*/58).fork()).ldelim();
+                    $root.google.protobuf.FeatureSet.encode(message.features, writer.uint32(/* id 7, wireType 2 =*/58).fork(), q + 1).ldelim();
                 if (message.uninterpretedOption != null && message.uninterpretedOption.length)
                     for (var i = 0; i < message.uninterpretedOption.length; ++i)
-                        $root.google.protobuf.UninterpretedOption.encode(message.uninterpretedOption[i], writer.uint32(/* id 999, wireType 2 =*/7994).fork()).ldelim();
+                        $root.google.protobuf.UninterpretedOption.encode(message.uninterpretedOption[i], writer.uint32(/* id 999, wireType 2 =*/7994).fork(), q + 1).ldelim();
                 if (message[".jspb.test.IsExtension.simpleOption"] != null && Object.hasOwnProperty.call(message, ".jspb.test.IsExtension.simpleOption"))
                     writer.uint32(/* id 42113038, wireType 2 =*/336904306).string(message[".jspb.test.IsExtension.simpleOption"]);
                 return writer;
@@ -18814,9 +19234,13 @@ $root.google = (function() {
              * @param {$protobuf.IConversionOptions} [options] Conversion options
              * @returns {Object.<string,*>} Plain object
              */
-            EnumOptions.toObject = function toObject(message, options) {
+            EnumOptions.toObject = function toObject(message, options, q) {
                 if (!options)
                     options = {};
+                if (q === undefined)
+                    q = 0;
+                if (q > $util.recursionLimit)
+                    throw Error("max depth exceeded");
                 var object = {};
                 if (options.arrays || options.defaults)
                     object.uninterpretedOption = [];
@@ -18834,11 +19258,11 @@ $root.google = (function() {
                 if (message.deprecatedLegacyJsonFieldConflicts != null && message.hasOwnProperty("deprecatedLegacyJsonFieldConflicts"))
                     object.deprecatedLegacyJsonFieldConflicts = message.deprecatedLegacyJsonFieldConflicts;
                 if (message.features != null && message.hasOwnProperty("features"))
-                    object.features = $root.google.protobuf.FeatureSet.toObject(message.features, options);
+                    object.features = $root.google.protobuf.FeatureSet.toObject(message.features, options, q + 1);
                 if (message.uninterpretedOption && message.uninterpretedOption.length) {
                     object.uninterpretedOption = [];
                     for (var j = 0; j < message.uninterpretedOption.length; ++j)
-                        object.uninterpretedOption[j] = $root.google.protobuf.UninterpretedOption.toObject(message.uninterpretedOption[j], options);
+                        object.uninterpretedOption[j] = $root.google.protobuf.UninterpretedOption.toObject(message.uninterpretedOption[j], options, q + 1);
                 }
                 if (message[".jspb.test.IsExtension.simpleOption"] != null && message.hasOwnProperty(".jspb.test.IsExtension.simpleOption"))
                     object[".jspb.test.IsExtension.simpleOption"] = message[".jspb.test.IsExtension.simpleOption"];
@@ -18964,20 +19388,24 @@ $root.google = (function() {
              * @param {$protobuf.Writer} [writer] Writer to encode to
              * @returns {$protobuf.Writer} Writer
              */
-            EnumValueOptions.encode = function encode(message, writer) {
+            EnumValueOptions.encode = function encode(message, writer, q) {
                 if (!writer)
                     writer = $Writer.create();
+                if (q === undefined)
+                    q = 0;
+                if (q > $util.recursionLimit)
+                    throw Error("max depth exceeded");
                 if (message.deprecated != null && Object.hasOwnProperty.call(message, "deprecated"))
                     writer.uint32(/* id 1, wireType 0 =*/8).bool(message.deprecated);
                 if (message.features != null && Object.hasOwnProperty.call(message, "features"))
-                    $root.google.protobuf.FeatureSet.encode(message.features, writer.uint32(/* id 2, wireType 2 =*/18).fork()).ldelim();
+                    $root.google.protobuf.FeatureSet.encode(message.features, writer.uint32(/* id 2, wireType 2 =*/18).fork(), q + 1).ldelim();
                 if (message.debugRedact != null && Object.hasOwnProperty.call(message, "debugRedact"))
                     writer.uint32(/* id 3, wireType 0 =*/24).bool(message.debugRedact);
                 if (message.featureSupport != null && Object.hasOwnProperty.call(message, "featureSupport"))
-                    $root.google.protobuf.FieldOptions.FeatureSupport.encode(message.featureSupport, writer.uint32(/* id 4, wireType 2 =*/34).fork()).ldelim();
+                    $root.google.protobuf.FieldOptions.FeatureSupport.encode(message.featureSupport, writer.uint32(/* id 4, wireType 2 =*/34).fork(), q + 1).ldelim();
                 if (message.uninterpretedOption != null && message.uninterpretedOption.length)
                     for (var i = 0; i < message.uninterpretedOption.length; ++i)
-                        $root.google.protobuf.UninterpretedOption.encode(message.uninterpretedOption[i], writer.uint32(/* id 999, wireType 2 =*/7994).fork()).ldelim();
+                        $root.google.protobuf.UninterpretedOption.encode(message.uninterpretedOption[i], writer.uint32(/* id 999, wireType 2 =*/7994).fork(), q + 1).ldelim();
                 return writer;
             };
 
@@ -19159,9 +19587,13 @@ $root.google = (function() {
              * @param {$protobuf.IConversionOptions} [options] Conversion options
              * @returns {Object.<string,*>} Plain object
              */
-            EnumValueOptions.toObject = function toObject(message, options) {
+            EnumValueOptions.toObject = function toObject(message, options, q) {
                 if (!options)
                     options = {};
+                if (q === undefined)
+                    q = 0;
+                if (q > $util.recursionLimit)
+                    throw Error("max depth exceeded");
                 var object = {};
                 if (options.arrays || options.defaults)
                     object.uninterpretedOption = [];
@@ -19174,15 +19606,15 @@ $root.google = (function() {
                 if (message.deprecated != null && message.hasOwnProperty("deprecated"))
                     object.deprecated = message.deprecated;
                 if (message.features != null && message.hasOwnProperty("features"))
-                    object.features = $root.google.protobuf.FeatureSet.toObject(message.features, options);
+                    object.features = $root.google.protobuf.FeatureSet.toObject(message.features, options, q + 1);
                 if (message.debugRedact != null && message.hasOwnProperty("debugRedact"))
                     object.debugRedact = message.debugRedact;
                 if (message.featureSupport != null && message.hasOwnProperty("featureSupport"))
-                    object.featureSupport = $root.google.protobuf.FieldOptions.FeatureSupport.toObject(message.featureSupport, options);
+                    object.featureSupport = $root.google.protobuf.FieldOptions.FeatureSupport.toObject(message.featureSupport, options, q + 1);
                 if (message.uninterpretedOption && message.uninterpretedOption.length) {
                     object.uninterpretedOption = [];
                     for (var j = 0; j < message.uninterpretedOption.length; ++j)
-                        object.uninterpretedOption[j] = $root.google.protobuf.UninterpretedOption.toObject(message.uninterpretedOption[j], options);
+                        object.uninterpretedOption[j] = $root.google.protobuf.UninterpretedOption.toObject(message.uninterpretedOption[j], options, q + 1);
                 }
                 return object;
             };
@@ -19288,16 +19720,20 @@ $root.google = (function() {
              * @param {$protobuf.Writer} [writer] Writer to encode to
              * @returns {$protobuf.Writer} Writer
              */
-            ServiceOptions.encode = function encode(message, writer) {
+            ServiceOptions.encode = function encode(message, writer, q) {
                 if (!writer)
                     writer = $Writer.create();
+                if (q === undefined)
+                    q = 0;
+                if (q > $util.recursionLimit)
+                    throw Error("max depth exceeded");
                 if (message.deprecated != null && Object.hasOwnProperty.call(message, "deprecated"))
                     writer.uint32(/* id 33, wireType 0 =*/264).bool(message.deprecated);
                 if (message.features != null && Object.hasOwnProperty.call(message, "features"))
-                    $root.google.protobuf.FeatureSet.encode(message.features, writer.uint32(/* id 34, wireType 2 =*/274).fork()).ldelim();
+                    $root.google.protobuf.FeatureSet.encode(message.features, writer.uint32(/* id 34, wireType 2 =*/274).fork(), q + 1).ldelim();
                 if (message.uninterpretedOption != null && message.uninterpretedOption.length)
                     for (var i = 0; i < message.uninterpretedOption.length; ++i)
-                        $root.google.protobuf.UninterpretedOption.encode(message.uninterpretedOption[i], writer.uint32(/* id 999, wireType 2 =*/7994).fork()).ldelim();
+                        $root.google.protobuf.UninterpretedOption.encode(message.uninterpretedOption[i], writer.uint32(/* id 999, wireType 2 =*/7994).fork(), q + 1).ldelim();
                 return writer;
             };
 
@@ -19456,9 +19892,13 @@ $root.google = (function() {
              * @param {$protobuf.IConversionOptions} [options] Conversion options
              * @returns {Object.<string,*>} Plain object
              */
-            ServiceOptions.toObject = function toObject(message, options) {
+            ServiceOptions.toObject = function toObject(message, options, q) {
                 if (!options)
                     options = {};
+                if (q === undefined)
+                    q = 0;
+                if (q > $util.recursionLimit)
+                    throw Error("max depth exceeded");
                 var object = {};
                 if (options.arrays || options.defaults)
                     object.uninterpretedOption = [];
@@ -19469,11 +19909,11 @@ $root.google = (function() {
                 if (message.deprecated != null && message.hasOwnProperty("deprecated"))
                     object.deprecated = message.deprecated;
                 if (message.features != null && message.hasOwnProperty("features"))
-                    object.features = $root.google.protobuf.FeatureSet.toObject(message.features, options);
+                    object.features = $root.google.protobuf.FeatureSet.toObject(message.features, options, q + 1);
                 if (message.uninterpretedOption && message.uninterpretedOption.length) {
                     object.uninterpretedOption = [];
                     for (var j = 0; j < message.uninterpretedOption.length; ++j)
-                        object.uninterpretedOption[j] = $root.google.protobuf.UninterpretedOption.toObject(message.uninterpretedOption[j], options);
+                        object.uninterpretedOption[j] = $root.google.protobuf.UninterpretedOption.toObject(message.uninterpretedOption[j], options, q + 1);
                 }
                 return object;
             };
@@ -19588,18 +20028,22 @@ $root.google = (function() {
              * @param {$protobuf.Writer} [writer] Writer to encode to
              * @returns {$protobuf.Writer} Writer
              */
-            MethodOptions.encode = function encode(message, writer) {
+            MethodOptions.encode = function encode(message, writer, q) {
                 if (!writer)
                     writer = $Writer.create();
+                if (q === undefined)
+                    q = 0;
+                if (q > $util.recursionLimit)
+                    throw Error("max depth exceeded");
                 if (message.deprecated != null && Object.hasOwnProperty.call(message, "deprecated"))
                     writer.uint32(/* id 33, wireType 0 =*/264).bool(message.deprecated);
                 if (message.idempotencyLevel != null && Object.hasOwnProperty.call(message, "idempotencyLevel"))
                     writer.uint32(/* id 34, wireType 0 =*/272).int32(message.idempotencyLevel);
                 if (message.features != null && Object.hasOwnProperty.call(message, "features"))
-                    $root.google.protobuf.FeatureSet.encode(message.features, writer.uint32(/* id 35, wireType 2 =*/282).fork()).ldelim();
+                    $root.google.protobuf.FeatureSet.encode(message.features, writer.uint32(/* id 35, wireType 2 =*/282).fork(), q + 1).ldelim();
                 if (message.uninterpretedOption != null && message.uninterpretedOption.length)
                     for (var i = 0; i < message.uninterpretedOption.length; ++i)
-                        $root.google.protobuf.UninterpretedOption.encode(message.uninterpretedOption[i], writer.uint32(/* id 999, wireType 2 =*/7994).fork()).ldelim();
+                        $root.google.protobuf.UninterpretedOption.encode(message.uninterpretedOption[i], writer.uint32(/* id 999, wireType 2 =*/7994).fork(), q + 1).ldelim();
                 return writer;
             };
 
@@ -19791,9 +20235,13 @@ $root.google = (function() {
              * @param {$protobuf.IConversionOptions} [options] Conversion options
              * @returns {Object.<string,*>} Plain object
              */
-            MethodOptions.toObject = function toObject(message, options) {
+            MethodOptions.toObject = function toObject(message, options, q) {
                 if (!options)
                     options = {};
+                if (q === undefined)
+                    q = 0;
+                if (q > $util.recursionLimit)
+                    throw Error("max depth exceeded");
                 var object = {};
                 if (options.arrays || options.defaults)
                     object.uninterpretedOption = [];
@@ -19807,11 +20255,11 @@ $root.google = (function() {
                 if (message.idempotencyLevel != null && message.hasOwnProperty("idempotencyLevel"))
                     object.idempotencyLevel = options.enums === String ? $root.google.protobuf.MethodOptions.IdempotencyLevel[message.idempotencyLevel] === undefined ? message.idempotencyLevel : $root.google.protobuf.MethodOptions.IdempotencyLevel[message.idempotencyLevel] : message.idempotencyLevel;
                 if (message.features != null && message.hasOwnProperty("features"))
-                    object.features = $root.google.protobuf.FeatureSet.toObject(message.features, options);
+                    object.features = $root.google.protobuf.FeatureSet.toObject(message.features, options, q + 1);
                 if (message.uninterpretedOption && message.uninterpretedOption.length) {
                     object.uninterpretedOption = [];
                     for (var j = 0; j < message.uninterpretedOption.length; ++j)
-                        object.uninterpretedOption[j] = $root.google.protobuf.UninterpretedOption.toObject(message.uninterpretedOption[j], options);
+                        object.uninterpretedOption[j] = $root.google.protobuf.UninterpretedOption.toObject(message.uninterpretedOption[j], options, q + 1);
                 }
                 return object;
             };
@@ -19969,12 +20417,16 @@ $root.google = (function() {
              * @param {$protobuf.Writer} [writer] Writer to encode to
              * @returns {$protobuf.Writer} Writer
              */
-            UninterpretedOption.encode = function encode(message, writer) {
+            UninterpretedOption.encode = function encode(message, writer, q) {
                 if (!writer)
                     writer = $Writer.create();
+                if (q === undefined)
+                    q = 0;
+                if (q > $util.recursionLimit)
+                    throw Error("max depth exceeded");
                 if (message.name != null && message.name.length)
                     for (var i = 0; i < message.name.length; ++i)
-                        $root.google.protobuf.UninterpretedOption.NamePart.encode(message.name[i], writer.uint32(/* id 2, wireType 2 =*/18).fork()).ldelim();
+                        $root.google.protobuf.UninterpretedOption.NamePart.encode(message.name[i], writer.uint32(/* id 2, wireType 2 =*/18).fork(), q + 1).ldelim();
                 if (message.identifierValue != null && Object.hasOwnProperty.call(message, "identifierValue"))
                     writer.uint32(/* id 3, wireType 2 =*/26).string(message.identifierValue);
                 if (message.positiveIntValue != null && Object.hasOwnProperty.call(message, "positiveIntValue"))
@@ -20193,9 +20645,13 @@ $root.google = (function() {
              * @param {$protobuf.IConversionOptions} [options] Conversion options
              * @returns {Object.<string,*>} Plain object
              */
-            UninterpretedOption.toObject = function toObject(message, options) {
+            UninterpretedOption.toObject = function toObject(message, options, q) {
                 if (!options)
                     options = {};
+                if (q === undefined)
+                    q = 0;
+                if (q > $util.recursionLimit)
+                    throw Error("max depth exceeded");
                 var object = {};
                 if (options.arrays || options.defaults)
                     object.name = [];
@@ -20224,7 +20680,7 @@ $root.google = (function() {
                 if (message.name && message.name.length) {
                     object.name = [];
                     for (var j = 0; j < message.name.length; ++j)
-                        object.name[j] = $root.google.protobuf.UninterpretedOption.NamePart.toObject(message.name[j], options);
+                        object.name[j] = $root.google.protobuf.UninterpretedOption.NamePart.toObject(message.name[j], options, q + 1);
                 }
                 if (message.identifierValue != null && message.hasOwnProperty("identifierValue"))
                     object.identifierValue = message.identifierValue;
@@ -20339,9 +20795,13 @@ $root.google = (function() {
                  * @param {$protobuf.Writer} [writer] Writer to encode to
                  * @returns {$protobuf.Writer} Writer
                  */
-                NamePart.encode = function encode(message, writer) {
+                NamePart.encode = function encode(message, writer, q) {
                     if (!writer)
                         writer = $Writer.create();
+                    if (q === undefined)
+                        q = 0;
+                    if (q > $util.recursionLimit)
+                        throw Error("max depth exceeded");
                     writer.uint32(/* id 1, wireType 2 =*/10).string(message.namePart);
                     writer.uint32(/* id 2, wireType 0 =*/16).bool(message.isExtension);
                     return writer;
@@ -20474,9 +20934,13 @@ $root.google = (function() {
                  * @param {$protobuf.IConversionOptions} [options] Conversion options
                  * @returns {Object.<string,*>} Plain object
                  */
-                NamePart.toObject = function toObject(message, options) {
+                NamePart.toObject = function toObject(message, options, q) {
                     if (!options)
                         options = {};
+                    if (q === undefined)
+                        q = 0;
+                    if (q > $util.recursionLimit)
+                        throw Error("max depth exceeded");
                     var object = {};
                     if (options.defaults) {
                         object.namePart = "";
@@ -20637,9 +21101,13 @@ $root.google = (function() {
              * @param {$protobuf.Writer} [writer] Writer to encode to
              * @returns {$protobuf.Writer} Writer
              */
-            FeatureSet.encode = function encode(message, writer) {
+            FeatureSet.encode = function encode(message, writer, q) {
                 if (!writer)
                     writer = $Writer.create();
+                if (q === undefined)
+                    q = 0;
+                if (q > $util.recursionLimit)
+                    throw Error("max depth exceeded");
                 if (message.fieldPresence != null && Object.hasOwnProperty.call(message, "fieldPresence"))
                     writer.uint32(/* id 1, wireType 0 =*/8).int32(message.fieldPresence);
                 if (message.enumType != null && Object.hasOwnProperty.call(message, "enumType"))
@@ -21045,9 +21513,13 @@ $root.google = (function() {
              * @param {$protobuf.IConversionOptions} [options] Conversion options
              * @returns {Object.<string,*>} Plain object
              */
-            FeatureSet.toObject = function toObject(message, options) {
+            FeatureSet.toObject = function toObject(message, options, q) {
                 if (!options)
                     options = {};
+                if (q === undefined)
+                    q = 0;
+                if (q > $util.recursionLimit)
+                    throw Error("max depth exceeded");
                 var object = {};
                 if (options.defaults) {
                     object.fieldPresence = options.enums === String ? "FIELD_PRESENCE_UNKNOWN" : 0;
@@ -21262,9 +21734,13 @@ $root.google = (function() {
                  * @param {$protobuf.Writer} [writer] Writer to encode to
                  * @returns {$protobuf.Writer} Writer
                  */
-                VisibilityFeature.encode = function encode(message, writer) {
+                VisibilityFeature.encode = function encode(message, writer, q) {
                     if (!writer)
                         writer = $Writer.create();
+                    if (q === undefined)
+                        q = 0;
+                    if (q > $util.recursionLimit)
+                        throw Error("max depth exceeded");
                     return writer;
                 };
 
@@ -21502,12 +21978,16 @@ $root.google = (function() {
              * @param {$protobuf.Writer} [writer] Writer to encode to
              * @returns {$protobuf.Writer} Writer
              */
-            FeatureSetDefaults.encode = function encode(message, writer) {
+            FeatureSetDefaults.encode = function encode(message, writer, q) {
                 if (!writer)
                     writer = $Writer.create();
+                if (q === undefined)
+                    q = 0;
+                if (q > $util.recursionLimit)
+                    throw Error("max depth exceeded");
                 if (message.defaults != null && message.defaults.length)
                     for (var i = 0; i < message.defaults.length; ++i)
-                        $root.google.protobuf.FeatureSetDefaults.FeatureSetEditionDefault.encode(message.defaults[i], writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
+                        $root.google.protobuf.FeatureSetDefaults.FeatureSetEditionDefault.encode(message.defaults[i], writer.uint32(/* id 1, wireType 2 =*/10).fork(), q + 1).ldelim();
                 if (message.minimumEdition != null && Object.hasOwnProperty.call(message, "minimumEdition"))
                     writer.uint32(/* id 4, wireType 0 =*/32).int32(message.minimumEdition);
                 if (message.maximumEdition != null && Object.hasOwnProperty.call(message, "maximumEdition"))
@@ -21803,9 +22283,13 @@ $root.google = (function() {
              * @param {$protobuf.IConversionOptions} [options] Conversion options
              * @returns {Object.<string,*>} Plain object
              */
-            FeatureSetDefaults.toObject = function toObject(message, options) {
+            FeatureSetDefaults.toObject = function toObject(message, options, q) {
                 if (!options)
                     options = {};
+                if (q === undefined)
+                    q = 0;
+                if (q > $util.recursionLimit)
+                    throw Error("max depth exceeded");
                 var object = {};
                 if (options.arrays || options.defaults)
                     object.defaults = [];
@@ -21816,7 +22300,7 @@ $root.google = (function() {
                 if (message.defaults && message.defaults.length) {
                     object.defaults = [];
                     for (var j = 0; j < message.defaults.length; ++j)
-                        object.defaults[j] = $root.google.protobuf.FeatureSetDefaults.FeatureSetEditionDefault.toObject(message.defaults[j], options);
+                        object.defaults[j] = $root.google.protobuf.FeatureSetDefaults.FeatureSetEditionDefault.toObject(message.defaults[j], options, q + 1);
                 }
                 if (message.minimumEdition != null && message.hasOwnProperty("minimumEdition"))
                     object.minimumEdition = options.enums === String ? $root.google.protobuf.Edition[message.minimumEdition] === undefined ? message.minimumEdition : $root.google.protobuf.Edition[message.minimumEdition] : message.minimumEdition;
@@ -21922,15 +22406,19 @@ $root.google = (function() {
                  * @param {$protobuf.Writer} [writer] Writer to encode to
                  * @returns {$protobuf.Writer} Writer
                  */
-                FeatureSetEditionDefault.encode = function encode(message, writer) {
+                FeatureSetEditionDefault.encode = function encode(message, writer, q) {
                     if (!writer)
                         writer = $Writer.create();
+                    if (q === undefined)
+                        q = 0;
+                    if (q > $util.recursionLimit)
+                        throw Error("max depth exceeded");
                     if (message.edition != null && Object.hasOwnProperty.call(message, "edition"))
                         writer.uint32(/* id 3, wireType 0 =*/24).int32(message.edition);
                     if (message.overridableFeatures != null && Object.hasOwnProperty.call(message, "overridableFeatures"))
-                        $root.google.protobuf.FeatureSet.encode(message.overridableFeatures, writer.uint32(/* id 4, wireType 2 =*/34).fork()).ldelim();
+                        $root.google.protobuf.FeatureSet.encode(message.overridableFeatures, writer.uint32(/* id 4, wireType 2 =*/34).fork(), q + 1).ldelim();
                     if (message.fixedFeatures != null && Object.hasOwnProperty.call(message, "fixedFeatures"))
-                        $root.google.protobuf.FeatureSet.encode(message.fixedFeatures, writer.uint32(/* id 5, wireType 2 =*/42).fork()).ldelim();
+                        $root.google.protobuf.FeatureSet.encode(message.fixedFeatures, writer.uint32(/* id 5, wireType 2 =*/42).fork(), q + 1).ldelim();
                     return writer;
                 };
 
@@ -22147,9 +22635,13 @@ $root.google = (function() {
                  * @param {$protobuf.IConversionOptions} [options] Conversion options
                  * @returns {Object.<string,*>} Plain object
                  */
-                FeatureSetEditionDefault.toObject = function toObject(message, options) {
+                FeatureSetEditionDefault.toObject = function toObject(message, options, q) {
                     if (!options)
                         options = {};
+                    if (q === undefined)
+                        q = 0;
+                    if (q > $util.recursionLimit)
+                        throw Error("max depth exceeded");
                     var object = {};
                     if (options.defaults) {
                         object.edition = options.enums === String ? "EDITION_UNKNOWN" : 0;
@@ -22159,9 +22651,9 @@ $root.google = (function() {
                     if (message.edition != null && message.hasOwnProperty("edition"))
                         object.edition = options.enums === String ? $root.google.protobuf.Edition[message.edition] === undefined ? message.edition : $root.google.protobuf.Edition[message.edition] : message.edition;
                     if (message.overridableFeatures != null && message.hasOwnProperty("overridableFeatures"))
-                        object.overridableFeatures = $root.google.protobuf.FeatureSet.toObject(message.overridableFeatures, options);
+                        object.overridableFeatures = $root.google.protobuf.FeatureSet.toObject(message.overridableFeatures, options, q + 1);
                     if (message.fixedFeatures != null && message.hasOwnProperty("fixedFeatures"))
-                        object.fixedFeatures = $root.google.protobuf.FeatureSet.toObject(message.fixedFeatures, options);
+                        object.fixedFeatures = $root.google.protobuf.FeatureSet.toObject(message.fixedFeatures, options, q + 1);
                     return object;
                 };
 
@@ -22251,12 +22743,16 @@ $root.google = (function() {
              * @param {$protobuf.Writer} [writer] Writer to encode to
              * @returns {$protobuf.Writer} Writer
              */
-            SourceCodeInfo.encode = function encode(message, writer) {
+            SourceCodeInfo.encode = function encode(message, writer, q) {
                 if (!writer)
                     writer = $Writer.create();
+                if (q === undefined)
+                    q = 0;
+                if (q > $util.recursionLimit)
+                    throw Error("max depth exceeded");
                 if (message.location != null && message.location.length)
                     for (var i = 0; i < message.location.length; ++i)
-                        $root.google.protobuf.SourceCodeInfo.Location.encode(message.location[i], writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
+                        $root.google.protobuf.SourceCodeInfo.Location.encode(message.location[i], writer.uint32(/* id 1, wireType 2 =*/10).fork(), q + 1).ldelim();
                 return writer;
             };
 
@@ -22392,16 +22888,20 @@ $root.google = (function() {
              * @param {$protobuf.IConversionOptions} [options] Conversion options
              * @returns {Object.<string,*>} Plain object
              */
-            SourceCodeInfo.toObject = function toObject(message, options) {
+            SourceCodeInfo.toObject = function toObject(message, options, q) {
                 if (!options)
                     options = {};
+                if (q === undefined)
+                    q = 0;
+                if (q > $util.recursionLimit)
+                    throw Error("max depth exceeded");
                 var object = {};
                 if (options.arrays || options.defaults)
                     object.location = [];
                 if (message.location && message.location.length) {
                     object.location = [];
                     for (var j = 0; j < message.location.length; ++j)
-                        object.location[j] = $root.google.protobuf.SourceCodeInfo.Location.toObject(message.location[j], options);
+                        object.location[j] = $root.google.protobuf.SourceCodeInfo.Location.toObject(message.location[j], options, q + 1);
                 }
                 return object;
             };
@@ -22524,9 +23024,13 @@ $root.google = (function() {
                  * @param {$protobuf.Writer} [writer] Writer to encode to
                  * @returns {$protobuf.Writer} Writer
                  */
-                Location.encode = function encode(message, writer) {
+                Location.encode = function encode(message, writer, q) {
                     if (!writer)
                         writer = $Writer.create();
+                    if (q === undefined)
+                        q = 0;
+                    if (q > $util.recursionLimit)
+                        throw Error("max depth exceeded");
                     if (message.path != null && message.path.length) {
                         writer.uint32(/* id 1, wireType 2 =*/10).fork();
                         for (var i = 0; i < message.path.length; ++i)
@@ -22744,9 +23248,13 @@ $root.google = (function() {
                  * @param {$protobuf.IConversionOptions} [options] Conversion options
                  * @returns {Object.<string,*>} Plain object
                  */
-                Location.toObject = function toObject(message, options) {
+                Location.toObject = function toObject(message, options, q) {
                     if (!options)
                         options = {};
+                    if (q === undefined)
+                        q = 0;
+                    if (q > $util.recursionLimit)
+                        throw Error("max depth exceeded");
                     var object = {};
                     if (options.arrays || options.defaults) {
                         object.path = [];
@@ -22865,12 +23373,16 @@ $root.google = (function() {
              * @param {$protobuf.Writer} [writer] Writer to encode to
              * @returns {$protobuf.Writer} Writer
              */
-            GeneratedCodeInfo.encode = function encode(message, writer) {
+            GeneratedCodeInfo.encode = function encode(message, writer, q) {
                 if (!writer)
                     writer = $Writer.create();
+                if (q === undefined)
+                    q = 0;
+                if (q > $util.recursionLimit)
+                    throw Error("max depth exceeded");
                 if (message.annotation != null && message.annotation.length)
                     for (var i = 0; i < message.annotation.length; ++i)
-                        $root.google.protobuf.GeneratedCodeInfo.Annotation.encode(message.annotation[i], writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
+                        $root.google.protobuf.GeneratedCodeInfo.Annotation.encode(message.annotation[i], writer.uint32(/* id 1, wireType 2 =*/10).fork(), q + 1).ldelim();
                 return writer;
             };
 
@@ -23006,16 +23518,20 @@ $root.google = (function() {
              * @param {$protobuf.IConversionOptions} [options] Conversion options
              * @returns {Object.<string,*>} Plain object
              */
-            GeneratedCodeInfo.toObject = function toObject(message, options) {
+            GeneratedCodeInfo.toObject = function toObject(message, options, q) {
                 if (!options)
                     options = {};
+                if (q === undefined)
+                    q = 0;
+                if (q > $util.recursionLimit)
+                    throw Error("max depth exceeded");
                 var object = {};
                 if (options.arrays || options.defaults)
                     object.annotation = [];
                 if (message.annotation && message.annotation.length) {
                     object.annotation = [];
                     for (var j = 0; j < message.annotation.length; ++j)
-                        object.annotation[j] = $root.google.protobuf.GeneratedCodeInfo.Annotation.toObject(message.annotation[j], options);
+                        object.annotation[j] = $root.google.protobuf.GeneratedCodeInfo.Annotation.toObject(message.annotation[j], options, q + 1);
                 }
                 return object;
             };
@@ -23136,9 +23652,13 @@ $root.google = (function() {
                  * @param {$protobuf.Writer} [writer] Writer to encode to
                  * @returns {$protobuf.Writer} Writer
                  */
-                Annotation.encode = function encode(message, writer) {
+                Annotation.encode = function encode(message, writer, q) {
                     if (!writer)
                         writer = $Writer.create();
+                    if (q === undefined)
+                        q = 0;
+                    if (q > $util.recursionLimit)
+                        throw Error("max depth exceeded");
                     if (message.path != null && message.path.length) {
                         writer.uint32(/* id 1, wireType 2 =*/10).fork();
                         for (var i = 0; i < message.path.length; ++i)
@@ -23348,9 +23868,13 @@ $root.google = (function() {
                  * @param {$protobuf.IConversionOptions} [options] Conversion options
                  * @returns {Object.<string,*>} Plain object
                  */
-                Annotation.toObject = function toObject(message, options) {
+                Annotation.toObject = function toObject(message, options, q) {
                     if (!options)
                         options = {};
+                    if (q === undefined)
+                        q = 0;
+                    if (q > $util.recursionLimit)
+                        throw Error("max depth exceeded");
                     var object = {};
                     if (options.arrays || options.defaults)
                         object.path = [];

--- a/tests/data/type_url.js
+++ b/tests/data/type_url.js
@@ -62,11 +62,15 @@ $root.TypeUrlTest = (function() {
      * @param {$protobuf.Writer} [writer] Writer to encode to
      * @returns {$protobuf.Writer} Writer
      */
-    TypeUrlTest.encode = function encode(message, writer) {
+    TypeUrlTest.encode = function encode(message, writer, q) {
         if (!writer)
             writer = $Writer.create();
+        if (q === undefined)
+            q = 0;
+        if (q > $util.recursionLimit)
+            throw Error("max depth exceeded");
         if (message.nested != null && Object.hasOwnProperty.call(message, "nested"))
-            $root.TypeUrlTest.Nested.encode(message.nested, writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
+            $root.TypeUrlTest.Nested.encode(message.nested, writer.uint32(/* id 1, wireType 2 =*/10).fork(), q + 1).ldelim();
         return writer;
     };
 
@@ -191,14 +195,18 @@ $root.TypeUrlTest = (function() {
      * @param {$protobuf.IConversionOptions} [options] Conversion options
      * @returns {Object.<string,*>} Plain object
      */
-    TypeUrlTest.toObject = function toObject(message, options) {
+    TypeUrlTest.toObject = function toObject(message, options, q) {
         if (!options)
             options = {};
+        if (q === undefined)
+            q = 0;
+        if (q > $util.recursionLimit)
+            throw Error("max depth exceeded");
         var object = {};
         if (options.defaults)
             object.nested = null;
         if (message.nested != null && message.hasOwnProperty("nested"))
-            object.nested = $root.TypeUrlTest.Nested.toObject(message.nested, options);
+            object.nested = $root.TypeUrlTest.Nested.toObject(message.nested, options, q + 1);
         return object;
     };
 
@@ -281,9 +289,13 @@ $root.TypeUrlTest = (function() {
          * @param {$protobuf.Writer} [writer] Writer to encode to
          * @returns {$protobuf.Writer} Writer
          */
-        Nested.encode = function encode(message, writer) {
+        Nested.encode = function encode(message, writer, q) {
             if (!writer)
                 writer = $Writer.create();
+            if (q === undefined)
+                q = 0;
+            if (q > $util.recursionLimit)
+                throw Error("max depth exceeded");
             if (message.a != null && Object.hasOwnProperty.call(message, "a"))
                 writer.uint32(/* id 1, wireType 2 =*/10).string(message.a);
             return writer;
@@ -405,9 +417,13 @@ $root.TypeUrlTest = (function() {
          * @param {$protobuf.IConversionOptions} [options] Conversion options
          * @returns {Object.<string,*>} Plain object
          */
-        Nested.toObject = function toObject(message, options) {
+        Nested.toObject = function toObject(message, options, q) {
             if (!options)
                 options = {};
+            if (q === undefined)
+                q = 0;
+            if (q > $util.recursionLimit)
+                throw Error("max depth exceeded");
             var object = {};
             if (options.defaults)
                 object.a = "";

--- a/tests/node/api_load-sync.js
+++ b/tests/node/api_load-sync.js
@@ -36,6 +36,35 @@ tape.test("load sync", function(test) {
     test.end();
 });
 
+tape.test("load sync import recursion limit", function(test) {
+    var fs = protobuf.util.fs,
+        readFileSync = fs.readFileSync,
+        recursionLimit = protobuf.util.recursionLimit;
+
+    protobuf.util.recursionLimit = 3;
+    fs.readFileSync = function(filename) {
+        var match = /chain-(\d+)\.proto$/.exec(filename);
+        if (match)
+            return "syntax = \"proto3\";\nimport \"chain-" + (Number(match[1]) + 1) + ".proto\";\n";
+        return readFileSync.apply(this, arguments);
+    };
+
+    try {
+        var root = new protobuf.Root();
+        root.resolvePath = function(origin, target) {
+            return target;
+        };
+        test.throws(function() {
+            root.loadSync("chain-0.proto");
+        }, /max depth exceeded/, "should reject excessive import nesting");
+    } finally {
+        fs.readFileSync = readFileSync;
+        protobuf.util.recursionLimit = recursionLimit;
+    }
+
+    test.end();
+});
+
 tape.test("should load bundled definitions even if resolvePath method was overrided", function(test) {
     var protoFilePath = "tests/data/common.proto";
     var root = new protobuf.Root();


### PR DESCRIPTION
Backports the miscellaneous input hardening from #2272 to the 7.x line, including not yet backported depth-limit consolidation from #2246.

No API changes.