### PR TITLE
fix: Consistently reject null message argument in fromObject

### DIFF
--- a/src/converter.js
+++ b/src/converter.js
@@ -42,7 +42,7 @@ function genValuePartial_fromObject(gen, field, fieldIndex, prop) {
             } gen
             ("}");
         } else gen
-            ("if(typeof d%s!==\"object\")", prop)
+            ("if(!util.isObject(d%s))", prop)
                 ("throw TypeError(%j)", field.fullName + ": object expected")
             ("m%s=types[%i].fromObject(d%s,q+1)", prop, fieldIndex, prop);
     } else {
@@ -109,6 +109,8 @@ converter.fromObject = function fromObject(mtype) {
     var gen = util.codegen(["d", "q"], mtype.name + "$fromObject")
     ("if(d instanceof C)")
         ("return d")
+    ("if(!util.isObject(d))")
+        ("throw TypeError(%j)", mtype.fullName + ": object expected")
     ("if(q===undefined)q=0")
     ("if(q>util.recursionLimit)")
         ("throw Error(\"max depth exceeded\")");
@@ -125,7 +127,7 @@ converter.fromObject = function fromObject(mtype) {
         // Map fields
         if (field.map) { gen
     ("if(d%s){", prop)
-        ("if(typeof d%s!==\"object\")", prop)
+        ("if(!util.isObject(d%s))", prop)
             ("throw TypeError(%j)", field.fullName + ": object expected")
         ("m%s={}", prop)
         ("for(var ks=Object.keys(d%s),i=0;i<ks.length;++i){", prop);

--- a/tests/api_type.js
+++ b/tests/api_type.js
@@ -409,6 +409,44 @@ tape.test("object conversion nesting", function(test) {
     test.end();
 });
 
+tape.test("object conversion rejects null message values", function(test) {
+    var root = protobuf.Root.fromJSON({
+        nested: {
+            Document: {
+                fields: {
+                    attrs: { keyType: "string", type: "Metadata", id: 1 },
+                    tags: { rule: "repeated", type: "Metadata", id: 2 },
+                    meta: { type: "Metadata", id: 3 }
+                }
+            },
+            Metadata: {
+                fields: {
+                    key: { type: "string", id: 1 },
+                    value: { type: "string", id: 2 }
+                }
+            }
+        }
+    });
+    var Document = root.lookupType("Document");
+    var Metadata = root.lookupType("Metadata");
+
+    test.throws(function() {
+        Metadata.fromObject(null);
+    }, /object expected/, "should reject null top-level messages");
+
+    test.throws(function() {
+        Document.fromObject({ attrs: { bad: null } });
+    }, /object expected/, "should reject null map message values");
+
+    test.throws(function() {
+        Document.fromObject({ tags: [ null ] });
+    }, /object expected/, "should reject null repeated message values");
+
+    test.equal(Object.prototype.hasOwnProperty.call(Document.fromObject({ meta: null }), "meta"), false, "should ignore null singular message fields");
+
+    test.end();
+});
+
 tape.test("feature resolution legacy proto3", function(test) {
     var json = {
         fields: {


### PR DESCRIPTION
Rejects `Message.fromObject(null)` consistently, including in repeated message elements and map message values. Preserves existing singular message field behavior where `null` is treated as absent.