### PR TITLE
fix(cli): Consistently handle derived names

### DIFF
--- a/cli/targets/json-module.js
+++ b/cli/targets/json-module.js
@@ -38,7 +38,7 @@ function escapeName(name) {
 
 function json_module(root, options, callback) {
     try {
-        var rootProp = protobuf.util.safeProp(options.root || "default");
+        var rootProp = "[" + JSON.stringify(String(options.root || "default")) + "]";
         var output = [
             (options.es6 ? "const" : "var") + " $root = ($protobuf.roots" + rootProp + " || ($protobuf.roots" + rootProp + " = new $protobuf.Root()))\n"
         ];

--- a/cli/targets/static.js
+++ b/cli/targets/static.js
@@ -41,7 +41,7 @@ function static_target(root, options, callback) {
             }
             push("// Exported root namespace");
         }
-        var rootProp = util.safeProp(config.root || "default");
+        var rootProp = "[" + JSON.stringify(String(config.root || "default")) + "]";
         push((config.es6 ? "const" : "var") + " $root = $protobuf.roots" + rootProp + " || ($protobuf.roots" + rootProp + " = {});");
         buildNamespace(null, root);
         return callback(null, out.join("\n"));
@@ -79,18 +79,24 @@ function pushComment(lines) {
     push(" */");
 }
 
+function objectPath(object) {
+    var parts = [];
+    while (object && object.name !== "") {
+        parts.unshift(escapeName(object.name));
+        object = object.parent;
+    }
+    return parts;
+}
+
 function exportName(object, asInterface) {
     if (asInterface) {
         if (object.__interfaceName)
             return object.__interfaceName;
     } else if (object.__exportName)
         return object.__exportName;
-    var parts = object.fullName.substring(1).split("."),
-        i = 0;
-    while (i < parts.length)
-        parts[i] = escapeName(parts[i++]);
-    if (asInterface)
-        parts[i - 1] = "I" + parts[i - 1];
+    var parts = objectPath(object);
+    if (asInterface && parts.length)
+        parts[parts.length - 1] = "I" + parts[parts.length - 1];
     return object[asInterface ? "__interfaceName" : "__exportName"] = parts.join(".");
 }
 
@@ -141,7 +147,15 @@ function buildNamespace(ref, ns) {
         push((config.es6 ? "const" : "var") + " " + escapeName(ns.name) + " = {};");
     }
 
+    var seenNames = new Set();
     ns.nestedArray.forEach(function(nested) {
+        // Only check names of elements that are emitted below
+        if (!(nested instanceof Enum || nested instanceof Namespace) || nested instanceof Service && !config.service)
+            return;
+        var name = escapeName(nested.name);
+        if (seenNames.has(name))
+            throw Error("duplicate generated name '" + name + "'");
+        seenNames.add(name);
         if (nested instanceof Enum)
             buildEnum(ns.name, nested);
         else if (nested instanceof Namespace)
@@ -237,8 +251,27 @@ var renameVars = {
 
 function buildFunction(type, functionName, gen, scope) {
     var code = gen.toString(functionName);
-
     var ast = espree.parse(code);
+
+    function rootMemberRef(object) {
+        var ref = {
+            "type": "Identifier",
+            "name": "$root"
+        };
+        var parts = objectPath(object);
+        for (var i = 0; i < parts.length; ++i)
+            ref = {
+                "type": "MemberExpression",
+                "computed": false,
+                "object": ref,
+                "property": {
+                    "type": "Identifier",
+                    "name": parts[i]
+                }
+            };
+        return ref;
+    }
+
     /* eslint-disable no-extra-parens */
     estraverse.replace(ast, {
         enter: function(node, parent) {
@@ -263,10 +296,7 @@ function buildFunction(type, functionName, gen, scope) {
                  || (parent.type === "BinaryExpression" && parent.operator === "instanceof" && parent.right === node)
                 )
             )
-                return {
-                    "type": "Identifier",
-                    "name": "$root" + type.fullName
-                };
+                return rootMemberRef(type);
             // replace types[N].ctor with the field's actual type constructor
             if (
                 node.type === "MemberExpression"
@@ -275,10 +305,7 @@ function buildFunction(type, functionName, gen, scope) {
              && node.object.property.type === "Literal"
              && node.property.type === "Identifier" && node.property.name === "ctor"
             )
-                return {
-                    "type": "Identifier",
-                    "name": "$root" + type.fieldsArray[node.object.property.value].resolvedType.fullName
-                };
+                return rootMemberRef(type.fieldsArray[node.object.property.value].resolvedType);
             // replace types[N].values with the field's actual enum object
             if (
                 node.type === "MemberExpression"
@@ -287,20 +314,14 @@ function buildFunction(type, functionName, gen, scope) {
              && node.object.property.type === "Literal"
              && node.property.type === "Identifier" && node.property.name === "values"
             )
-                return {
-                    "type": "Identifier",
-                    "name": "$root" + type.fieldsArray[node.object.property.value].resolvedType.fullName
-                };
+                return rootMemberRef(type.fieldsArray[node.object.property.value].resolvedType);
             // replace types[N] with the field's actual type
             if (
                 node.type === "MemberExpression"
              && node.object.type === "Identifier" && node.object.name === "types"
              && node.property.type === "Literal"
             )
-                return {
-                    "type": "Identifier",
-                    "name": "$root" + type.fieldsArray[node.property.value].resolvedType.fullName
-                };
+                return rootMemberRef(type.fieldsArray[node.property.value].resolvedType);
             return undefined;
         }
     });

--- a/cli/util.js
+++ b/cli/util.js
@@ -126,7 +126,7 @@ exports.wrap = function(OUTPUT, options) {
         return $1.length ? OUTPUT.replace(/^/mg, $1) : OUTPUT;
     });
     if (options.lint !== "")
-        wrap = "/*" + options.lint + "*/\n" + wrap;
+        wrap = "/*" + String(options.lint).replace(/\*\//g, "* /") + "*/\n" + wrap;
     return wrap.replace(/\r?\n/g, "\n");
 };
 

--- a/src/roots.js
+++ b/src/roots.js
@@ -1,5 +1,5 @@
 "use strict";
-module.exports = {};
+module.exports = Object.create(null);
 
 /**
  * Named roots.

--- a/tests/cli-pbjs.js
+++ b/tests/cli-pbjs.js
@@ -162,6 +162,81 @@ tape.test("pbjs keeps es6 as an ES module wrapper alias", function(test) {
     });
 });
 
+tape.test("pbjs escapes wrapper lint comments", function(test) {
+    cliTest(test, function() {
+        var root = new protobuf.Root();
+        var staticModuleTarget = require("../cli/targets/static-module");
+
+        staticModuleTarget(root, {
+            wrap: "commonjs",
+            lint: "note */ text"
+        }, function(err, jsCode) {
+            test.error(err, "static-module code generation worked");
+            test.equal(jsCode.indexOf("note */ text"), -1, "does not emit raw comment terminator");
+            test.ok(jsCode.indexOf("note * / text") >= 0, "escapes comment terminator");
+            test.doesNotThrow(function() {
+                new Function("require", "module", "exports", jsCode); // eslint-disable-line no-new-func
+            }, "should generate parseable output");
+            test.end();
+        });
+    });
+});
+
+tape.test("pbjs supports dictionary generated root names", function(test) {
+    cliTest(test, function() {
+        var staticTarget = require("../cli/targets/static");
+        var jsonModuleTarget = require("../cli/targets/json-module");
+        var root = protobuf.Root.fromJSON({
+            nested: {
+                M: {
+                    fields: {}
+                }
+            }
+        });
+
+        test.equal(Object.getPrototypeOf(protobuf.roots), null, "roots uses dictionary semantics");
+
+        delete protobuf.roots.__proto__;
+        delete protobuf.roots.constructor;
+        staticTarget(root, {
+            root: "__proto__"
+        }, function(staticErr, staticCode) {
+            test.error(staticErr, "static target accepts dictionary root name");
+            test.ok(staticCode.indexOf("$protobuf.roots[\"__proto__\"]") >= 0, "static target uses bracket root access");
+            var $protobuf = protobuf;
+            test.doesNotThrow(function() {
+                eval(staticCode);
+            }, "static output should execute");
+            test.ok(Object.prototype.hasOwnProperty.call(protobuf.roots, "__proto__"), "static target creates own root property");
+
+            jsonModuleTarget(root, {
+                wrap: "commonjs",
+                root: "constructor",
+                lint: ""
+            }, function(jsonErr, jsonCode) {
+                test.error(jsonErr, "json-module target accepts dictionary root name");
+                test.ok(jsonCode.indexOf("$protobuf.roots[\"constructor\"]") >= 0, "json-module target uses bracket root access");
+
+                var module = { exports: {} };
+                function localRequire(request) {
+                    if (request.indexOf("protobufjs") === 0)
+                        return protobuf;
+                    throw Error("unexpected require: " + request);
+                }
+
+                test.doesNotThrow(function() {
+                    new Function("require", "module", "exports", jsonCode)(localRequire, module, module.exports); // eslint-disable-line no-new-func
+                }, "json-module output should execute");
+                test.ok(Object.prototype.hasOwnProperty.call(protobuf.roots, "constructor"), "json-module target creates own root property");
+                test.equal(module.exports, protobuf.roots.constructor, "json-module exports dictionary root");
+                delete protobuf.roots.__proto__;
+                delete protobuf.roots.constructor;
+                test.end();
+            });
+        });
+    });
+});
+
 tape.test("pbjs supports custom target paths", function(test) {
     cliTest(test, function() {
         var pbjs = require("../cli/pbjs");
@@ -682,6 +757,83 @@ tape.test("pbjs escapes static target names", function(test) {
             test.doesNotThrow(function() {
                 new Function("$protobuf", jsCode); // eslint-disable-line no-new-func
             }, "should generate parseable output");
+            test.end();
+        });
+    });
+});
+
+tape.test("pbjs rejects static target escaped name collisions", function(test) {
+    cliTest(test, function() {
+        var root = protobuf.Root.fromJSON({
+            nested: {
+                "pkg-name": {
+                    nested: {}
+                },
+                pkgname: {
+                    nested: {}
+                }
+            }
+        });
+        var staticTarget = require("../cli/targets/static");
+
+        staticTarget(root, {}, function(err) {
+            test.match(err && err.message, /duplicate generated name 'pkgname'/, "rejects ambiguous generated names");
+            test.end();
+        });
+    });
+});
+
+tape.test("pbjs builds static references from escaped path segments", function(test) {
+    cliTest(test, function() {
+        var root = protobuf.Root.fromJSON({
+            nested: {
+                "pkg.name": {
+                    nested: {
+                        Child: {
+                            fields: {
+                                value: { type: "string", id: 1 }
+                            }
+                        },
+                        Kind: {
+                            values: {
+                                UNKNOWN: 0,
+                                READY: 1
+                            }
+                        },
+                        Parent: {
+                            fields: {
+                                child: { type: "Child", id: 1 },
+                                kind: { type: "Kind", id: 2 }
+                            }
+                        },
+                        TestService: {
+                            methods: {
+                                Call: {
+                                    requestType: "Child",
+                                    responseType: "Parent"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        });
+        var staticTarget = require("../cli/targets/static");
+
+        staticTarget(root, {
+            create: true,
+            service: true,
+            verify: true,
+            convert: true
+        }, function(err, jsCode) {
+            test.error(err, "static code generation worked");
+            test.equal(jsCode.indexOf("$root.pkg.name"), -1, "does not split dotted descriptor names");
+            test.ok(jsCode.indexOf("$root.pkgname.Child") >= 0, "uses escaped path segment for request type");
+            test.ok(jsCode.indexOf("$root.pkgname.Parent") >= 0, "uses escaped path segment for response type");
+            test.doesNotThrow(function() {
+                new Function("$protobuf", jsCode); // eslint-disable-line no-new-func
+            }, "should generate parseable output");
+
             test.end();
         });
     });

--- a/tests/data/comments.js
+++ b/tests/data/comments.js
@@ -7,7 +7,7 @@ var $protobuf = require("../../minimal");
 var $Reader = $protobuf.Reader, $Writer = $protobuf.Writer, $util = $protobuf.util;
 
 // Exported root namespace
-var $root = $protobuf.roots.test_comments || ($protobuf.roots.test_comments = {});
+var $root = $protobuf.roots["test_comments"] || ($protobuf.roots["test_comments"] = {});
 
 $root.Test1 = (function() {
 

--- a/tests/data/convert.js
+++ b/tests/data/convert.js
@@ -7,7 +7,7 @@ var $protobuf = require("../../minimal");
 var $Reader = $protobuf.Reader, $Writer = $protobuf.Writer, $util = $protobuf.util;
 
 // Exported root namespace
-var $root = $protobuf.roots.test_convert || ($protobuf.roots.test_convert = {});
+var $root = $protobuf.roots["test_convert"] || ($protobuf.roots["test_convert"] = {});
 
 $root.Message = (function() {
 

--- a/tests/data/mapbox/vector_tile.js
+++ b/tests/data/mapbox/vector_tile.js
@@ -7,7 +7,7 @@ var $protobuf = require("../../../minimal");
 var $Reader = $protobuf.Reader, $Writer = $protobuf.Writer, $util = $protobuf.util;
 
 // Exported root namespace
-var $root = $protobuf.roots.test_vector_tile || ($protobuf.roots.test_vector_tile = {});
+var $root = $protobuf.roots["test_vector_tile"] || ($protobuf.roots["test_vector_tile"] = {});
 
 $root.vector_tile = (function() {
 

--- a/tests/data/package.js
+++ b/tests/data/package.js
@@ -7,7 +7,7 @@ var $protobuf = require("../../minimal");
 var $Reader = $protobuf.Reader, $Writer = $protobuf.Writer, $util = $protobuf.util;
 
 // Exported root namespace
-var $root = $protobuf.roots.test_package || ($protobuf.roots.test_package = {});
+var $root = $protobuf.roots["test_package"] || ($protobuf.roots["test_package"] = {});
 
 $root.Package = (function() {
 

--- a/tests/data/rpc-es6.js
+++ b/tests/data/rpc-es6.js
@@ -5,7 +5,7 @@ import $protobuf from "protobufjs/minimal.js";
 const $Reader = $protobuf.Reader, $Writer = $protobuf.Writer, $util = $protobuf.util;
 
 // Exported root namespace
-const $root = $protobuf.roots.test_rpc || ($protobuf.roots.test_rpc = {});
+const $root = $protobuf.roots["test_rpc"] || ($protobuf.roots["test_rpc"] = {});
 
 export const MyService = $root.MyService = (() => {
 

--- a/tests/data/rpc.js
+++ b/tests/data/rpc.js
@@ -7,7 +7,7 @@ var $protobuf = require("../../minimal");
 var $Reader = $protobuf.Reader, $Writer = $protobuf.Writer, $util = $protobuf.util;
 
 // Exported root namespace
-var $root = $protobuf.roots.test_rpc || ($protobuf.roots.test_rpc = {});
+var $root = $protobuf.roots["test_rpc"] || ($protobuf.roots["test_rpc"] = {});
 
 $root.MyService = (function() {
 

--- a/tests/data/test.js
+++ b/tests/data/test.js
@@ -7,7 +7,7 @@ var $protobuf = require("../../minimal");
 var $Reader = $protobuf.Reader, $Writer = $protobuf.Writer, $util = $protobuf.util;
 
 // Exported root namespace
-var $root = $protobuf.roots.test_test || ($protobuf.roots.test_test = {});
+var $root = $protobuf.roots["test_test"] || ($protobuf.roots["test_test"] = {});
 
 $root.jspb = (function() {
 

--- a/tests/data/type_url.js
+++ b/tests/data/type_url.js
@@ -7,7 +7,7 @@ var $protobuf = require("../../minimal");
 var $Reader = $protobuf.Reader, $Writer = $protobuf.Writer, $util = $protobuf.util;
 
 // Exported root namespace
-var $root = $protobuf.roots.test_type_url || ($protobuf.roots.test_type_url = {});
+var $root = $protobuf.roots["test_type_url"] || ($protobuf.roots["test_type_url"] = {});
 
 $root.TypeUrlTest = (function() {
 


### PR DESCRIPTION
Updates CLI-specific codegen to consistently handle derived names by rejecting name collisions, using dictionary-style root access, and properly escaping references derived from reflection structures. Also handles prematurely terminated lint comments.