### PR TITLE
fix: Prefer nested type resolution over global fallback

### DIFF
--- a/src/namespace.js
+++ b/src/namespace.js
@@ -426,14 +426,14 @@ Namespace.prototype.lookup = function lookup(path, filterTypes, parentAlreadyChe
     if (path[0] === "")
         return this.root.lookup(path.slice(1), filterTypes);
 
-    // Early bailout for objects with matching absolute paths
-    var found = this.root._fullyQualifiedObjects && this.root._fullyQualifiedObjects["." + flatPath];
+    // Lookup at this namespace and below
+    var found = this._lookupImpl(path, flatPath);
     if (found && (!filterTypes || filterTypes.indexOf(found.constructor) > -1)) {
         return found;
     }
 
-    // Do a regular lookup at this namespace and below
-    found = this._lookupImpl(path, flatPath);
+    // Fall back to respective absolute path once relative scope has been checked (non-standard)
+    found = this.root._fullyQualifiedObjects && this.root._fullyQualifiedObjects["." + flatPath];
     if (found && (!filterTypes || filterTypes.indexOf(found.constructor) > -1)) {
         return found;
     }

--- a/tests/api_namespace.js
+++ b/tests/api_namespace.js
@@ -35,6 +35,19 @@ tape.test("reflected namespaces", function(test) {
 
     test.equal(ns.get("Msg").lookupTypeOrEnum("Enm"), ns.lookup(".ns.Msg.Enm"), "should lookup the nearest type or enum");
 
+    var collisionRoot = protobuf.parse("syntax = \"proto3\";\
+message NestedMessage { int32 id = 1; }\
+message TestMessage {\
+    message NestedMessage {\
+        int32 id = 1;\
+        string name = 2;\
+    }\
+    NestedMessage nested = 1;\
+}").root.resolveAll();
+    var TestMessage = collisionRoot.lookupType("TestMessage");
+    test.equal(TestMessage.fields.nested.resolvedType.fullName, ".TestMessage.NestedMessage", "should prefer nested types over global types with the same name");
+    test.equal(TestMessage.decode(TestMessage.encode({ nested: { id: 1, name: "hello" } }).finish()).nested.name, "hello", "should encode fields from the nested type");
+
     test.throws(function() {
         ns.lookupType("Enm");
     }, Error, "should throw when looking up an enum as a type");


### PR DESCRIPTION
Fixes relative type lookup when a nested type has the same name as a global type.

Previously, `Namespace.lookup` checked the root fully-qualified object cache before resolving relative to the current namespace, so an unqualified field type like `NestedMessage` inside `TestMessage` could incorrectly resolve to `.NestedMessage` instead of `.TestMessage.NestedMessage`. This now checks the relative scope first.

Fixes #2077