### PR TITLE
feat: Expose RPC metadata on service methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,8 @@ Message types expose focused methods for validation, conversion, and binary I/O.
 * **message#toJSON**(): `object`  
   Converts a message instance to JSON-compatible output using default conversion options.
 
+Message instances provide runtime identity, so they can be tested with `instanceof`. Their `toJSON` method integrates them with `JSON.stringify`.
+
 Length-delimited methods read and write a varint byte length before the message, which is useful for streams and framed protocols.
 
 If required fields are missing while decoding proto2 data, `decode` throws `protobuf.util.ProtocolError` with the partially decoded message available as `err.instance`.
@@ -311,7 +313,23 @@ protobuf.js will populate the constructor with the usual static runtime methods 
 
 ### Services
 
-protobuf.js supports service clients built from reflected service definitions. The service API is transport-agnostic: provide an `rpcImpl` function to connect it to HTTP, WebSocket, gRPC, or another transport. See [examples/streaming-rpc.js](./examples/streaming-rpc.js) for details.
+protobuf.js supports service clients built from service definitions. The service API is transport-agnostic: provide an `rpcImpl` function to connect it to HTTP, WebSocket, gRPC, or another transport.
+
+```js
+function myRpcImpl(method, requestData, callback) {
+  // method.name
+  // method.path
+  // method.requestStream?
+  // method.responseStream?
+  performRequest(requestData, function(err, responseData) {
+    callback(err, responseData);
+  });
+}
+
+const myService = MyService.create(myRpcImpl/*, requestDelimited?, responseDelimited? */);
+```
+
+See [examples/streaming-rpc.js](./examples/streaming-rpc.js) for a streaming example.
 
 ### Descriptors
 

--- a/cli/lib/tsd-jsdoc/publish.js
+++ b/cli/lib/tsd-jsdoc/publish.js
@@ -837,8 +837,20 @@ function handleTypeDef(element, parent) {
         if (element.tsType)
             write(element.tsType.replace(/\r?\n|\r/g, "\n"));
         else {
-            if (element.type && element.type.names.length === 1 && element.type.names[0] === "function")
-                writeFunctionSignature(element, false, true);
+            if (element.type && element.type.names.length === 1 && element.type.names[0] === "function") {
+                if (element.properties && element.properties.length) {
+                    writeln("{");
+                    ++indent;
+                    writeFunctionSignature(element, false, false);
+                    writeln(";");
+                    element.properties.forEach(function(property) {
+                        writeProperty(property);
+                    });
+                    --indent;
+                    write("}");
+                } else
+                    writeFunctionSignature(element, false, true);
+            }
             else if (type === "object") {
                 if (element.properties && element.properties.length)
                     writeInterfaceBody(element);

--- a/cli/targets/static.js
+++ b/cli/targets/static.js
@@ -883,7 +883,8 @@ function buildService(ref, service) {
     service.methodsArray.forEach(function(method) {
         method.resolve();
         var lcName = protobuf.util.lcFirst(method.name),
-            cbName = escapeName(method.name + "Callback");
+            cbName = escapeName(method.name + "Callback"),
+            methodTypeName = escapeName(method.name);
         push("");
         pushComment([
             "Callback as used by {@link " + exportName(service) + "#" + escapeName(lcName) + "}.",
@@ -897,30 +898,39 @@ function buildService(ref, service) {
         push("");
         pushComment([
             method.comment || "Calls " + method.name + ".",
-            "@function " + lcName,
             "@memberof " + exportName(service),
-            "@instance",
-            "@param {" + exportName(method.resolvedRequestType, !config.forceMessage) + "} request " + method.resolvedRequestType.name + " message or plain object",
-            "@param {" + exportName(service) + "." + cbName + "} callback Node-style callback called with the error, if any, and " + method.resolvedResponseType.name,
-            "@returns {undefined}",
-            "@variation 1"
+            "@typedef " + methodTypeName,
+            "@type {{",
+            "  (request: " + exportName(method.resolvedRequestType, !config.forceMessage) + ", callback: " + exportName(service) + "." + cbName + "): void;",
+            "  (request: " + exportName(method.resolvedRequestType, !config.forceMessage) + "): Promise<" + exportName(method.resolvedResponseType) + ">;",
+            "  readonly name: " + JSON.stringify(method.name) + ";",
+            "  readonly path: " + JSON.stringify(method.path) + ";",
+            "  readonly requestType: " + JSON.stringify(method.requestType) + ";",
+            "  readonly responseType: " + JSON.stringify(method.responseType) + ";",
+            "  readonly requestStream: " + (method.requestStream ? "true" : "undefined") + ";",
+            "  readonly responseStream: " + (method.responseStream ? "true" : "undefined") + ";",
+            "}}"
         ]);
-        push("Object.defineProperty(" + escapeName(service.name) + ".prototype" + util.safeProp(lcName) + " = function " + escapeName(lcName) + "(request, callback) {");
+        push("");
+        pushComment([
+            method.comment || "Calls " + method.name + ".",
+            "@name " + exportName(service) + "#" + lcName,
+            "@type {" + exportName(service) + "." + methodTypeName + "}"
+        ]);
+        push("Object.defineProperties(" + escapeName(service.name) + ".prototype" + util.safeProp(lcName) + " = function " + escapeName(lcName) + "(request, callback) {");
             ++indent;
             push("return this.rpcCall(" + escapeName(lcName) + ", $root." + exportName(method.resolvedRequestType) + ", $root." + exportName(method.resolvedResponseType) + ", request, callback);");
             --indent;
-        push("}, \"name\", { value: " + JSON.stringify(method.name) + " });");
-        if (config.comments)
-            push("");
-        pushComment([
-            method.comment || "Calls " + method.name + ".",
-            "@function " + lcName,
-            "@memberof " + exportName(service),
-            "@instance",
-            "@param {" + exportName(method.resolvedRequestType, !config.forceMessage) + "} request " + method.resolvedRequestType.name + " message or plain object",
-            "@returns {Promise<" + exportName(method.resolvedResponseType) + ">} Promise",
-            "@variation 2"
-        ]);
+        push("}, {");
+            ++indent;
+            push("name: { value: " + JSON.stringify(method.name) + " },");
+            push("path: { value: " + JSON.stringify(method.path) + " },");
+            push("requestType: { value: " + JSON.stringify(method.requestType) + " },");
+            push("responseType: { value: " + JSON.stringify(method.responseType) + " },");
+            push("requestStream: { value: " + (method.requestStream ? "true" : "undefined") + " },");
+            push("responseStream: { value: " + (method.responseStream ? "true" : "undefined") + " }");
+            --indent;
+        push("});");
     });
 }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -666,13 +666,16 @@ export class Method extends ReflectionObject {
     requestType: string;
 
     /** Whether requests are streamed or not. */
-    requestStream?: boolean;
+    requestStream?: true;
 
     /** Response type. */
     responseType: string;
 
     /** Whether responses are streamed or not. */
-    responseStream?: boolean;
+    responseStream?: true;
+
+    /** gRPC-style method path. */
+    path: string;
 
     /** Resolved request type. */
     resolvedRequestType: (Type|null);
@@ -1453,13 +1456,17 @@ export namespace rpc {
      */
     type ServiceMethodCallback<TRes extends Message<TRes>> = (error: (Error|null), response?: TRes) => void;
 
-    /**
-     * A service method part of a {@link rpc.Service} as created by {@link Service.create}.
-     * @param request Request message or plain object
-     * @param [callback] Node-style callback called with the error, if any, and the response message
-     * @returns Promise if `callback` has been omitted, otherwise `undefined`
-     */
-    type ServiceMethod<TReq extends Message<TReq>, TRes extends Message<TRes>> = (request: (TReq|Properties<TReq>), callback?: rpc.ServiceMethodCallback<TRes>) => Promise<Message<TRes>>;
+    /** A service method part of a {@link rpc.Service} as created by {@link Service.create}. */
+    type ServiceMethod<TReq extends Message<TReq>, TRes extends Message<TRes>> = {
+  (request: TReq|Properties<TReq>, callback: rpc.ServiceMethodCallback<TRes>): void;
+  (request: TReq|Properties<TReq>): Promise<TRes>;
+  readonly name: string;
+  readonly path: string;
+  readonly requestType: string;
+  readonly responseType: string;
+  readonly requestStream: true|undefined;
+  readonly responseStream: true|undefined;
+};
 
     /** An RPC service as returned by {@link Service#create}. */
     class Service extends util.EventEmitter {

--- a/src/method.js
+++ b/src/method.js
@@ -61,7 +61,7 @@ function Method(name, type, requestType, responseType, requestStream, responseSt
 
     /**
      * Whether requests are streamed or not.
-     * @type {boolean|undefined}
+     * @type {true|undefined}
      */
     this.requestStream = requestStream ? true : undefined; // toJSON
 
@@ -73,9 +73,15 @@ function Method(name, type, requestType, responseType, requestStream, responseSt
 
     /**
      * Whether responses are streamed or not.
-     * @type {boolean|undefined}
+     * @type {true|undefined}
      */
     this.responseStream = responseStream ? true : undefined; // toJSON
+
+    /**
+     * gRPC-style method path.
+     * @type {string}
+     */
+    this.path = "/" + this.name;
 
     /**
      * Resolved request type.
@@ -153,6 +159,14 @@ Method.prototype.resolve = function resolve() {
     /* istanbul ignore if */
     if (this.resolved)
         return this;
+
+    if (this.parent) {
+        var serviceName = this.parent.fullName;
+        if (serviceName.charAt(0) === ".")
+            serviceName = serviceName.substring(1);
+        this.path = "/" + serviceName + "/" + this.name;
+    } else
+        this.path = "/" + this.name;
 
     this.resolvedRequestType = this.parent.lookupType(this.requestType);
     this.resolvedResponseType = this.parent.lookupType(this.responseType);

--- a/src/rpc/service.js
+++ b/src/rpc/service.js
@@ -23,10 +23,16 @@ var util = require("../util/minimal");
  * @typedef rpc.ServiceMethod
  * @template TReq extends Message<TReq>
  * @template TRes extends Message<TRes>
- * @type {function}
- * @param {TReq|Properties<TReq>} request Request message or plain object
- * @param {rpc.ServiceMethodCallback<TRes>} [callback] Node-style callback called with the error, if any, and the response message
- * @returns {Promise<Message<TRes>>} Promise if `callback` has been omitted, otherwise `undefined`
+ * @type {{
+ *   (request: TReq|Properties<TReq>, callback: rpc.ServiceMethodCallback<TRes>): void;
+ *   (request: TReq|Properties<TReq>): Promise<TRes>;
+ *   readonly name: string;
+ *   readonly path: string;
+ *   readonly requestType: string;
+ *   readonly responseType: string;
+ *   readonly requestStream: true|undefined;
+ *   readonly responseStream: true|undefined;
+ * }}
  */
 
 /**

--- a/tests/api_service.js
+++ b/tests/api_service.js
@@ -43,7 +43,6 @@ tape.test("reflected services", function(test) {
     def.methods.MyMethod = methodDef;
     MyService = protobuf.Service.fromJSON("MyService", def);
     test.same(MyService.toJSON(), def, "should construct with methods from and convert back to JSON");
-    MyMethod = MyService.get("MyMethod");
 
     test.end();
 });
@@ -68,6 +67,7 @@ tape.test("feature resolution legacy proto3", function(test) {
 
     test.same(Service.toJSON(), json, "JSON should roundtrip");
     test.same(Method.toJSON(), json.methods.Method, "method JSON should roundtrip");
+    test.equal(Method.path, "/Service/Method", "should expose the method path");
 
     test.equal(Service._edition, "proto3", "should infer proto3 syntax");
     test.equal(Service._features.field_presence, "IMPLICIT", "should have implicit presence by default");

--- a/tests/cli-pbjs.js
+++ b/tests/cli-pbjs.js
@@ -110,6 +110,67 @@ tape.test("pbjs generates unsigned fixed64 defaults", function(test) {
     });
 });
 
+tape.test("pbjs static service methods expose rpc metadata", function(test) {
+    cliTest(test, function() {
+        var root = protobuf.parse([
+            "syntax = \"proto3\";",
+            "package rpcmeta;",
+            "service TestService {",
+            "  rpc Unary (Request) returns (Response);",
+            "  rpc ServerStream (Request) returns (stream Response);",
+            "  rpc ClientStream (stream Request) returns (Response);",
+            "}",
+            "message Request {}",
+            "message Response {}"
+        ].join("\n")).root;
+        root.resolveAll();
+
+        var staticTarget = require("../cli/targets/static");
+
+        staticTarget(root, {
+            create: true,
+            decode: true,
+            encode: true,
+            convert: true,
+            service: true,
+            comments: true,
+            root: "rpcMetadata"
+        }, function(err, jsCode) {
+            test.error(err, "static code generation worked");
+
+            delete protobuf.roots.rpcMetadata;
+            var $protobuf = protobuf;
+            eval(jsCode);
+
+            var TestService = protobuf.roots.rpcMetadata.rpcmeta.TestService;
+            var unary = TestService.prototype.unary;
+            var serverStream = TestService.prototype.serverStream;
+            var clientStream = TestService.prototype.clientStream;
+
+            test.equal(unary.name, "Unary", "unary method exposes its proto name");
+            test.equal(unary.path, "/rpcmeta.TestService/Unary", "unary method exposes its rpc path");
+            test.equal(unary.requestType, "Request", "unary method exposes request type");
+            test.equal(unary.responseType, "Response", "unary method exposes response type");
+            test.equal(unary.requestStream, undefined, "unary method has no request stream flag");
+            test.equal(unary.responseStream, undefined, "unary method has no response stream flag");
+
+            test.equal(serverStream.responseStream, true, "server streaming method exposes response stream flag");
+            test.equal(clientStream.requestStream, true, "client streaming method exposes request stream flag");
+
+            require("../cli/pbts").process(jsCode, [], function(dtsErr, tsCode) {
+                test.error(dtsErr, "declaration generation worked");
+                test.ok(tsCode.indexOf("unary: rpcmeta.TestService.Unary;") >= 0, "declaration exposes method as typed property");
+                test.ok(tsCode.indexOf("type Unary = {") >= 0, "declaration emits method callable type");
+                test.ok(tsCode.indexOf("readonly path: \"/rpcmeta.TestService/Unary\";") >= 0, "declaration exposes literal rpc path");
+                test.ok(tsCode.indexOf("readonly responseStream: true;") >= 0, "declaration exposes streaming metadata");
+
+                delete protobuf.roots.rpcMetadata;
+                test.end();
+            });
+        });
+    });
+});
+
 tape.test("pbjs generates correct ES module static-module imports", function(test) {
     cliTest(test, function() {
         var root = protobuf.loadSync("tests/data/cli/test.proto");

--- a/tests/comp_typescript.js
+++ b/tests/comp_typescript.js
@@ -35,6 +35,35 @@ const reflectedConvertedValue = HelloReflected.fromObject({ value: "hi" }).value
 const parsedOptionValue = (_a = HelloReflected.parsedOptions) === null || _a === void 0 ? void 0 : _a[0]["(custom_option)"];
 const reflectedMethod = new __1.Method("Call", undefined, "Hello", "Hello", false, false, undefined, undefined, [{ option: 1 }]);
 const parsedMethodOptionValue = (_b = reflectedMethod.parsedOptions) === null || _b === void 0 ? void 0 : _b[0].option;
+const reflectedMethodPath = reflectedMethod.path;
+const reflectedMethodRequestStream = reflectedMethod.requestStream;
+const rpcImpl = (method, requestData, callback) => {
+    const path = method.path;
+    const requestType = method.requestType;
+    const responseStream = method.responseStream;
+    callback(null, requestData);
+};
+function checkGenericRpcServiceMethod(method, request) {
+    const promiseResult = method(request);
+    const callbackResult = method(request, (err, response) => {
+        const callbackError = err;
+        const callbackResponse = response;
+    });
+    const path = method.path;
+    const requestStream = method.requestStream;
+}
+function checkStaticRpcServiceTypes(staticRpcService, staticRpcRequest) {
+    const staticRpcResponse = staticRpcService.myMethod(staticRpcRequest);
+    staticRpcService.myMethod(staticRpcRequest, (err, response) => {
+        const staticRpcError = err;
+        const staticRpcCallbackResponse = response;
+    });
+    const staticRpcMethodPath = staticRpcService.myMethod.path;
+    const staticRpcMethodRequestType = staticRpcService.myMethod.requestType;
+    const staticRpcMethodResponseType = staticRpcService.myMethod.responseType;
+    const staticRpcMethodRequestStream = staticRpcService.myMethod.requestStream;
+    const staticRpcMethodResponseStream = staticRpcService.myMethod.responseStream;
+}
 const enumDescriptor = {
     edition: "proto2",
     values: { A: 0 },

--- a/tests/comp_typescript.ts
+++ b/tests/comp_typescript.ts
@@ -1,6 +1,8 @@
 // test currently consists only of not throwing
 
-import { Root, Message, Method, Type, Field, MapField, OneOf, IEnum, IField, IMethod, IOneOf, IService, IType, ReflectedMessage } from "..";
+import { Root, Message, Method, Type, Field, MapField, OneOf, IEnum, IField, IMethod, IOneOf, IService, IType, ReflectedMessage, RPCImpl } from "..";
+import type { rpc as RpcNamespace } from "..";
+import type { MyService as StaticRpcService, MyRequest as StaticRpcRequest, MyResponse as StaticRpcResponse } from "./data/rpc.d";
 
 // Reflection
 const root = Root.fromJSON({
@@ -28,6 +30,35 @@ const reflectedConvertedValue: string = HelloReflected.fromObject({ value: "hi" 
 const parsedOptionValue: number | undefined = HelloReflected.parsedOptions?.[0]["(custom_option)"];
 const reflectedMethod = new Method("Call", undefined, "Hello", "Hello", false, false, undefined, undefined, [{ option: 1 }]);
 const parsedMethodOptionValue: number | undefined = reflectedMethod.parsedOptions?.[0].option;
+const reflectedMethodPath: string = reflectedMethod.path;
+const reflectedMethodRequestStream: true | undefined = reflectedMethod.requestStream;
+const rpcImpl: RPCImpl = (method, requestData, callback) => {
+    const path: string = method.path;
+    const requestType: string = method.requestType;
+    const responseStream: true | undefined = method.responseStream;
+    callback(null, requestData);
+};
+function checkGenericRpcServiceMethod(method: RpcNamespace.ServiceMethod<Message<{}>, Message<{}>>, request: Message<{}>): void {
+    const promiseResult: Promise<Message<{}>> = method(request);
+    const callbackResult: void = method(request, (err, response) => {
+        const callbackError: Error | null = err;
+        const callbackResponse: Message<{}> | undefined = response;
+    });
+    const path: string = method.path;
+    const requestStream: true | undefined = method.requestStream;
+}
+function checkStaticRpcServiceTypes(staticRpcService: StaticRpcService, staticRpcRequest: StaticRpcRequest): void {
+    const staticRpcResponse: Promise<StaticRpcResponse> = staticRpcService.myMethod(staticRpcRequest);
+    staticRpcService.myMethod(staticRpcRequest, (err, response) => {
+        const staticRpcError: Error | null = err;
+        const staticRpcCallbackResponse: StaticRpcResponse | undefined = response;
+    });
+    const staticRpcMethodPath: "/MyService/MyMethod" = staticRpcService.myMethod.path;
+    const staticRpcMethodRequestType: "MyRequest" = staticRpcService.myMethod.requestType;
+    const staticRpcMethodResponseType: "MyResponse" = staticRpcService.myMethod.responseType;
+    const staticRpcMethodRequestStream: undefined = staticRpcService.myMethod.requestStream;
+    const staticRpcMethodResponseStream: undefined = staticRpcService.myMethod.responseStream;
+}
 
 const enumDescriptor: IEnum = {
     edition: "proto2",

--- a/tests/data/rpc-es6.d.ts
+++ b/tests/data/rpc-es6.d.ts
@@ -4,12 +4,21 @@ import Long = require("long");
 export class MyService extends $protobuf.rpc.Service {
     constructor(rpcImpl: $protobuf.RPCImpl, requestDelimited?: boolean, responseDelimited?: boolean);
     static create(rpcImpl: $protobuf.RPCImpl, requestDelimited?: boolean, responseDelimited?: boolean): MyService;
-    myMethod(request: IMyRequest, callback: MyService.MyMethodCallback): void;
-    myMethod(request: IMyRequest): Promise<MyResponse>;
+    myMethod: MyService.MyMethod;
 }
 
 export namespace MyService {
     type MyMethodCallback = (error: (Error|null), response?: MyResponse) => void;
+    type MyMethod = {
+  (request: IMyRequest, callback: MyService.MyMethodCallback): void;
+  (request: IMyRequest): Promise<MyResponse>;
+  readonly name: "MyMethod";
+  readonly path: "/MyService/MyMethod";
+  readonly requestType: "MyRequest";
+  readonly responseType: "MyResponse";
+  readonly requestStream: undefined;
+  readonly responseStream: undefined;
+};
 }
 
 export interface IMyRequest extends MyRequest.$Properties {

--- a/tests/data/rpc-es6.js
+++ b/tests/data/rpc-es6.js
@@ -50,27 +50,35 @@ export const MyService = $root.MyService = (() => {
 
     /**
      * Calls MyMethod.
-     * @function myMethod
      * @memberof MyService
-     * @instance
-     * @param {IMyRequest} request MyRequest message or plain object
-     * @param {MyService.MyMethodCallback} callback Node-style callback called with the error, if any, and MyResponse
-     * @returns {undefined}
-     * @variation 1
+     * @typedef MyMethod
+     * @type {{
+     *   (request: IMyRequest, callback: MyService.MyMethodCallback): void;
+     *   (request: IMyRequest): Promise<MyResponse>;
+     *   readonly name: "MyMethod";
+     *   readonly path: "/MyService/MyMethod";
+     *   readonly requestType: "MyRequest";
+     *   readonly responseType: "MyResponse";
+     *   readonly requestStream: undefined;
+     *   readonly responseStream: undefined;
+     * }}
      */
-    Object.defineProperty(MyService.prototype.myMethod = function myMethod(request, callback) {
-        return this.rpcCall(myMethod, $root.MyRequest, $root.MyResponse, request, callback);
-    }, "name", { value: "MyMethod" });
 
     /**
      * Calls MyMethod.
-     * @function myMethod
-     * @memberof MyService
-     * @instance
-     * @param {IMyRequest} request MyRequest message or plain object
-     * @returns {Promise<MyResponse>} Promise
-     * @variation 2
+     * @name MyService#myMethod
+     * @type {MyService.MyMethod}
      */
+    Object.defineProperties(MyService.prototype.myMethod = function myMethod(request, callback) {
+        return this.rpcCall(myMethod, $root.MyRequest, $root.MyResponse, request, callback);
+    }, {
+        name: { value: "MyMethod" },
+        path: { value: "/MyService/MyMethod" },
+        requestType: { value: "MyRequest" },
+        responseType: { value: "MyResponse" },
+        requestStream: { value: undefined },
+        responseStream: { value: undefined }
+    });
 
     return MyService;
 })();

--- a/tests/data/rpc-reserved.d.ts
+++ b/tests/data/rpc-reserved.d.ts
@@ -4,12 +4,21 @@ import Long = require("long");
 export class MyService extends $protobuf.rpc.Service {
     constructor(rpcImpl: $protobuf.RPCImpl, requestDelimited?: boolean, responseDelimited?: boolean);
     static create(rpcImpl: $protobuf.RPCImpl, requestDelimited?: boolean, responseDelimited?: boolean): MyService;
-    delete(request: IMyRequest, callback: MyService.DeleteCallback): void;
-    delete(request: IMyRequest): Promise<MyResponse>;
+    delete: MyService.Delete;
 }
 
 export namespace MyService {
     type DeleteCallback = (error: (Error|null), response?: MyResponse) => void;
+    type Delete = {
+  (request: IMyRequest, callback: MyService.DeleteCallback): void;
+  (request: IMyRequest): Promise<MyResponse>;
+  readonly name: "Delete";
+  readonly path: "/MyService/Delete";
+  readonly requestType: "MyRequest";
+  readonly responseType: "MyResponse";
+  readonly requestStream: undefined;
+  readonly responseStream: undefined;
+};
 }
 
 export interface IMyRequest extends MyRequest.$Properties {

--- a/tests/data/rpc-reserved.js
+++ b/tests/data/rpc-reserved.js
@@ -52,27 +52,35 @@ $root.MyService = (function() {
 
     /**
      * Calls Delete.
-     * @function delete
      * @memberof MyService
-     * @instance
-     * @param {IMyRequest} request MyRequest message or plain object
-     * @param {MyService.DeleteCallback} callback Node-style callback called with the error, if any, and MyResponse
-     * @returns {undefined}
-     * @variation 1
+     * @typedef Delete
+     * @type {{
+     *   (request: IMyRequest, callback: MyService.DeleteCallback): void;
+     *   (request: IMyRequest): Promise<MyResponse>;
+     *   readonly name: "Delete";
+     *   readonly path: "/MyService/Delete";
+     *   readonly requestType: "MyRequest";
+     *   readonly responseType: "MyResponse";
+     *   readonly requestStream: undefined;
+     *   readonly responseStream: undefined;
+     * }}
      */
-    Object.defineProperty(MyService.prototype["delete"] = function delete_(request, callback) {
-        return this.rpcCall(delete_, $root.MyRequest, $root.MyResponse, request, callback);
-    }, "name", { value: "Delete" });
 
     /**
      * Calls Delete.
-     * @function delete
-     * @memberof MyService
-     * @instance
-     * @param {IMyRequest} request MyRequest message or plain object
-     * @returns {Promise<MyResponse>} Promise
-     * @variation 2
+     * @name MyService#delete
+     * @type {MyService.Delete}
      */
+    Object.defineProperties(MyService.prototype["delete"] = function delete_(request, callback) {
+        return this.rpcCall(delete_, $root.MyRequest, $root.MyResponse, request, callback);
+    }, {
+        name: { value: "Delete" },
+        path: { value: "/MyService/Delete" },
+        requestType: { value: "MyRequest" },
+        responseType: { value: "MyResponse" },
+        requestStream: { value: undefined },
+        responseStream: { value: undefined }
+    });
 
     return MyService;
 })();

--- a/tests/data/rpc.d.ts
+++ b/tests/data/rpc.d.ts
@@ -4,12 +4,21 @@ import Long = require("long");
 export class MyService extends $protobuf.rpc.Service {
     constructor(rpcImpl: $protobuf.RPCImpl, requestDelimited?: boolean, responseDelimited?: boolean);
     static create(rpcImpl: $protobuf.RPCImpl, requestDelimited?: boolean, responseDelimited?: boolean): MyService;
-    myMethod(request: IMyRequest, callback: MyService.MyMethodCallback): void;
-    myMethod(request: IMyRequest): Promise<MyResponse>;
+    myMethod: MyService.MyMethod;
 }
 
 export namespace MyService {
     type MyMethodCallback = (error: (Error|null), response?: MyResponse) => void;
+    type MyMethod = {
+  (request: IMyRequest, callback: MyService.MyMethodCallback): void;
+  (request: IMyRequest): Promise<MyResponse>;
+  readonly name: "MyMethod";
+  readonly path: "/MyService/MyMethod";
+  readonly requestType: "MyRequest";
+  readonly responseType: "MyResponse";
+  readonly requestStream: undefined;
+  readonly responseStream: undefined;
+};
 }
 
 export interface IMyRequest extends MyRequest.$Properties {

--- a/tests/data/rpc.js
+++ b/tests/data/rpc.js
@@ -52,27 +52,35 @@ $root.MyService = (function() {
 
     /**
      * Calls MyMethod.
-     * @function myMethod
      * @memberof MyService
-     * @instance
-     * @param {IMyRequest} request MyRequest message or plain object
-     * @param {MyService.MyMethodCallback} callback Node-style callback called with the error, if any, and MyResponse
-     * @returns {undefined}
-     * @variation 1
+     * @typedef MyMethod
+     * @type {{
+     *   (request: IMyRequest, callback: MyService.MyMethodCallback): void;
+     *   (request: IMyRequest): Promise<MyResponse>;
+     *   readonly name: "MyMethod";
+     *   readonly path: "/MyService/MyMethod";
+     *   readonly requestType: "MyRequest";
+     *   readonly responseType: "MyResponse";
+     *   readonly requestStream: undefined;
+     *   readonly responseStream: undefined;
+     * }}
      */
-    Object.defineProperty(MyService.prototype.myMethod = function myMethod(request, callback) {
-        return this.rpcCall(myMethod, $root.MyRequest, $root.MyResponse, request, callback);
-    }, "name", { value: "MyMethod" });
 
     /**
      * Calls MyMethod.
-     * @function myMethod
-     * @memberof MyService
-     * @instance
-     * @param {IMyRequest} request MyRequest message or plain object
-     * @returns {Promise<MyResponse>} Promise
-     * @variation 2
+     * @name MyService#myMethod
+     * @type {MyService.MyMethod}
      */
+    Object.defineProperties(MyService.prototype.myMethod = function myMethod(request, callback) {
+        return this.rpcCall(myMethod, $root.MyRequest, $root.MyResponse, request, callback);
+    }, {
+        name: { value: "MyMethod" },
+        path: { value: "/MyService/MyMethod" },
+        requestType: { value: "MyRequest" },
+        responseType: { value: "MyResponse" },
+        requestStream: { value: undefined },
+        responseStream: { value: undefined }
+    });
 
     return MyService;
 })();


### PR DESCRIPTION
Adds RPC method metadata (`name`, `path`, `requestType`, `responseType`, `requestStream`, `responseStream`) to reflected and generated static service methods. In particular, `path` is useful when implementing gRPC-style RPC transports.

Fixes #2045