### PR TITLE
feat: Add spec-compliant protojson extension

### DIFF
--- a/.github/actions/conformance/action.yml
+++ b/.github/actions/conformance/action.yml
@@ -73,6 +73,7 @@ runs:
       run: |
         mkdir -p "${{ inputs.output-dir }}"
         : > "${{ inputs.output-dir }}/failure_list.txt"
+        PROTOBUFJS_CONFORMANCE_MODE=reflect \
         "${{ inputs.runner-cache }}/build/conformance_test_runner" \
           --maximum_edition "${{ inputs.maximum-edition }}" \
           --enforce_recommended \
@@ -82,29 +83,68 @@ runs:
           "${{ steps.node.outputs.path }}" tests/conformance/testee.js --list \
           > "${{ inputs.output-dir }}/conformance-tests.log" 2>&1
 
-    - name: "Run conformance suite"
+    - name: "Run conformance suites"
       id: run-conformance
       shell: bash
       run: |
-        set +e
-        "${{ inputs.runner-cache }}/build/conformance_test_runner" \
-          --maximum_edition "${{ inputs.maximum-edition }}" \
-          --enforce_recommended \
-          --failure_list "${{ inputs.output-dir }}/failure_list.txt" \
-          --output_dir "${{ inputs.output-dir }}" \
-          "${{ steps.node.outputs.path }}" tests/conformance/testee.js \
-          > "${{ inputs.output-dir }}/conformance.log" 2>&1
-        status=$?
-        set -e
-        echo "exit_code=$status" >> "$GITHUB_OUTPUT"
-        tail -n 80 "${{ inputs.output-dir }}/conformance.log"
-        if [ -s "${{ inputs.output-dir }}/failing_tests.txt" ]; then
-          echo ""
-          echo "Failing conformance tests:"
-          cat "${{ inputs.output-dir }}/failing_tests.txt"
-        fi
+        status=0
 
-    - name: "Summarize conformance results"
+        run_mode() {
+          local mode="$1"
+          local mode_dir="${{ inputs.output-dir }}/${mode}"
+          local mode_status=0
+
+          mkdir -p "$mode_dir"
+          : > "$mode_dir/failure_list.txt"
+
+          set +e
+          PROTOBUFJS_CONFORMANCE_MODE="$mode" \
+          "${{ inputs.runner-cache }}/build/conformance_test_runner" \
+            --maximum_edition "${{ inputs.maximum-edition }}" \
+            --enforce_recommended \
+            --verbose \
+            --failure_list "$mode_dir/failure_list.txt" \
+            --output_dir "$mode_dir" \
+            "${{ steps.node.outputs.path }}" tests/conformance/testee.js \
+            > "$mode_dir/conformance.log" 2>&1
+          mode_status=$?
+          set -e
+
+          if [ "$mode_status" -ne 0 ]; then
+            status="$mode_status"
+          fi
+
+          echo ""
+          echo "Last conformance log lines for ${mode} mode:"
+          tail -n 80 "$mode_dir/conformance.log"
+          if [ -s "$mode_dir/failing_tests.txt" ]; then
+            echo ""
+            echo "Failing conformance tests for ${mode} mode:"
+            cat "$mode_dir/failing_tests.txt"
+          fi
+        }
+
+        run_mode static
+        run_mode reflect
+
+        echo "exit_code=$status" >> "$GITHUB_OUTPUT"
+
+    - name: "Summarize static conformance results"
       if: always()
       shell: bash
-      run: node tests/conformance/report.js "${{ inputs.output-dir }}/conformance.log" "${{ inputs.output-dir }}/conformance-tests.log" --json "${{ inputs.output-dir }}/conformance.json" | tee -a "$GITHUB_STEP_SUMMARY"
+      run: |
+        {
+          echo "## Static"
+          echo ""
+          node tests/conformance/report.js "${{ inputs.output-dir }}/static/conformance.log" "${{ inputs.output-dir }}/conformance-tests.log" --binary-only --json "${{ inputs.output-dir }}/static/conformance.json"
+        } | tee -a "$GITHUB_STEP_SUMMARY"
+
+    - name: "Summarize reflect conformance results"
+      if: always()
+      shell: bash
+      run: |
+        {
+          echo "## Reflect"
+          echo ""
+          node tests/conformance/report.js "${{ inputs.output-dir }}/reflect/conformance.log" "${{ inputs.output-dir }}/conformance-tests.log" --json "${{ inputs.output-dir }}/reflect/conformance.json"
+        } | tee -a "$GITHUB_STEP_SUMMARY"

--- a/.github/actions/conformance/action.yml
+++ b/.github/actions/conformance/action.yml
@@ -18,7 +18,7 @@ inputs:
     default: "2024"
 outputs:
   exit-code:
-    description: "Exit code returned by the upstream conformance runner."
+    description: "Exit code returned by the conformance suites."
     value: ${{ steps.run-conformance.outputs.exit_code }}
 runs:
   using: "composite"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -78,8 +78,11 @@ jobs:
       with:
         name: conformance-results
         path: |
-          tests/conformance/out/conformance.json
-          tests/conformance/out/conformance.log
           tests/conformance/out/conformance-tests.log
-          tests/conformance/out/failing_tests.txt
+          tests/conformance/out/static/conformance.json
+          tests/conformance/out/static/conformance.log
+          tests/conformance/out/static/failing_tests.txt
+          tests/conformance/out/reflect/conformance.json
+          tests/conformance/out/reflect/conformance.log
+          tests/conformance/out/reflect/failing_tests.txt
         if-no-files-found: ignore

--- a/README.md
+++ b/README.md
@@ -9,13 +9,9 @@
 
 **Protocol Buffers** are a language-neutral, platform-neutral, extensible way of serializing structured data for use in communications protocols, data storage, and more, originally designed at Google ([see](https://protobuf.dev/)).
 
-**protobuf.js** is a standalone JavaScript implementation of Protocol Buffers for Node.js and the browser. It works with `.proto` files out of the box, is optimized for fast binary I/O, and supports runtime reflection as well as reflection-free static code generation with strong TypeScript declarations.
+**protobuf.js** is a standalone JavaScript implementation of Protocol Buffers for Node.js and browsers. It is tuned for fast binary I/O, battle-tested at scale, can load `.proto` files directly, and supports runtime reflection as well as static code generation with strong TypeScript declarations.
 
-## About
-
-protobuf.js has grown from a personal project into a widely used JavaScript infrastructure library for Protocol Buffers. It is independently maintained, with participation from the upstream Protocol Buffers ecosystem, and is intentionally not tied to any specific vendor platform, commercial service, or schema registry.
-
-If protobuf.js is important to your project or organization, especially if you depend on it commercially, [consider supporting](https://github.com/sponsors/dcodeIO) its ongoing maintenance.
+If protobuf.js is important to your project or organization, especially if you depend on it commercially, [consider supporting its ongoing maintenance](https://github.com/sponsors/dcodeIO).
 
 ## Getting started
 
@@ -31,34 +27,11 @@ The [command line utility](./cli/#readme) for generating reflection bundles, sta
 npm install --save-dev protobufjs-cli
 ```
 
-The CLI is a small but capable standalone protobuf.js toolchain. It does not require `protoc`, but also provides `protoc-gen-pbjs` for standard `protoc` plugin workflows.
+The CLI is a JS-native protobuf.js toolchain. It does not require `protoc`, but optionally provides `protoc-gen-pbjs` for `protoc`-based workflows.
 
-### Choose a runtime
+#### Browser builds
 
-Pick the smallest runtime variant that supports how your application loads schemas and whether it needs reflection at runtime.
-
-| Import                  | Includes           | Use when
-| ----------------------- | ------------------ | --------
-| `protobufjs`            | Reflection, Parser | You load `.proto` files at runtime
-| `protobufjs/light.js`   | Reflection         | You load JSON bundles or build schemas programmatically
-| `protobufjs/minimal.js` | Static runtime     | You use generated static code
-
-The full build includes the light build, and the light build includes the minimal runtime.
-
-### Browser builds
-
-Pick the distribution matching your runtime variant and pin an exact version:
-
-```html
-<!-- Full -->
-<script src="https://cdn.jsdelivr.net/npm/protobufjs@8.X.X/dist/protobuf.min.js"></script>
-<!-- Light -->
-<script src="https://cdn.jsdelivr.net/npm/protobufjs@8.X.X/dist/light/protobuf.min.js"></script>
-<!-- Minimal -->
-<script src="https://cdn.jsdelivr.net/npm/protobufjs@8.X.X/dist/minimal/protobuf.min.js"></script>
-```
-
-Browser builds support CommonJS and AMD loaders and export globally as `window.protobuf`.
+Canonical browser builds for each runtime variant are [provided via the jsDelivr CDN](https://cdn.jsdelivr.net/npm/protobufjs@8.X.X/dist/), supporting CommonJS, AMD and global `window.protobuf`. Make sure to pin an exact version in production.
 
 ## Usage
 
@@ -92,10 +65,6 @@ Optionally use `load()` with a callback, or `loadSync()` for synchronous loading
 ```ts
 const payload = { awesomeField: "hello" };
 
-// Optionally verify if the payload is of uncertain shape
-const err = AwesomeMessage.verify(payload);
-if (err) throw Error(err);
-
 // Optionally create a message instance from already valid data
 const message = AwesomeMessage.create(payload);
 
@@ -103,11 +72,11 @@ const encoded = AwesomeMessage.encode(message).finish();
 const decoded = AwesomeMessage.decode(encoded);
 ```
 
-`encode` expects a message instance or equivalent plain object and does not verify input implicitly. Use `verify` for plain objects whose shape is not guaranteed, `create` to create a message instance from already valid data when useful, and `fromObject` when conversion from broader JavaScript objects is needed.
+`encode` expects a message instance or equivalent plain object and does not verify input implicitly. Use `create` to create a message instance from already valid data when useful, `verify` for plain objects whose shape is not guaranteed, and `fromObject` when conversion from broader JavaScript objects is needed.
 
-Plain objects can be encoded directly when they already use protobuf.js runtime types: numbers for 32-bit numeric fields, booleans for `bool`, strings for `string`, `Uint8Array` or `Buffer` for `bytes`, arrays for repeated fields, and plain objects for maps. Map keys are the string representation of the respective value or an 8-character hash string for 64-bit/`Long` keys. When exact 64-bit integer support is required, install [`long`](https://github.com/dcodeIO/long.js) with protobuf.js.
+Plain objects can be encoded directly when they already use protobuf.js runtime types: numbers for 32-bit numeric fields, booleans for `bool`, strings for `string`, `Uint8Array` or `Buffer` for `bytes`, arrays for repeated fields, and plain objects for maps. Map keys are the string representation of the respective value or an 8-character hash string for 64-bit keys.
 
-Unknown fields present on the wire are preserved by default in `message.$unknowns` and forwarded when the message is re-encoded. Unknown field data can be dropped from a decoded message with `delete message.$unknowns`, discarded during decode per reader with `reader.discardUnknown = true`, or disabled by default for subsequently created readers with `Reader.discardUnknown = true`.
+Unknown fields present on the wire are preserved by default in `message.$unknowns` and forwarded when the message is re-encoded. Unknown field data can be dropped from a decoded message with `delete message.$unknowns`, discarded during decode with `reader.discardUnknown = true` per reader, or disabled by default for subsequently created readers with `Reader.discardUnknown = true`.
 
 ### Convert plain objects
 
@@ -164,7 +133,7 @@ Message types expose focused methods for validation, conversion, and binary I/O.
 * **toObject**(message: `Message`, options?: `ConversionOptions`): `object`  
   Converts a message instance to a configurable plain JavaScript object.
 
-* **message#toJSON**(): `object`  
+* **message.toJSON**(): `object`  
   Converts a message instance to JSON-compatible output using default conversion options.
 
 Message instances provide runtime identity, so they can be tested with `instanceof`. Their `toJSON` method integrates them with `JSON.stringify`.
@@ -172,6 +141,18 @@ Message instances provide runtime identity, so they can be tested with `instance
 Length-delimited methods read and write a varint byte length before the message, which is useful for streams and framed protocols.
 
 If required fields are missing while decoding proto2 data, `decode` throws `protobuf.util.ProtocolError` with the partially decoded message available as `err.instance`.
+
+## Runtimes
+
+Pick the smallest runtime variant that supports how your application loads schemas and whether it needs reflection at runtime.
+
+| Import                  | Includes           | Use when
+| ----------------------- | ------------------ | --------
+| `protobufjs`            | Reflection, Parser | You load `.proto` files at runtime
+| `protobufjs/light.js`   | Reflection         | You load JSON bundles or build schemas programmatically
+| `protobufjs/minimal.js` | Static runtime     | You use generated static code
+
+The full build includes the light build, and the light build includes the minimal runtime.
 
 ## Code generation
 
@@ -335,9 +316,13 @@ See [examples/streaming-rpc.js](./examples/streaming-rpc.js) for a streaming exa
 
 For `google/protobuf/descriptor.proto` interoperability, see [ext/descriptor](./ext/README.md#descriptor). Note that because protobuf.js does not use `descriptor.proto` internally, options are parsed and presented literally.
 
-### Text format
+### ProtoJSON
 
-Protocol Buffers Text Format is supported via [ext/textformat](./ext/README.md#textformat) and exercised by the conformance suite.
+Protocol Buffers support a special [ProtoJSON format](https://protobuf.dev/programming-guides/json/) to share data with systems that do not support the binary wire format, for example when implementing gateways. Spec-compliant ProtoJSON is supported with reflection metadata present via the [ext/protojson](./ext/README.md#protojson) extension.
+
+### Text Format
+
+Protocol Buffers [Text Format](https://protobuf.dev/reference/protobuf/textformat-spec/) is a special syntax for representing protobuf data in text form, which can be useful for configurations or tests. Spec-compliant Text Format is supported with reflection metadata present via the [ext/textformat](./ext/README.md#textformat) extension.
 
 ### Content Security Policy
 
@@ -345,19 +330,21 @@ In [CSP](https://w3c.github.io/webappsec-csp/)-restricted environments that disa
 
 ## Conformance
 
-protobuf.js targets complete binary wire-format conformance for **Proto2**, **Proto3** and **Editions**. CI runs the official Protocol Buffers conformance suite, with logs [uploaded as artifacts](https://github.com/protobufjs/protobuf.js/actions/workflows/test.yml?query=branch%3Amaster+event%3Apush).
+protobuf.js targets complete binary wire-format conformance for **Proto2**, **Proto3** and **Editions** in any mode, plus complete **ProtoJSON** and **Text Format** conformance with reflection metadata present. CI runs the official Protocol Buffers conformance suite for validation, with logs [uploaded as artifacts](https://github.com/protobufjs/protobuf.js/actions/workflows/test.yml?query=branch%3Amaster+event%3Apush).
 
-Wire format by syntax:
-
-| Syntax   |               Total |          Required |       Recommended |
-| -------- | ------------------: | ----------------: | ----------------: |
-| Proto2   |   100.00% (694/694) | 100.00% (485/485) | 100.00% (209/209) |
-| Proto3   |   100.00% (689/689) | 100.00% (482/482) | 100.00% (207/207) |
-| Editions | 100.00% (1176/1176) | 100.00% (926/926) | 100.00% (250/250) |
+| Category   |               Total |            Required |         Recommended |
+| ---------- | ------------------: | ------------------: | ------------------: |
+| Binary     | 100.00% (2805/2805) | 100.00% (1939/1939) |   100.00% (866/866) |
+| ↳ Proto2   |   100.00% (703/703) |   100.00% (485/485) |   100.00% (218/218) |
+| ↳ Proto3   |   100.00% (698/698) |   100.00% (482/482) |   100.00% (216/216) |
+| ↳ Editions | 100.00% (1404/1404) |   100.00% (972/972) |   100.00% (432/432) |
+| ProtoJSON  | 100.00% (2762/2762) | 100.00% (2328/2328) |   100.00% (434/434) |
+| TextFormat |   100.00% (883/883) |   100.00% (819/819) |     100.00% (64/64) |
+| Overall    | 100.00% (6450/6450) | 100.00% (5086/5086) | 100.00% (1364/1364) |
 
 ## Performance
 
-In both reflection and static modes, protobuf.js builds specialized encoders and decoders instead of interpreting descriptors at runtime.
+In both reflection and reflection-free modes, protobuf.js builds specialized encoders and decoders instead of interpreting descriptors at runtime.
 
 The repository includes a [small benchmark](./bench). It compares protobuf.js reflection and static code against JSON encode/decode, protoc-gen-js, and protoc-gen-es. Results depend on hardware, Node.js version, and message shape, so they should be treated as indicative rather than absolute.
 

--- a/README.md
+++ b/README.md
@@ -312,17 +312,21 @@ const myService = MyService.create(myRpcImpl/*, requestDelimited?, responseDelim
 
 See [examples/streaming-rpc.js](./examples/streaming-rpc.js) for a streaming example.
 
+## Extensions
+
+Optional extensions provide descriptor conversion and text-based protobuf formats when reflection metadata is available. Most applications only need the binary APIs above.
+
 ### Descriptors
 
-For `google/protobuf/descriptor.proto` interoperability, see [ext/descriptor](./ext/README.md#descriptor). Note that because protobuf.js does not use `descriptor.proto` internally, options are parsed and presented literally.
+For converting reflected roots and objects to and from `protoc` descriptor messages, see [ext/descriptor](./ext/README.md#descriptor).
 
 ### ProtoJSON
 
-Protocol Buffers support a special [ProtoJSON format](https://protobuf.dev/programming-guides/json/) to share data with systems that do not support the binary wire format, for example when implementing gateways. Spec-compliant ProtoJSON is supported with reflection metadata present via the [ext/protojson](./ext/README.md#protojson) extension.
+Protocol Buffers support a special [ProtoJSON format](https://protobuf.dev/programming-guides/json/) to share data with systems that do not support the binary wire format, for example when implementing gateways. Spec-compliant ProtoJSON is supported via [ext/protojson](./ext/README.md#protojson).
 
 ### Text Format
 
-Protocol Buffers [Text Format](https://protobuf.dev/reference/protobuf/textformat-spec/) is a special syntax for representing protobuf data in text form, which can be useful for configurations or tests. Spec-compliant Text Format is supported with reflection metadata present via the [ext/textformat](./ext/README.md#textformat) extension.
+Protocol Buffers [Text Format](https://protobuf.dev/reference/protobuf/textformat-spec/) is a special syntax for representing protobuf data in text form, which can be useful for configurations or tests. Spec-compliant Text Format is supported via [ext/textformat](./ext/README.md#textformat).
 
 ### Content Security Policy
 
@@ -330,7 +334,7 @@ In [CSP](https://w3c.github.io/webappsec-csp/)-restricted environments that disa
 
 ## Conformance
 
-protobuf.js targets complete binary wire-format conformance for **Proto2**, **Proto3** and **Editions** in any mode, plus complete **ProtoJSON** and **Text Format** conformance with reflection metadata present. CI runs the official Protocol Buffers conformance suite for validation, with logs [uploaded as artifacts](https://github.com/protobufjs/protobuf.js/actions/workflows/test.yml?query=branch%3Amaster+event%3Apush).
+protobuf.js targets complete binary wire-format conformance for **Proto2**, **Proto3** and **Editions** in both static and reflection modes, plus complete **ProtoJSON** and **Text Format** conformance with reflection metadata present. CI runs the official Protocol Buffers conformance suite for validation, with logs [uploaded as artifacts](https://github.com/protobufjs/protobuf.js/actions/workflows/test.yml?query=branch%3Amaster+event%3Apush).
 
 | Category   |               Total |            Required |         Recommended |
 | ---------- | ------------------: | ------------------: | ------------------: |

--- a/README.md
+++ b/README.md
@@ -182,11 +182,11 @@ import { awesomepackage } from "./awesome.js";
 const message = awesomepackage.AwesomeMessage.create({ awesomeField: "hello" });
 ```
 
-In [CSP](https://w3c.github.io/webappsec-csp/)-restricted environments that disallow unsafe-eval, use generated static code instead of runtime code generation.
+While static code is verbose by design, its repeated patterns compress well with Brotli or gzip, and it works in [CSP](https://w3c.github.io/webappsec-csp/)-restricted environments that disallow unsafe-eval without sacrificing performance.
 
 ### Reflection bundles
 
-Bundling schemas avoids reparsing `.proto` files at runtime and can reduce browser requests when schemas would otherwise be loaded separately. While reflection requires at least `protobufjs/light.js`, large schemas often produce smaller bundles than equivalent static modules because most code is shared via reflection.
+Reflection bundles store schemas as compact JSON, avoiding `.proto` parsing at runtime and letting browsers load schema metadata in one request. While they require at least `protobufjs/light.js`, large schemas can produce smaller combined payloads than equivalent static modules because common code is shared through reflection.
 
 ```sh
 npx pbjs -t json -o awesome.json awesome1.proto awesome2.proto ...

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The [command line utility](./cli/#readme) for generating reflection bundles, sta
 npm install --save-dev protobufjs-cli
 ```
 
-The CLI is a JS-native protobuf.js toolchain. It does not require `protoc`, but optionally provides `protoc-gen-pbjs` for `protoc`-based workflows.
+The CLI is a JS-native protobuf.js toolchain that does not require setting up `protoc`. If you prefer a `protoc`-based workflow, it provides `protoc-gen-pbjs` as an option.
 
 #### Browser builds
 
@@ -316,11 +316,11 @@ See [examples/streaming-rpc.js](./examples/streaming-rpc.js) for a streaming exa
 
 ### Extensions
 
-Optional extensions provide descriptor conversion and text-based protobuf formats when reflection metadata is available. Most applications only need the binary APIs above.
+The following extensions provide descriptor conversion and text-based protobuf formats when reflection metadata is available. Most applications only need the binary APIs above.
 
 #### Descriptors
 
-For converting reflected roots and objects to and from `protoc` descriptor messages, see [ext/descriptor](./ext/README.md#descriptor).
+protobuf.js uses a compact JSON-based reflection representation internally that is easy to embed and fast to parse, so schemas can be loaded directly without first decoding binary descriptor blobs or postprocessing their full JSON representation. See [ext/descriptor](./ext/README.md#descriptor) for use cases that need conversion between reflected roots and `protoc` descriptor messages.
 
 #### ProtoJSON
 

--- a/README.md
+++ b/README.md
@@ -182,6 +182,8 @@ import { awesomepackage } from "./awesome.js";
 const message = awesomepackage.AwesomeMessage.create({ awesomeField: "hello" });
 ```
 
+In [CSP](https://w3c.github.io/webappsec-csp/)-restricted environments that disallow unsafe-eval, use generated static code instead of runtime code generation.
+
 ### Reflection bundles
 
 Bundling schemas avoids reparsing `.proto` files at runtime and can reduce browser requests when schemas would otherwise be loaded separately. While reflection requires at least `protobufjs/light.js`, large schemas often produce smaller bundles than equivalent static modules because most code is shared via reflection.
@@ -312,25 +314,21 @@ const myService = MyService.create(myRpcImpl/*, requestDelimited?, responseDelim
 
 See [examples/streaming-rpc.js](./examples/streaming-rpc.js) for a streaming example.
 
-## Extensions
+### Extensions
 
 Optional extensions provide descriptor conversion and text-based protobuf formats when reflection metadata is available. Most applications only need the binary APIs above.
 
-### Descriptors
+#### Descriptors
 
 For converting reflected roots and objects to and from `protoc` descriptor messages, see [ext/descriptor](./ext/README.md#descriptor).
 
-### ProtoJSON
+#### ProtoJSON
 
 Protocol Buffers support a special [ProtoJSON format](https://protobuf.dev/programming-guides/json/) to share data with systems that do not support the binary wire format, for example when implementing gateways. Spec-compliant ProtoJSON is supported via [ext/protojson](./ext/README.md#protojson).
 
-### Text Format
+#### Text Format
 
 Protocol Buffers [Text Format](https://protobuf.dev/reference/protobuf/textformat-spec/) is a special syntax for representing protobuf data in text form, which can be useful for configurations or tests. Spec-compliant Text Format is supported via [ext/textformat](./ext/README.md#textformat).
-
-### Content Security Policy
-
-In [CSP](https://w3c.github.io/webappsec-csp/)-restricted environments that disallow unsafe-eval, use generated static code instead of runtime code generation.
 
 ## Conformance
 

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ If required fields are missing while decoding proto2 data, `decode` throws `prot
 
 ## Runtimes
 
-Pick the smallest runtime variant that supports how your application loads schemas and whether it needs reflection at runtime.
+protobuf.js provides three runtime entry points, keeping parser and reflection support optional: Runtime `.proto` loading needs the parser, JSON/reflection bundles need reflection support, and generated static modules only need the minimal runtime.
 
 | Import                  | Includes           | Use when
 | ----------------------- | ------------------ | --------
@@ -156,7 +156,7 @@ The full build includes the light build, and the light build includes the minima
 
 ## Code generation
 
-Choose the integration style that fits your workflow and use [`protobufjs-cli`](./cli/#readme) to generate reflection bundles, static JavaScript code, and matching TypeScript declarations, either standalone with `pbjs` or through its `protoc-gen-pbjs` plugin for `protoc`.
+Use [`protobufjs-cli`](./cli/#readme) to generate reflection bundles, static JavaScript code, and matching TypeScript declarations, either directly with `pbjs` or through the optional `protoc-gen-pbjs` plugin for `protoc`.
 
 Reflection keeps schemas as JSON metadata and generates optimized functions at runtime. Static code emits schema-specific, reflection-free functions ahead of time. The main tradeoffs are how schemas are loaded, how bundle size scales with schema size, and whether reflection metadata should remain available at runtime.
 
@@ -186,7 +186,7 @@ While static code is verbose by design, its repeated patterns compress well with
 
 ### Reflection bundles
 
-Reflection bundles store schemas as compact JSON, avoiding `.proto` parsing at runtime and letting browsers load schema metadata in one request. While they require at least `protobufjs/light.js`, large schemas can produce smaller combined payloads than equivalent static modules because common code is shared through reflection.
+Reflection bundles store schemas as compact JSON metadata, avoiding `.proto` parsing at runtime and letting browsers load schema metadata in one request. While they require at least `protobufjs/light.js`, large schemas can produce smaller combined bundles than equivalent static modules because common code is shared through reflection.
 
 ```sh
 npx pbjs -t json -o awesome.json awesome1.proto awesome2.proto ...

--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -7,6 +7,7 @@ var js = require("@eslint/js"),
 module.exports = [
     {
         ignores: [
+            ".tmp/**",
             "**/node_modules/**",
             "bin/**",
             "cli/wrappers/**",

--- a/ext/README.md
+++ b/ext/README.md
@@ -9,7 +9,7 @@ import protobuf from "protobufjs";
 import descriptor from "protobufjs/ext/descriptor.js";
 
 // Convert an existing root to a FileDescriptorSet message.
-const root = protobuf.Root.fromJSON(bundle);
+const root = ...;
 const set = root.toDescriptor("proto2");
 
 // Encode descriptor buffers.
@@ -21,7 +21,7 @@ const decodedRoot = protobuf.Root.fromDescriptor(buffer);
 
 The extension requires reflection metadata and also works with `protobufjs/light.js` when schemas are loaded from JSON or otherwise provided as reflection objects.
 
-Importing the extension adds `.fromDescriptor(descriptor[, syntaxOrEdition])` and `#toDescriptor([syntaxOrEdition])` methods to reflection objects and exports reflected descriptor types from `google.protobuf`. Descriptor inputs can be decoded messages, readers, or `Uint8Array`s for the corresponding descriptor message.
+Importing the extension adds `.fromDescriptor(descriptor[, syntaxOrEdition])` and `#toDescriptor([syntaxOrEdition])` methods to reflected types and exports reflected descriptor types from `google.protobuf`. Descriptor inputs can be decoded messages, readers, or `Uint8Array`s for the corresponding descriptor message.
 
 | Descriptor type               | protobuf.js type | Remarks |
 |-------------------------------|------------------|---------|
@@ -62,20 +62,46 @@ Not all `descriptor.proto` features translate perfectly to a protobuf.js root. A
 
 The exported TypeScript interfaces can be used to reference specific descriptor message instances, for example `protobuf.Message<IDescriptorProto>`.
 
-## textformat
+## protojson
 
-Optional text format support for reflected message types.
+Optional ProtoJSON support for reflected message types.
+
+> [!NOTE]
+> Specialized code generation for the `pbjs` static-module target is a potential future extension. If you need this for high-throughput JSON transcoding or REST fallbacks in production, consider getting in touch and supporting the codegen and conformance work.
 
 ```js
 import protobuf from "protobufjs";
-import "protobufjs/ext/textformat.js";
+import protojson from "protobufjs/ext/protojson.js";
 
-const root = protobuf.Root.fromJSON(bundle);
+const root = ...;
 const MyType = root.lookupType("MyType");
-const message = MyType.fromText("value: 1");
-const text = MyType.toText(message);
+const message = protojson.fromJson(MyType, { value: 1 });
+const json = protojson.toJson(MyType, message);
 ```
 
-The extension patches `protobuf.Type` at runtime and requires reflection metadata. It works with `protobufjs/light.js` when schemas are loaded from JSON or otherwise provided as reflection objects. Static-only code using `protobufjs/minimal.js` is not supported.
+```js
+const messageFromString = protojson.fromJsonString(MyType, '{"value":1}');
+const jsonString = protojson.toJsonString(MyType, messageFromString);
+```
 
-Text output is produced from the message object passed to `toText`. Unknown fields can be printed with numeric field names by passing `{ unknowns: true }` to `toText`.
+Importing the extension has no prototype side effects. Calling `protojson.install()` installs `fromJson`, `fromJsonString`, `toJson` and `toJsonString` convenience methods on `protobuf.Type.prototype`. It works with `protobufjs/light.js` when schemas are loaded from JSON or otherwise provided as reflection objects.
+
+Unknown fields can be ignored while parsing by passing `{ ignoreUnknownFields: true }` to `fromJson` or `fromJsonString`.
+
+## textformat
+
+Optional Text Format support for reflected message types.
+
+```js
+import protobuf from "protobufjs";
+import textformat from "protobufjs/ext/textformat.js";
+
+const root = ...;
+const MyType = root.lookupType("MyType");
+const message = textformat.fromText(MyType, "value: 1");
+const text = textformat.toText(MyType, message);
+```
+
+Importing the extension has no prototype side effects. Calling `textformat.install()` installs `fromText` and `toText` convenience methods on `protobuf.Type.prototype`. It works with `protobufjs/light.js` when schemas are loaded from JSON or otherwise provided as reflection objects.
+
+Unknown fields can be printed with numeric field names by passing `{ unknowns: true }` to `toText`.

--- a/ext/README.md
+++ b/ext/README.md
@@ -2,7 +2,7 @@
 
 ## descriptor
 
-Optional `google/protobuf/descriptor.proto` interoperability layer for reflected roots and objects.
+Optional `descriptor.proto` support for converting reflected protobuf.js roots and objects to and from descriptor messages.
 
 ```js
 import protobuf from "protobufjs";
@@ -21,46 +21,9 @@ const decodedRoot = protobuf.Root.fromDescriptor(buffer);
 
 The extension requires reflection metadata and also works with `protobufjs/light.js` when schemas are loaded from JSON or otherwise provided as reflection objects.
 
-Importing the extension adds `.fromDescriptor(descriptor[, syntaxOrEdition])` and `#toDescriptor([syntaxOrEdition])` methods to reflected types and exports reflected descriptor types from `google.protobuf`. Descriptor inputs can be decoded messages, readers, or `Uint8Array`s for the corresponding descriptor message.
+Importing the extension adds `.fromDescriptor(descriptor[, syntaxOrEdition])` and `#toDescriptor([syntaxOrEdition])` methods to reflection objects and exports the bundled descriptor types from `google.protobuf`. Descriptor inputs can be decoded messages, readers, or buffers of the corresponding descriptor messages.
 
-| Descriptor type               | protobuf.js type | Remarks |
-|-------------------------------|------------------|---------|
-| **FileDescriptorSet**         | Root             | |
-| FileDescriptorProto           |                  | dependencies and source info are ignored on input and not emitted |
-| FileOptions                   |                  | |
-| FileOptionsOptimizeMode       |                  | |
-| SourceCodeInfo                |                  | exported descriptor type; not mapped to reflection |
-| SourceCodeInfoLocation        |                  | |
-| GeneratedCodeInfo             |                  | exported descriptor type; not mapped to reflection |
-| GeneratedCodeInfoAnnotation   |                  | |
-| **DescriptorProto**           | Type             | |
-| MessageOptions                |                  | |
-| DescriptorProtoExtensionRange |                  | |
-| DescriptorProtoReservedRange  |                  | |
-| **FieldDescriptorProto**      | Field / MapField | map entries are reconstructed as map fields |
-| FieldDescriptorProtoLabel     |                  | |
-| FieldDescriptorProtoType      |                  | |
-| FieldOptions                  |                  | |
-| FieldOptionsCType             |                  | |
-| FieldOptionsJSType            |                  | |
-| **OneofDescriptorProto**      | OneOf            | |
-| OneofOptions                  |                  | |
-| **EnumDescriptorProto**       | Enum             | |
-| EnumOptions                   |                  | |
-| EnumValueDescriptorProto      |                  | |
-| EnumValueOptions              |                  | |
-| **ServiceDescriptorProto**    | Service          | |
-| ServiceOptions                |                  | |
-| **MethodDescriptorProto**     | Method           | |
-| MethodOptions                 |                  | |
-| FeatureSet                    |                  | exported descriptor type; used by edition-aware options |
-| FeatureSetDefaults            |                  | exported descriptor type |
-| UninterpretedOption           |                  | exported descriptor type; options are not interpreted |
-| UninterpretedOptionNamePart   |                  | |
-
-Not all `descriptor.proto` features translate perfectly to a protobuf.js root. A root has only limited knowledge of packages and individual files, for example, which is compensated by guessing and generating file names.
-
-The exported TypeScript interfaces can be used to reference specific descriptor message instances, for example `protobuf.Message<IDescriptorProto>`.
+The conversion covers descriptor messages that correspond to protobuf.js reflection objects: files and file sets, messages, fields and map fields, oneofs, enums, services and methods. Descriptor-only metadata such as source locations, generated-code annotations and uninterpreted options remains available through the exported descriptor message types, but is not mapped onto reflection objects. File names are inferred when generating descriptors because roots do not retain exact file/package boundaries.
 
 ## protojson
 

--- a/ext/descriptor.generated.d.ts
+++ b/ext/descriptor.generated.d.ts
@@ -258,8 +258,8 @@ export interface IFieldDescriptorProto {
     /** Oneof index if part of a oneof */
     oneofIndex?: number;
 
-    /** Not supported */
-    jsonName?: any;
+    /** JSON name (lowerCamelCase) */
+    jsonName?: string;
 
     /** Field options */
     options?: IFieldOptions;

--- a/ext/descriptor.js
+++ b/ext/descriptor.js
@@ -363,7 +363,7 @@ function FieldBase_fromDescriptor(descriptor, edition, nested, mapEntries) {
  * @property {string} [extendee] Extended type name
  * @property {string} [defaultValue] Literal default value
  * @property {number} [oneofIndex] Oneof index if part of a oneof
- * @property {*} [jsonName] Not supported
+ * @property {string} [jsonName] JSON name (lowerCamelCase)
  * @property {IFieldOptions} [options] Field options
  * @property {boolean} [proto3Optional] Whether this is a proto3 optional field
  */
@@ -460,13 +460,22 @@ Field.fromDescriptor = function fromDescriptor(descriptor, edition, nested) {
             throw Error("illegal type name: " + extendee);
     } else
         extendee = undefined;
+    // Prefer json_name as the JS field name when present, while retaining both
+    // descriptor names for round-tripping and ProtoJSON lookup.
+    var fieldName = descriptor.jsonName && descriptor.jsonName.length
+        ? descriptor.jsonName
+        : descriptor.name.length ? descriptor.name : "field" + descriptor.number;
     var field = new Field(
-        descriptor.name.length ? descriptor.name : "field" + descriptor.number,
+        fieldName,
         descriptor.number,
         fieldType,
         fieldRule,
         extendee
     );
+    if (descriptor.name.length && descriptor.name !== fieldName)
+        field.protoName = descriptor.name;
+    if (descriptor.jsonName && descriptor.jsonName.length)
+        field.jsonName = descriptor.jsonName;
 
     if (!nested)
         field._edition = edition;
@@ -536,7 +545,13 @@ function MapField_fromDescriptor(descriptor, entryDescriptor) {
  * @param {string} [edition="proto2"] The syntax or edition to use
  */
 Field.prototype.toDescriptor = function toDescriptor(edition) {
-    var descriptor = exports.FieldDescriptorProto.create({ name: this.name, number: this.id });
+    // Emit descriptor names in FieldDescriptorProto form, including json_name only
+    // when it differs, and derive missing names so unresolved fields serialize consistently.
+    var protoName = this.protoName || this.name;
+    var jsonName = this.jsonName || $protobuf.util.jsonName(protoName);
+    var descriptor = exports.FieldDescriptorProto.create({ name: protoName, number: this.id });
+    if (jsonName !== protoName)
+        descriptor.jsonName = jsonName;
 
     if (this.map) {
 

--- a/ext/protojson.LICENSE
+++ b/ext/protojson.LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/ext/protojson.d.ts
+++ b/ext/protojson.d.ts
@@ -1,0 +1,20 @@
+import * as $protobuf from "..";
+import { IProtoJsonOptions } from "./protojson.generated";
+
+export * from "./protojson.generated";
+
+declare module ".." {
+    interface Type {
+        /** Installed by `protojson.install()`. Parses an already-parsed ProtoJSON value. */
+        fromJson(json: any, options?: IProtoJsonOptions): $protobuf.Message<{}>;
+
+        /** Installed by `protojson.install()`. Parses ProtoJSON text. */
+        fromJsonString(json: string, options?: IProtoJsonOptions): $protobuf.Message<{}>;
+
+        /** Installed by `protojson.install()`. Formats a message as ProtoJSON. */
+        toJson(message: ($protobuf.Message<{}>|{ [k: string]: any }), options?: IProtoJsonOptions): any;
+
+        /** Installed by `protojson.install()`. Formats a message as ProtoJSON text. */
+        toJsonString(message: ($protobuf.Message<{}>|{ [k: string]: any }), options?: IProtoJsonOptions): string;
+    }
+}

--- a/ext/protojson.generated.d.ts
+++ b/ext/protojson.generated.d.ts
@@ -1,0 +1,49 @@
+// DO NOT EDIT! This is a generated file. Edit the source file instead and regenerate.
+
+import * as $protobuf from "..";
+
+/** ProtoJSON conversion options. */
+export interface IProtoJsonOptions {
+
+    /** Ignores unknown object members and unrecognized enum names while parsing. */
+    ignoreUnknownFields?: boolean;
+}
+
+/**
+ * Parses a message from an already-parsed ProtoJSON value using the specified reflected type.
+ * @param type Reflected message type
+ * @param json Already-parsed ProtoJSON value
+ * @param [options] Conversion options
+ * @returns Message instance
+ */
+export function fromJson(type: $protobuf.Type, json: any, options?: IProtoJsonOptions): $protobuf.Message<{}>;
+
+/**
+ * Parses a message from ProtoJSON text using the specified reflected type.
+ * @param type Reflected message type
+ * @param json ProtoJSON text
+ * @param [options] Conversion options
+ * @returns Message instance
+ */
+export function fromJsonString(type: $protobuf.Type, json: string, options?: IProtoJsonOptions): $protobuf.Message<{}>;
+
+/**
+ * Formats a message as ProtoJSON using the specified reflected type.
+ * @param type Reflected message type
+ * @param message Message instance or plain object
+ * @param [options] Conversion options
+ * @returns ProtoJSON value (object, array, string, number, boolean or null)
+ */
+export function toJson(type: $protobuf.Type, message: ($protobuf.Message<{}>|{ [k: string]: any }), options?: IProtoJsonOptions): any;
+
+/**
+ * Formats a message as ProtoJSON text using the specified reflected type.
+ * @param type Reflected message type
+ * @param message Message instance or plain object
+ * @param [options] Conversion options
+ * @returns ProtoJSON text
+ */
+export function toJsonString(type: $protobuf.Type, message: ($protobuf.Message<{}>|{ [k: string]: any }), options?: IProtoJsonOptions): string;
+
+/** Installs reflected {@link Type} convenience methods. */
+export function install(): void;

--- a/ext/protojson.js
+++ b/ext/protojson.js
@@ -456,7 +456,7 @@ function toJsonValue(type, message, options, depth) {
                 arr[j] = writeSingular(field, value[j], options, depth);
             setOwn(out, key, arr);
         } else {
-            if (!hasOwn(message, field.name))
+            if (!hasOwn(message, field.name) || isImplicitDefault(field, value))
                 continue;
             setOwn(out, key, writeSingular(field, value, options, depth));
         }

--- a/ext/protojson.js
+++ b/ext/protojson.js
@@ -1,0 +1,903 @@
+// Copyright 2021 Google LLC
+// Copyright 2026 The protobuf.js Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Derived from proto3-json-serializer v3.0.4 and modified by The protobuf.js Authors.
+
+"use strict";
+var protobuf = require("../light");
+
+/* global BigInt */
+
+var Type = protobuf.Type,
+    Enum = protobuf.Enum,
+    util = protobuf.util;
+
+var protojson = protobuf.protojson = module.exports = {};
+
+function isExtension(field) {
+    return Boolean(field.declaringField) || field.name.charAt(0) === ".";
+}
+
+function extensionName(field) {
+    var df = field.declaringField || field,
+        full = df.fullName.charAt(0) === "." ? df.fullName.slice(1) : df.fullName;
+    return "[" + (df.protoName ? full.replace(/[^.]+$/, df.protoName) : full) + "]";
+}
+
+function indexField(index, key, field, type) {
+    var existing = index[key];
+    if (existing !== undefined && existing !== field)
+        throw Error(type.fullName + ": duplicate ProtoJSON field name " + JSON.stringify(key));
+    index[key] = field;
+}
+
+function fieldsByJsonName(type) {
+    if (type._fieldsByJsonName)
+        return type._fieldsByJsonName;
+    var index = Object.create(null),
+        fields = type.fieldsArray,
+        i = 0;
+    for (; i < fields.length; ++i) {
+        var field = fields[i].resolve();
+        if (isExtension(field))
+            indexField(index, extensionName(field), field, type);
+        else {
+            indexField(index, field.name, field, type);
+            indexField(index, field.jsonName, field, type);
+            indexField(index, field.protoName, field, type);
+        }
+    }
+    type._fieldsByJsonName = index;
+    return index;
+}
+
+// --- reading scalars ---
+
+var INT_RANGE = {
+    int32:    ["-2147483648", "2147483647"],
+    sint32:   ["-2147483648", "2147483647"],
+    sfixed32: ["-2147483648", "2147483647"],
+    uint32:   ["0", "4294967295"],
+    fixed32:  ["0", "4294967295"],
+    int64:    ["-9223372036854775808", "9223372036854775807"],
+    sint64:   ["-9223372036854775808", "9223372036854775807"],
+    sfixed64: ["-9223372036854775808", "9223372036854775807"],
+    uint64:   ["0", "18446744073709551615"],
+    fixed64:  ["0", "18446744073709551615"]
+};
+
+var LONG_TYPE = { int64: 1, uint64: 1, sint64: 1, fixed64: 1, sfixed64: 1 };
+
+var MAX_FLOAT = 3.4028234663852886e38;
+var hasBigInt = typeof BigInt !== "undefined";
+
+var NUMERIC_RE = /^[+-]?(?:[0-9]*\.[0-9]+|[0-9]+\.?)(?:[eE][+-]?[0-9]+)?$/;
+
+var SKIP = {};
+
+function invalid(name, value, what) {
+    return Error(name + ": " + what + ": " + JSON.stringify(value));
+}
+
+function parseIntegerString(value, type, name) {
+    var str;
+    if (typeof value === "number") {
+        if (!isFinite(value) || Math.floor(value) !== value)
+            throw invalid(name, value, "not an integer");
+        str = numberToIntString(value);
+    } else if (typeof value === "string") {
+        if (value.length === 0 || /^\s|\s$/.test(value))
+            throw invalid(name, value, "invalid integer");
+        if (/^[+-]?[0-9]+$/.test(value))
+            str = value;
+        else if (NUMERIC_RE.test(value)) {
+            var num = Number(value);
+            if (!isFinite(num) || Math.floor(num) !== num)
+                throw invalid(name, value, "not an integer");
+            str = numberToIntString(num);
+        } else
+            throw invalid(name, value, "invalid integer");
+    } else
+        throw invalid(name, value, "expected integer (number or string)");
+
+    var range = INT_RANGE[type];
+    if (LONG_TYPE[type]) {
+        if (hasBigInt) {
+            var big = BigInt(str);
+            if (big < BigInt(range[0]) || big > BigInt(range[1]))
+                throw invalid(name, value, "out of range for " + type);
+        }
+    } else if (Number(str) < Number(range[0]) || Number(str) > Number(range[1]))
+        throw invalid(name, value, "out of range for " + type);
+    return str;
+}
+
+function parseMapIntegerKey(key, type, name) {
+    var unsigned = type === "uint32" || type === "fixed32" || type === "uint64" || type === "fixed64";
+    if (!(unsigned ? /^[0-9]+$/ : /^-?[0-9]+$/).test(key))
+        throw invalid(name, key, "invalid " + type + " map key");
+    if (hasBigInt) {
+        var big = BigInt(key),
+            range = INT_RANGE[type];
+        if (big < BigInt(range[0]) || big > BigInt(range[1]))
+            throw invalid(name, key, "out of range for " + type + " map key");
+        return big.toString();
+    }
+    parseIntegerString(key, type, name);
+    if (LONG_TYPE[type]) {
+        var normalized = key.replace(/^-?0+(?=\d)/, key.charAt(0) === "-" ? "-" : "");
+        return normalized === "-0" ? "0" : normalized;
+    }
+    return String(Number(key));
+}
+
+function numberToIntString(num) {
+    if (num >= -9007199254740991 && num <= 9007199254740991)
+        return String(num);
+    return num.toFixed(0);
+}
+
+function parseFloat32Or64(value, isFloat, name) {
+    var num;
+    if (typeof value === "number") {
+        if (!isFinite(value))
+            throw invalid(name, value, "number out of range");
+        num = value;
+    } else if (value === "NaN")
+        return NaN;
+    else if (value === "Infinity")
+        return Infinity;
+    else if (value === "-Infinity")
+        return -Infinity;
+    else if (typeof value === "string") {
+        if (value.length === 0 || /^\s|\s$/.test(value) || !NUMERIC_RE.test(value))
+            throw invalid(name, value, "invalid number");
+        num = Number(value);
+        if (!isFinite(num))
+            throw invalid(name, value, "invalid number");
+    } else
+        throw invalid(name, value, "expected number");
+    if (isFloat && Math.abs(num) > MAX_FLOAT)
+        throw invalid(name, value, "out of range for float");
+    return num;
+}
+
+function validateUtf16(value, name) {
+    for (var i = 0; i < value.length; ++i) {
+        var c = value.charCodeAt(i);
+        if (c >= 0xD800 && c <= 0xDBFF) {
+            var next = value.charCodeAt(i + 1);
+            if (!(next >= 0xDC00 && next <= 0xDFFF))
+                throw invalid(name, value, "unpaired high surrogate");
+            ++i;
+        } else if (c >= 0xDC00 && c <= 0xDFFF)
+            throw invalid(name, value, "unpaired low surrogate");
+    }
+}
+
+function parseBytes(value, name) {
+    if (typeof value !== "string")
+        throw invalid(name, value, "expected base64 string");
+    var s = value.replace(/-/g, "+").replace(/_/g, "/");
+    while (s.length % 4)
+        s += "=";
+    var buffer = util.newBuffer(util.base64.length(s));
+    util.base64.decode(s, buffer, 0);
+    return buffer;
+}
+
+function longFromString(str, unsigned) {
+    return util.Long ? util.Long.fromString(str, unsigned) : parseInt(str, 10);
+}
+
+function readScalar(type, value, name) {
+    switch (type) {
+        case "int32": case "sint32": case "sfixed32":
+        case "uint32": case "fixed32":
+            return Number(parseIntegerString(value, type, name));
+        case "int64": case "sint64": case "sfixed64":
+            return longFromString(parseIntegerString(value, type, name), false);
+        case "uint64": case "fixed64":
+            return longFromString(parseIntegerString(value, type, name), true);
+        case "float":
+            return parseFloat32Or64(value, true, name);
+        case "double":
+            return parseFloat32Or64(value, false, name);
+        case "bool":
+            if (typeof value !== "boolean")
+                throw invalid(name, value, "expected boolean");
+            return value;
+        case "string":
+            if (typeof value !== "string")
+                throw invalid(name, value, "expected string");
+            validateUtf16(value, name);
+            return value;
+        case "bytes":
+            return parseBytes(value, name);
+        default:
+            throw Error(name + ": unsupported scalar type " + type);
+    }
+}
+
+function readEnum(enm, value, name, options) {
+    if (typeof value === "string") {
+        var num = enm.values[value];
+        if (num !== undefined)
+            return num;
+        if (options.ignoreUnknownFields)
+            return SKIP;
+        throw invalid(name, value, "unknown enum value");
+    }
+    if (typeof value === "number") {
+        if (!isFinite(value) || Math.floor(value) !== value)
+            throw invalid(name, value, "invalid enum number");
+        return value;
+    }
+    if (value === null && enm.fullName === ".google.protobuf.NullValue")
+        return 0;
+    throw invalid(name, value, "expected enum string or number");
+}
+
+function readMapKey(field, key) {
+    switch (field.keyType) {
+        case "bool":
+            if (key !== "true" && key !== "false")
+                throw invalid(field.fullName, key, "invalid bool map key");
+            return key;
+        case "string":
+            validateUtf16(key, field.fullName);
+            return key;
+        case "int32": case "sint32": case "sfixed32":
+        case "uint32": case "fixed32":
+        case "int64": case "sint64": case "sfixed64":
+        case "uint64": case "fixed64":
+            return parseMapIntegerKey(key, field.keyType, field.fullName);
+        default:
+            throw Error(field.fullName + ": unsupported map key type " + field.keyType);
+    }
+}
+
+// --- reading messages ---
+
+function readField(field, value, options, depth) {
+    if (field.map) {
+        if (value === null || typeof value !== "object" || Array.isArray(value))
+            throw invalid(field.fullName, value, "expected object for map");
+        var map = Object.create(null), k;
+        for (k in value)
+            if (hasOwn(value, k)) {
+                var mk = readMapKey(field, k),
+                    mv = readSingular(field, value[k], options, depth);
+                if (mv !== SKIP) {
+                    if (hasOwn(map, mk))
+                        throw invalid(field.fullName, k, "duplicate map key");
+                    map[mk] = mv;
+                }
+            }
+        return map;
+    }
+    if (field.repeated) {
+        if (!Array.isArray(value))
+            throw invalid(field.fullName, value, "expected array");
+        var arr = [], i = 0;
+        for (; i < value.length; ++i) {
+            if (value[i] === null && !isValueType(field.resolvedType))
+                throw invalid(field.fullName, null, "null element");
+            var el = readSingular(field, value[i], options, depth);
+            if (el !== SKIP)
+                arr.push(el);
+        }
+        return arr;
+    }
+    return readSingular(field, value, options, depth);
+}
+
+function readSingular(field, value, options, depth) {
+    if (field.resolvedType instanceof Type)
+        return readMessage(field.resolvedType, value, options, depth + 1);
+    if (field.resolvedType instanceof Enum)
+        return readEnum(field.resolvedType, value, field.fullName, options);
+    return readScalar(field.type, value, field.fullName);
+}
+
+function isValueType(type) {
+    return type instanceof Type && type.fullName === ".google.protobuf.Value";
+}
+
+function isImplicitDefault(field, value) {
+    if (field.hasPresence || field.repeated || field.map || field.resolvedType instanceof Type)
+        return false;
+    if (field.resolvedType instanceof Enum)
+        return value === 0;
+    switch (field.type) {
+        case "bool": return value === false;
+        case "string": return value === "";
+        case "bytes": return value == null || value.length === 0;
+        default: return longToNumber(value) === 0;
+    }
+}
+
+function readMessage(type, value, options, depth) {
+    if (depth > util.recursionLimit)
+        throw Error("max depth exceeded");
+
+    var wkt = WKT_FROM[type.fullName];
+    if (wkt)
+        return wkt(type, value, options, depth);
+
+    if (value === null || typeof value !== "object" || Array.isArray(value))
+        throw invalid(type.fullName, value, "expected object");
+
+    var index = fieldsByJsonName(type),
+        out = {},
+        seenFields = Object.create(null),
+        seenOneofs = Object.create(null),
+        key;
+
+    for (key in value) {
+        if (!hasOwn(value, key))
+            continue;
+        var field = index[key];
+        if (field === undefined) {
+            if (options.ignoreUnknownFields)
+                continue;
+            throw invalid(type.fullName, key, "unknown field");
+        }
+        if (seenFields[field.name])
+            throw invalid(type.fullName, key, "duplicate field");
+        seenFields[field.name] = true;
+        var fv = value[key], fieldValue;
+        if (fv === null) {
+            if (isValueType(field.resolvedType))
+                fieldValue = { nullValue: 0 };
+            else if (field.resolvedType instanceof Enum && field.resolvedType.fullName === ".google.protobuf.NullValue")
+                fieldValue = 0;
+            else
+                continue;
+        } else
+            fieldValue = readField(field, fv, options, depth);
+        if (fieldValue === SKIP)
+            continue;
+        if (field.partOf) {
+            if (seenOneofs[field.partOf.name])
+                throw Error(type.fullName + ": multiple values for oneof " + field.partOf.name);
+            seenOneofs[field.partOf.name] = true;
+        }
+        if (!isImplicitDefault(field, fieldValue))
+            out[field.name] = fieldValue;
+    }
+    return out;
+}
+
+// --- writing messages ---
+
+function hasOwn(o, k) {
+    return o != null && Object.prototype.hasOwnProperty.call(o, k);
+}
+
+function setOwn(o, k, v) {
+    if (k === "__proto__")
+        util.makeProp(o, k);
+    o[k] = v;
+}
+
+function writeScalar(type, value) {
+    switch (type) {
+        case "int64": case "sint64": case "sfixed64":
+        case "uint64": case "fixed64":
+            return value == null ? "0" : String(value);
+        case "float": case "double":
+            return typeof value === "number" && !isFinite(value) ? String(value) : value;
+        case "bytes":
+            return value == null ? "" : util.base64.encode(value, 0, value.length);
+        default:
+            return value;
+    }
+}
+
+function writeSingular(field, value, options, depth) {
+    if (field.resolvedType instanceof Type)
+        return toJsonValue(field.resolvedType, value, options, depth + 1);
+    if (field.resolvedType instanceof Enum) {
+        if (field.resolvedType.fullName === ".google.protobuf.NullValue")
+            return null;
+        var name = field.resolvedType.valuesById[value];
+        return name === undefined ? value : name;
+    }
+    return writeScalar(field.type, value);
+}
+
+function toJsonValue(type, message, options, depth) {
+    if (depth > util.recursionLimit)
+        throw Error("max depth exceeded");
+
+    var wkt = WKT_TO[type.fullName];
+    if (wkt)
+        return wkt(type, message, options, depth);
+
+    var out = {},
+        fields = type.fieldsArray,
+        i = 0;
+    for (; i < fields.length; ++i) {
+        var field = fields[i].resolve(),
+            value = message[field.name];
+        if (value == null)
+            continue;
+        var key = isExtension(field) ? extensionName(field) : field.jsonName;
+        if (field.map) {
+            var mk = Object.keys(value);
+            if (!mk.length)
+                continue;
+            var longKey = LONG_TYPE[field.keyType],
+                unsignedKey = field.keyType === "uint64" || field.keyType === "fixed64",
+                mo = {}, ki = 0;
+            for (; ki < mk.length; ++ki) {
+                var outKey = longKey ? util.longFromKey(mk[ki], unsignedKey).toString() : mk[ki];
+                setOwn(mo, outKey, writeSingular(field, value[mk[ki]], options, depth));
+            }
+            setOwn(out, key, mo);
+        } else if (field.repeated) {
+            if (!value.length)
+                continue;
+            var arr = new Array(value.length), j = 0;
+            for (; j < value.length; ++j)
+                arr[j] = writeSingular(field, value[j], options, depth);
+            setOwn(out, key, arr);
+        } else {
+            if (!hasOwn(message, field.name))
+                continue;
+            setOwn(out, key, writeSingular(field, value, options, depth));
+        }
+    }
+    return out;
+}
+
+// --- well-known types ---
+
+function longToNumber(value) {
+    if (value == null) return 0;
+    if (typeof value === "number") return value;
+    if (typeof value.toNumber === "function") return value.toNumber();
+    return Number(value) || 0;
+}
+
+function nanosToString(nanos) {
+    var str = String(nanos < 0 ? -nanos : nanos);
+    while (str.length < 9) str = "0" + str;
+    while (str.length > 3 && str.slice(str.length - 3) === "000") str = str.slice(0, str.length - 3);
+    return str;
+}
+
+function fracToNanos(frac) {
+    while (frac.length < 9) frac += "0";
+    return parseInt(frac.slice(0, 9), 10);
+}
+
+function daysInMonth(year, month) {
+    switch (month) {
+        case 2:
+            return year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0) ? 29 : 28;
+        case 4:
+        case 6:
+        case 9:
+        case 11:
+            return 30;
+        default:
+            return 31;
+    }
+}
+
+function camelToSnake(path) {
+    return path.replace(/[A-Z]/g, function ($0) { return "_" + $0.toLowerCase(); });
+}
+
+var WKT_FROM = {};
+var WKT_TO = {};
+
+WKT_FROM[".google.protobuf.Duration"] = function (type, value) {
+    if (typeof value !== "string")
+        throw invalid(type.fullName, value, "expected duration string");
+    var match = /^(-)?([0-9]+)(?:\.([0-9]{1,9}))?s$/.exec(value);
+    if (!match)
+        throw invalid(type.fullName, value, "invalid duration");
+    var sign = match[1] ? -1 : 1,
+        seconds = parseInt(match[2], 10) * sign || 0,
+        nanos = match[3] ? fracToNanos(match[3]) * sign || 0 : 0;
+    if (seconds > 315576000000 || seconds < -315576000000)
+        throw invalid(type.fullName, value, "duration out of range");
+    return { seconds: seconds, nanos: nanos };
+};
+WKT_TO[".google.protobuf.Duration"] = function (type, message) {
+    var seconds = longToNumber(message.seconds),
+        nanos = message.nanos || 0;
+    if (seconds > 315576000000 || seconds < -315576000000)
+        throw Error("google.protobuf.Duration out of range");
+    if (nanos > 999999999 || nanos < -999999999 || seconds && nanos && seconds < 0 !== nanos < 0)
+        throw Error("google.protobuf.Duration nanos invalid");
+    var result = (seconds < 0 || nanos < 0 ? "-" : "") + Math.abs(seconds);
+    if (nanos)
+        result += "." + nanosToString(nanos);
+    return result + "s";
+};
+
+WKT_FROM[".google.protobuf.Timestamp"] = function (type, value) {
+    if (typeof value !== "string")
+        throw invalid(type.fullName, value, "expected timestamp string");
+    var match = /^(\d{4})-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01])T([01]\d|2[0-3]):([0-5]\d):([0-5]\d)(?:\.(\d{1,9}))?(Z|[+-](?:[01]\d|2[0-3]):[0-5]\d)$/.exec(value);
+    if (!match)
+        throw invalid(type.fullName, value, "invalid timestamp");
+    var year = parseInt(match[1], 10),
+        month = parseInt(match[2], 10),
+        day = parseInt(match[3], 10);
+    if (day > daysInMonth(year, month))
+        throw invalid(type.fullName, value, "invalid timestamp date");
+    var millis = new Date(value).getTime();
+    if (isNaN(millis))
+        throw invalid(type.fullName, value, "invalid timestamp");
+    var seconds = Math.floor(millis / 1000),
+        nanos = match[7] ? fracToNanos(match[7]) : 0;
+    if (seconds < -62135596800 || seconds > 253402300799)
+        throw invalid(type.fullName, value, "timestamp out of range");
+    return { seconds: seconds, nanos: nanos };
+};
+WKT_TO[".google.protobuf.Timestamp"] = function (type, message) {
+    var seconds = longToNumber(message.seconds),
+        nanos = message.nanos || 0;
+    if (seconds < -62135596800 || seconds > 253402300799)
+        throw Error("google.protobuf.Timestamp out of range");
+    if (nanos < 0 || nanos > 999999999)
+        throw Error("google.protobuf.Timestamp nanos out of range");
+    var iso = new Date(seconds * 1000).toISOString();
+    return nanos
+        ? iso.replace(/\.\d+Z$/, "." + nanosToString(nanos) + "Z")
+        : iso.replace(/\.\d+Z$/, "Z");
+};
+
+WKT_FROM[".google.protobuf.FieldMask"] = function (type, value) {
+    if (typeof value !== "string")
+        throw invalid(type.fullName, value, "expected field mask string");
+    if (value.indexOf("_") !== -1)
+        throw invalid(type.fullName, value, "field mask path must be lowerCamelCase");
+    var paths = value.length ? value.split(",") : [],
+        i = 0;
+    for (; i < paths.length; ++i)
+        paths[i] = camelToSnake(paths[i]);
+    return { paths: paths };
+};
+WKT_TO[".google.protobuf.FieldMask"] = function (type, message) {
+    var paths = message.paths || [],
+        out = [],
+        i = 0;
+    for (; i < paths.length; ++i) {
+        var camel = util.jsonName(paths[i]);
+        if (camelToSnake(camel) !== paths[i])
+            throw Error("google.protobuf.FieldMask path does not round-trip: " + paths[i]);
+        out.push(camel);
+    }
+    return out.join(",");
+};
+
+["DoubleValue", "FloatValue", "Int64Value", "UInt64Value", "Int32Value",
+ "UInt32Value", "BoolValue", "StringValue", "BytesValue"].forEach(function (name) {
+    var fullName = ".google.protobuf." + name;
+    WKT_FROM[fullName] = function (type, value, options, depth) {
+        return { value: readSingular(type.fields.value.resolve(), value, options, depth) };
+    };
+    WKT_TO[fullName] = function (type, message, options, depth) {
+        return writeSingular(type.fields.value.resolve(), message.value, options, depth);
+    };
+});
+
+function valueFromJson(json, depth) {
+    if (depth > util.recursionLimit)
+        throw Error("max depth exceeded");
+    if (json === null)
+        return { nullValue: 0 };
+    switch (typeof json) {
+        case "number":
+            if (!isFinite(json))
+                throw Error("google.protobuf.Value cannot hold a non-finite number");
+            return { numberValue: json };
+        case "string":
+            validateUtf16(json, "google.protobuf.Value.string_value");
+            return { stringValue: json };
+        case "boolean":
+            return { boolValue: json };
+    }
+    if (Array.isArray(json)) {
+        var values = new Array(json.length), i = 0;
+        for (; i < json.length; ++i)
+            values[i] = valueFromJson(json[i], depth + 1);
+        return { listValue: { values: values } };
+    }
+    return { structValue: { fields: structFieldsFromJson(json, depth + 1) } };
+}
+function structFieldsFromJson(json, depth) {
+    var fields = Object.create(null), k;
+    for (k in json)
+        if (hasOwn(json, k)) {
+            validateUtf16(k, "google.protobuf.Struct.fields");
+            fields[k] = valueFromJson(json[k], depth);
+        }
+    return fields;
+}
+WKT_FROM[".google.protobuf.Value"] = function (type, value, options, depth) {
+    return valueFromJson(value, depth);
+};
+WKT_FROM[".google.protobuf.Struct"] = function (type, value, options, depth) {
+    if (value === null || typeof value !== "object" || Array.isArray(value))
+        throw invalid(type.fullName, value, "google.protobuf.Struct must be an object");
+    return { fields: structFieldsFromJson(value, depth + 1) };
+};
+WKT_FROM[".google.protobuf.ListValue"] = function (type, value, options, depth) {
+    if (!Array.isArray(value))
+        throw invalid(type.fullName, value, "google.protobuf.ListValue must be an array");
+    var values = new Array(value.length), i = 0;
+    for (; i < value.length; ++i)
+        values[i] = valueFromJson(value[i], depth + 1);
+    return { values: values };
+};
+
+function valueToJson(message, options, depth) {
+    if (depth > util.recursionLimit)
+        throw Error("max depth exceeded");
+    if (message == null || hasOwn(message, "nullValue"))
+        return null;
+    if (hasOwn(message, "numberValue")) {
+        if (typeof message.numberValue === "number" && !isFinite(message.numberValue))
+            throw Error("google.protobuf.Value cannot hold a non-finite number");
+        return message.numberValue;
+    }
+    if (hasOwn(message, "stringValue")) return message.stringValue;
+    if (hasOwn(message, "boolValue")) return message.boolValue;
+    if (hasOwn(message, "structValue")) return structToJson(message.structValue, options, depth + 1);
+    if (hasOwn(message, "listValue")) return listToJson(message.listValue, options, depth + 1);
+    return null;
+}
+function structToJson(message, options, depth) {
+    var out = {}, fields = message && message.fields, k;
+    if (fields)
+        for (k in fields)
+            if (hasOwn(fields, k))
+                setOwn(out, k, valueToJson(fields[k], options, depth));
+    return out;
+}
+function listToJson(message, options, depth) {
+    var values = message && message.values;
+    if (!values) return [];
+    var arr = new Array(values.length), i = 0;
+    for (; i < values.length; ++i)
+        arr[i] = valueToJson(values[i], options, depth);
+    return arr;
+}
+WKT_TO[".google.protobuf.Value"] = function (type, message, options, depth) {
+    return valueToJson(message, options, depth);
+};
+WKT_TO[".google.protobuf.Struct"] = function (type, message, options, depth) {
+    return structToJson(message, options, depth);
+};
+WKT_TO[".google.protobuf.ListValue"] = function (type, message, options, depth) {
+    return listToJson(message, options, depth);
+};
+
+WKT_FROM[".google.protobuf.Any"] = function (type, value, options, depth) {
+    if (value === null || typeof value !== "object" || Array.isArray(value))
+        throw invalid(type.fullName, value, "google.protobuf.Any must be an object");
+    var typeUrl = value["@type"];
+    if (typeUrl === undefined)
+        return {};
+    if (typeof typeUrl !== "string")
+        throw Error("google.protobuf.Any @type must be a string");
+    var name = typeUrl.substring(typeUrl.lastIndexOf("/") + 1),
+        msgType = type.root.lookupType(name),
+        custom = WKT_FROM[msgType.fullName] !== undefined,
+        body;
+    if (custom)
+        body = value.value;
+    else {
+        body = {};
+        for (var k in value)
+            if (hasOwn(value, k) && k !== "@type")
+                setOwn(body, k, value[k]);
+    }
+    var inner = readMessage(msgType, body, options, depth + 1);
+    var url = typeUrl.charAt(0) === "." ? typeUrl.slice(1) : typeUrl;
+    if (url.indexOf("/") === -1)
+        url = "/" + url;
+    return { type_url: url, value: msgType.encode(inner).finish() };
+};
+WKT_TO[".google.protobuf.Any"] = function (type, message, options, depth) {
+    if (!message.type_url)
+        return {};
+    var name = message.type_url.substring(message.type_url.lastIndexOf("/") + 1),
+        msgType = type.root.lookupType(name),
+        decoded = msgType.decode(message.value),
+        body = toJsonValue(msgType, decoded, options, depth + 1),
+        result;
+    if (WKT_TO[msgType.fullName])
+        result = { "@type": message.type_url, "value": body };
+    else {
+        result = { "@type": message.type_url };
+        for (var k in body)
+            if (hasOwn(body, k))
+                setOwn(result, k, body[k]);
+    }
+    return result;
+};
+
+// --- duplicate keys ---
+
+// JSON.parse keeps the last duplicate key, but ProtoJSON rejects duplicates.
+function checkDuplicateKeys(str) {
+    var stack = [],
+        expectKey = false,
+        i = 0,
+        n = str.length;
+    while (i < n) {
+        var c = str.charAt(i);
+        if (c === "{") {
+            stack.push(Object.create(null));
+            expectKey = true;
+            ++i;
+        } else if (c === "[") {
+            stack.push(null);
+            expectKey = false;
+            ++i;
+        } else if (c === "}" || c === "]") {
+            stack.pop();
+            expectKey = false;
+            ++i;
+        } else if (c === ":") {
+            expectKey = false;
+            ++i;
+        } else if (c === ",") {
+            expectKey = stack.length > 0 && stack[stack.length - 1] !== null;
+            ++i;
+        } else if (c === "\"") {
+            var start = i++;
+            while (i < n) {
+                var ch = str.charAt(i++);
+                if (ch === "\\") ++i;
+                else if (ch === "\"") break;
+            }
+            if (expectKey) {
+                var seen = stack[stack.length - 1],
+                    name = JSON.parse(str.slice(start, i));
+                if (seen[name])
+                    throw Error("duplicate key in JSON object: " + JSON.stringify(name));
+                seen[name] = true;
+                expectKey = false;
+            }
+        } else
+            ++i;
+    }
+}
+
+// --- public API ---
+
+/**
+ * ProtoJSON conversion options.
+ * @interface IProtoJsonOptions
+ * @property {boolean} [ignoreUnknownFields=false] Ignores unknown object members and unrecognized enum names while parsing.
+ */
+
+/**
+ * Parses a message from an already-parsed ProtoJSON value using the specified reflected type.
+ * @function fromJson
+ * @name fromJson
+ * @param {$protobuf.Type} type Reflected message type
+ * @param {*} json Already-parsed ProtoJSON value
+ * @param {IProtoJsonOptions} [options] Conversion options
+ * @returns {$protobuf.Message<{}>} Message instance
+ */
+protojson.fromJson = function fromJson(type, json, options) {
+    if (!(type instanceof Type))
+        throw TypeError("type must be a Type");
+    type.root.resolveAll();
+    return type.create(readMessage(type, json, options || {}, 0));
+};
+
+/**
+ * Parses a message from ProtoJSON text using the specified reflected type.
+ * @function fromJsonString
+ * @name fromJsonString
+ * @param {$protobuf.Type} type Reflected message type
+ * @param {string} json ProtoJSON text
+ * @param {IProtoJsonOptions} [options] Conversion options
+ * @returns {$protobuf.Message<{}>} Message instance
+ */
+protojson.fromJsonString = function fromJsonString(type, json, options) {
+    if (typeof json !== "string")
+        throw TypeError("json must be a string");
+    checkDuplicateKeys(json);
+    return protojson.fromJson(type, JSON.parse(json), options);
+};
+
+/**
+ * Formats a message as ProtoJSON using the specified reflected type.
+ * @function toJson
+ * @name toJson
+ * @param {$protobuf.Type} type Reflected message type
+ * @param {$protobuf.Message<{}>|Object.<string,*>} message Message instance or plain object
+ * @param {IProtoJsonOptions} [options] Conversion options
+ * @returns {*} ProtoJSON value (object, array, string, number, boolean or null)
+ */
+protojson.toJson = function toJson(type, message, options) {
+    if (!(type instanceof Type))
+        throw TypeError("type must be a Type");
+    type.root.resolveAll();
+    return toJsonValue(type, message, options || {}, 0);
+};
+
+/**
+ * Formats a message as ProtoJSON text using the specified reflected type.
+ * @function toJsonString
+ * @name toJsonString
+ * @param {$protobuf.Type} type Reflected message type
+ * @param {$protobuf.Message<{}>|Object.<string,*>} message Message instance or plain object
+ * @param {IProtoJsonOptions} [options] Conversion options
+ * @returns {string} ProtoJSON text
+ */
+protojson.toJsonString = function toJsonString(type, message, options) {
+    return JSON.stringify(protojson.toJson(type, message, options));
+};
+
+/**
+ * Installs reflected {@link Type} convenience methods.
+ * @function install
+ * @name install
+ * @returns {undefined}
+ */
+protojson.install = function install() {
+    /**
+     * Parses a message of this type from an already-parsed ProtoJSON value. Convenience for {@link protojson.fromJson}.
+     * @param {*} json Already-parsed ProtoJSON value
+     * @param {IProtoJsonOptions} [options] Conversion options
+     * @returns {Message<{}>} Message instance
+     */
+    Type.prototype.fromJson = function fromJson(json, options) {
+        return protojson.fromJson(this, json, options);
+    };
+
+    /**
+     * Parses a message of this type from ProtoJSON text. Convenience for {@link protojson.fromJsonString}.
+     * @param {string} json ProtoJSON text
+     * @param {IProtoJsonOptions} [options] Conversion options
+     * @returns {Message<{}>} Message instance
+     */
+    Type.prototype.fromJsonString = function fromJsonString(json, options) {
+        return protojson.fromJsonString(this, json, options);
+    };
+
+    /**
+     * Formats a message of this type as ProtoJSON. Convenience for {@link protojson.toJson}.
+     * @param {Message<{}>|Object.<string,*>} message Message instance or plain object
+     * @param {IProtoJsonOptions} [options] Conversion options
+     * @returns {*} ProtoJSON value
+     */
+    Type.prototype.toJson = function toJson(message, options) {
+        return protojson.toJson(this, message, options);
+    };
+
+    /**
+     * Formats a message of this type as ProtoJSON text. Convenience for {@link protojson.toJsonString}.
+     * @param {Message<{}>|Object.<string,*>} message Message instance or plain object
+     * @param {IProtoJsonOptions} [options] Conversion options
+     * @returns {string} ProtoJSON text
+     */
+    Type.prototype.toJsonString = function toJsonString(message, options) {
+        return protojson.toJsonString(this, message, options);
+    };
+};

--- a/ext/textformat.d.ts
+++ b/ext/textformat.d.ts
@@ -10,10 +10,10 @@ declare module ".." {
     }
 
     interface Type {
-        /** Parses this type from protobuf text format. */
+        /** Installed by `textformat.install()`. Parses this type from protobuf text format. */
         fromText(text: string): $protobuf.Message<{}>;
 
-        /** Formats a message of this type as protobuf text format. */
+        /** Installed by `textformat.install()`. Formats a message of this type as protobuf text format. */
         toText(message: ($protobuf.Message<{}>|{ [k: string]: any }), options?: ITextFormatOptions): string;
     }
 }

--- a/ext/textformat.generated.d.ts
+++ b/ext/textformat.generated.d.ts
@@ -1,5 +1,7 @@
 // DO NOT EDIT! This is a generated file. Edit the source file instead and regenerate.
 
+import * as $protobuf from "..";
+
 /** Maximum recursion depth for formatting length-delimited unknown fields. */
 export let unknownRecursionLimit: number;
 
@@ -9,3 +11,23 @@ export interface ITextFormatOptions {
     /** Also includes and formats unknown fields. */
     unknowns?: boolean;
 }
+
+/**
+ * Parses a message from protobuf text format using the specified reflected type.
+ * @param type Reflected message type
+ * @param text Text format input
+ * @returns Message instance
+ */
+export function fromText(type: $protobuf.Type, text: string): $protobuf.Message<{}>;
+
+/**
+ * Formats a message as protobuf text format using the specified reflected type.
+ * @param type Reflected message type
+ * @param message Message instance or plain object
+ * @param [options] Text format options
+ * @returns Text format output
+ */
+export function toText(type: $protobuf.Type, message: ($protobuf.Message<{}>|{ [k: string]: any }), options?: ITextFormatOptions): string;
+
+/** Installs reflected {@link Type} convenience methods. */
+export function install(): void;

--- a/ext/textformat.js
+++ b/ext/textformat.js
@@ -69,39 +69,60 @@ function parseText(type, text) {
  */
 
 /**
+ * Parses a message from protobuf text format using the specified reflected type.
+ * @function fromText
+ * @name fromText
+ * @param {$protobuf.Type} type Reflected message type
+ * @param {string} text Text format input
+ * @returns {$protobuf.Message<{}>} Message instance
+ */
+textformat.fromText = function fromText(type, text) {
+    return parseText(type, text);
+};
+
+/**
  * Formats a message as protobuf text format using the specified reflected type.
- * @param {Type} type Reflected message type
- * @param {Message<{}>|Object.<string,*>} message Message instance or plain object
+ * @function toText
+ * @name toText
+ * @param {$protobuf.Type} type Reflected message type
+ * @param {$protobuf.Message<{}>|Object.<string,*>} message Message instance or plain object
  * @param {ITextFormatOptions} [options] Text format options
  * @returns {string} Text format output
- * @private
  */
-function formatText(type, message, options) {
+textformat.toText = function toText(type, message, options) {
     if (!(type instanceof Type))
         throw TypeError("type must be a Type");
     type.root.resolveAll();
     var lines = [];
     writeMessage(type, message, lines, 0, options || {}, 0);
     return lines.join("\n");
-}
-
-/**
- * Parses this type from protobuf text format.
- * @param {string} text Text format input
- * @returns {Message<{}>} Message instance
- */
-Type.prototype.fromText = function fromText(text) {
-    return parseText(this, text);
 };
 
 /**
- * Formats a message of this type as protobuf text format.
- * @param {Message<{}>|Object.<string,*>} message Message instance or plain object
- * @param {ITextFormatOptions} [options] Text format options
- * @returns {string} Text format output
+ * Installs reflected {@link Type} convenience methods.
+ * @function install
+ * @name install
+ * @returns {undefined}
  */
-Type.prototype.toText = function toText(message, options) {
-    return formatText(this, message, options);
+textformat.install = function install() {
+    /**
+     * Parses a message of this type from protobuf text format. Convenience for {@link textformat.fromText}.
+     * @param {string} text Text format input
+     * @returns {Message<{}>} Message instance
+     */
+    Type.prototype.fromText = function fromText(text) {
+        return textformat.fromText(this, text);
+    };
+
+    /**
+     * Formats a message of this type as protobuf text format. Convenience for {@link textformat.toText}.
+     * @param {Message<{}>|Object.<string,*>} message Message instance or plain object
+     * @param {ITextFormatOptions} [options] Text format options
+     * @returns {string} Text format output
+     */
+    Type.prototype.toText = function toText(message, options) {
+        return textformat.toText(this, message, options);
+    };
 };
 
 function Tokenizer(source) {

--- a/index.d.ts
+++ b/index.d.ts
@@ -314,6 +314,18 @@ export class Field extends FieldBase {
     readonly hasPresence: boolean;
 
     /**
+     * The field name as declared in the .proto source (snake_case). Populated on resolve,
+     * falling back to `name`. Mirrors `FieldDescriptorProto.name`.
+     */
+    readonly protoName: string;
+
+    /**
+     * The JSON name of this field (lowerCamelCase per protoc's `ToJsonName`, or an
+     * explicit `[json_name]`). Populated on resolve. This is the key used on ProtoJSON output.
+     */
+    readonly jsonName: string;
+
+    /**
      * Field decorator (TypeScript).
      * @param fieldId Field id
      * @param fieldType Field type
@@ -387,6 +399,12 @@ export class FieldBase extends ReflectionObject {
 
     /** Comment for this field. */
     comment: (string|null);
+
+    /** Field name as declared in the .proto source, if different from `name`. */
+    protoName?: string;
+
+    /** JSON name, if different from the derived default. */
+    jsonName?: string;
 
     /**
      * Converts this field to a field descriptor.
@@ -2675,8 +2693,16 @@ export namespace util {
      * Converts a string to camel case.
      * @param str String to convert
      * @returns Converted string
+     * @deprecated Use {@link util.jsonName} for protobuf field JSON names.
      */
     function camelCase(str: string): string;
+
+    /**
+     * Converts a proto field name to its protoc-compatible JSON name.
+     * @param str Proto field name
+     * @returns JSON name
+     */
+    function jsonName(str: string): string;
 
     /**
      * Compares reflected fields by id.

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "build": "npm run build:bundle && npm run build:types",
     "build:bundle": "gulp --gulpfile scripts/gulpfile.js",
     "build:tests": "node ./scripts/gentests.js",
-    "build:types": "node cli/bin/pbts --main --global protobuf --out index.d.ts src/ && node cli/bin/pbts --main --import \"\\$protobuf=..\" --out ext/descriptor.generated.d.ts ext/descriptor.js && node cli/bin/pbts --main --out ext/textformat.generated.d.ts ext/textformat.js",
+    "build:types": "node cli/bin/pbts --main --global protobuf --out index.d.ts src/ && node cli/bin/pbts --main --import \"\\$protobuf=..\" --out ext/descriptor.generated.d.ts ext/descriptor.js && node cli/bin/pbts --main --import \"\\$protobuf=..\" --out ext/textformat.generated.d.ts ext/textformat.js && node cli/bin/pbts --main --import \"\\$protobuf=..\" --out ext/protojson.generated.d.ts ext/protojson.js",
     "coverage": "npm run coverage:test && npm run coverage:report",
     "coverage:test": "nyc --silent tape -r ./lib/tape-adapter tests/*.js tests/node/*.js",
     "coverage:report": "nyc report --reporter=lcov --reporter=text",

--- a/src/field.js
+++ b/src/field.js
@@ -38,6 +38,12 @@ Field.fromJSON = function fromJSON(name, json) {
     var field = new Field(name, json.id, json.type, json.rule, json.extend, json.options, json.comment);
     if (json.edition)
         field._edition = json.edition;
+    if (json.protoName)
+        field.protoName = json.protoName;
+    if (json.jsonName !== undefined)
+        field.jsonName = json.jsonName;
+    else if (json.options && json.options.json_name !== undefined)
+        field.jsonName = json.options.json_name;
     field._defaultEdition = "proto3";  // For backwards-compatibility.
     return field;
 };
@@ -177,6 +183,18 @@ function Field(name, id, type, rule, extend, options, comment) {
      * @type {string|null}
      */
     this.comment = comment;
+
+    /**
+     * Field name as declared in the .proto source, if different from `name`.
+     * @type {string|undefined}
+     */
+    this.protoName = undefined;
+
+    /**
+     * JSON name, if different from the derived default.
+     * @type {string|undefined}
+     */
+    this.jsonName = undefined;
 }
 
 /**
@@ -247,6 +265,22 @@ Object.defineProperty(Field.prototype, "hasPresence", {
 });
 
 /**
+ * The field name as declared in the .proto source (snake_case). Populated on resolve,
+ * falling back to `name`. Mirrors `FieldDescriptorProto.name`.
+ * @name Field#protoName
+ * @type {string}
+ * @readonly
+ */
+
+/**
+ * The JSON name of this field (lowerCamelCase per protoc's `ToJsonName`, or an
+ * explicit `[json_name]`). Populated on resolve. This is the key used on ProtoJSON output.
+ * @name Field#jsonName
+ * @type {string}
+ * @readonly
+ */
+
+/**
  * @override
  */
 Field.prototype.setOption = function setOption(name, value, ifNotSet) {
@@ -279,13 +313,15 @@ Field.prototype.setOption = function setOption(name, value, ifNotSet) {
 Field.prototype.toJSON = function toJSON(toJSONOptions) {
     var keepComments = toJSONOptions ? Boolean(toJSONOptions.keepComments) : false;
     return util.toObject([
-        "edition" , this._editionToJSON(),
-        "rule"    , this.rule !== "optional" && this.rule || undefined,
-        "type"    , this.type,
-        "id"      , this.id,
-        "extend"  , this.extend,
-        "options" , this.options,
-        "comment" , keepComments ? this.comment : undefined
+        "edition"      , this._editionToJSON(),
+        "rule"         , this.rule !== "optional" && this.rule || undefined,
+        "type"         , this.type,
+        "id"           , this.id,
+        "extend"       , this.extend,
+        "protoName"    , this.protoName !== this.name ? this.protoName : undefined,
+        "jsonName"     , this.jsonName !== util.jsonName(this.protoName || this.name) ? this.jsonName : undefined,
+        "options"      , this.options,
+        "comment"      , keepComments ? this.comment : undefined
     ]);
 };
 
@@ -353,6 +389,12 @@ Field.prototype.resolve = function resolve() {
     // ensure proper value on prototype
     if (this.parent instanceof Type && this.parent._ctor)
         this.parent._ctor.prototype[this.name] = this.defaultValue;
+
+    // derive the proto/JSON names
+    if (this.protoName === undefined)
+        this.protoName = this.name;
+    if (this.jsonName === undefined)
+        this.jsonName = util.jsonName(this.protoName);
 
     return ReflectionObject.prototype.resolve.call(this);
 };

--- a/src/mapfield.js
+++ b/src/mapfield.js
@@ -65,7 +65,14 @@ function MapField(name, id, keyType, type, options, comment) {
  * @throws {TypeError} If arguments are invalid
  */
 MapField.fromJSON = function fromJSON(name, json) {
-    return new MapField(name, json.id, json.keyType, json.type, json.options, json.comment);
+    var field = new MapField(name, json.id, json.keyType, json.type, json.options, json.comment);
+    if (json.protoName)
+        field.protoName = json.protoName;
+    if (json.jsonName !== undefined)
+        field.jsonName = json.jsonName;
+    else if (json.options && json.options.json_name !== undefined)
+        field.jsonName = json.options.json_name;
+    return field;
 };
 
 /**
@@ -76,12 +83,14 @@ MapField.fromJSON = function fromJSON(name, json) {
 MapField.prototype.toJSON = function toJSON(toJSONOptions) {
     var keepComments = toJSONOptions ? Boolean(toJSONOptions.keepComments) : false;
     return util.toObject([
-        "keyType" , this.keyType,
-        "type"    , this.type,
-        "id"      , this.id,
-        "extend"  , this.extend,
-        "options" , this.options,
-        "comment" , keepComments ? this.comment : undefined
+        "keyType"      , this.keyType,
+        "type"         , this.type,
+        "id"           , this.id,
+        "extend"       , this.extend,
+        "protoName"    , this.protoName !== this.name ? this.protoName : undefined,
+        "jsonName"     , this.jsonName !== util.jsonName(this.protoName || this.name) ? this.jsonName : undefined,
+        "options"      , this.options,
+        "comment"      , keepComments ? this.comment : undefined
     ]);
 };
 

--- a/src/parse.js
+++ b/src/parse.js
@@ -482,10 +482,13 @@ function parse(source, root, options) {
         if (!nameRe.test(name))
             throw illegal(name, "name");
 
+        var protoName = name;
         name = applyCase(name);
         skip("=");
 
         var field = new Field(name, parseId(next()), type, rule === "proto3_optional" ? "optional" : rule, extend);
+        if (protoName !== name)
+            field.protoName = protoName;
 
         ifBlock(field, function parseField_block(token) {
 
@@ -627,7 +630,11 @@ function parse(source, root, options) {
             throw illegal(name, "name");
 
         skip("=");
-        var field = new MapField(applyCase(name), parseId(next()), keyType, valueType);
+        var protoName = name;
+        name = applyCase(name);
+        var field = new MapField(name, parseId(next()), keyType, valueType);
+        if (protoName !== name)
+            field.protoName = protoName;
         ifBlock(field, function parseMapField_block(token) {
 
             /* istanbul ignore else */
@@ -839,11 +846,18 @@ function parse(source, root, options) {
             topLevelOptions[name] = value;
             return;
         }
+        // lift json_name onto Field
+        if (name === "json_name" && parent instanceof Field) {
+            parent.jsonName = value;
+            return;
+        }
         if (parent.setOption)
             parent.setOption(name, value);
     }
 
     function setParsedOption(parent, name, value, propName) {
+        if (name === "json_name" && parent instanceof Field)
+            return; // lifted onto Field#jsonName above
         if (parent.setParsedOption)
             parent.setParsedOption(name, value, propName);
     }

--- a/src/type.js
+++ b/src/type.js
@@ -89,6 +89,13 @@ function Type(name, options) {
      * @private
      */
     this._ctor = null;
+
+    /**
+     * Cached fields by JSON name.
+     * @type {Object.<string,Field>|null}
+     * @private
+     */
+    this._fieldsByJsonName = null; // used by ext/protojson
 }
 
 Object.defineProperties(Type.prototype, {
@@ -215,7 +222,7 @@ Type.generateConstructor = function generateConstructor(mtype) {
 };
 
 function clearCache(type) {
-    type._fieldsById = type._fieldsArray = type._oneofsArray = null;
+    type._fieldsById = type._fieldsArray = type._oneofsArray = type._fieldsByJsonName = null;
     delete type.encode;
     delete type.decode;
     delete type.verify;

--- a/src/util.js
+++ b/src/util.js
@@ -93,11 +93,34 @@ var camelCaseRe = /_([a-z])/g;
  * Converts a string to camel case.
  * @param {string} str String to convert
  * @returns {string} Converted string
+ * @deprecated Use {@link util.jsonName} for protobuf field JSON names.
  */
 util.camelCase = function camelCase(str) {
     return str.substring(0, 1)
          + str.substring(1)
                .replace(camelCaseRe, function($0, $1) { return $1.toUpperCase(); });
+};
+
+/**
+ * Converts a proto field name to its protoc-compatible JSON name.
+ * @param {string} str Proto field name
+ * @returns {string} JSON name
+ */
+util.jsonName = function jsonName(str) {
+    var result = "",
+        upperNext = false,
+        i = 0;
+    for (; i < str.length; ++i) {
+        var ch = str.charAt(i);
+        if (ch === "_")
+            upperNext = true;
+        else if (upperNext) {
+            result += ch.toUpperCase();
+            upperNext = false;
+        } else
+            result += ch;
+    }
+    return result;
 };
 
 /**

--- a/tests/api_protojson.js
+++ b/tests/api_protojson.js
@@ -1,0 +1,535 @@
+var tape = require("tape");
+
+var protobuf = require("..");
+var protojson = require("../ext/protojson");
+
+function owns(obj, key) {
+    return Object.prototype.hasOwnProperty.call(obj, key);
+}
+
+var proto = "syntax = \"proto3\";\
+message Msg { int32 value = 1; }\
+enum Choice { A = 0; B = 1; }\
+message Inner { int32 value = 1; }\
+message Outer {\
+  Inner inner = 1;\
+  Choice choice = 2;\
+  repeated Choice choices = 3;\
+  map<string, Choice> choice_map = 4;\
+}\
+message MapMsg {\
+  map<int32, string> int32_map = 1;\
+  map<uint64, string> uint64_map = 2;\
+  map<bool, string> bool_map = 3;\
+  map<string, string> string_map = 4;\
+}";
+
+var root = protobuf.parse(proto).root,
+    Msg = root.lookupType("Msg"),
+    Outer = root.lookupType("Outer"),
+    MapMsg = root.lookupType("MapMsg"),
+    timestampRoot = protobuf.Root.fromJSON({
+        nested: {
+            google: {
+                nested: {
+                    protobuf: {
+                        nested: {
+                            Timestamp: {
+                                fields: {
+                                    seconds: { type: "int64", id: 1 },
+                                    nanos: { type: "int32", id: 2 }
+                                }
+                            },
+                            Duration: {
+                                fields: {
+                                    seconds: { type: "int64", id: 1 },
+                                    nanos: { type: "int32", id: 2 }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            WithTimestamp: {
+                fields: {
+                    ts: { type: "google.protobuf.Timestamp", id: 1 }
+                }
+            },
+            WithDuration: {
+                fields: {
+                    duration: { type: "google.protobuf.Duration", id: 1 }
+                }
+            }
+        }
+    }),
+    WithTimestamp = timestampRoot.lookupType("WithTimestamp"),
+    WithDuration = timestampRoot.lookupType("WithDuration");
+
+function createWktRoot() {
+    var root = new protobuf.Root();
+    protobuf.parse("syntax = \"proto3\";\
+package google.protobuf;\
+message Any { string type_url = 1; bytes value = 2; }\
+message Empty {}\
+message Duration { int64 seconds = 1; int32 nanos = 2; }\
+message Timestamp { int64 seconds = 1; int32 nanos = 2; }\
+message FieldMask { repeated string paths = 1; }\
+message StringValue { string value = 1; }\
+message Int64Value { int64 value = 1; }\
+message BytesValue { bytes value = 1; }\
+enum NullValue { NULL_VALUE = 0; }\
+message Struct { map<string, Value> fields = 1; }\
+message ListValue { repeated Value values = 1; }\
+message Value {\
+  oneof kind {\
+    NullValue null_value = 1;\
+    double number_value = 2;\
+    string string_value = 3;\
+    bool bool_value = 4;\
+    Struct struct_value = 5;\
+    ListValue list_value = 6;\
+  }\
+}", root);
+    protobuf.parse("syntax = \"proto3\";\
+package test;\
+message Payload { string name = 1; int32 count = 2; }\
+message WktMsg {\
+  google.protobuf.Any any = 1;\
+  google.protobuf.Any duration_any = 2;\
+  google.protobuf.Value value = 3;\
+  google.protobuf.Struct struct = 4;\
+  google.protobuf.ListValue list = 5;\
+  google.protobuf.StringValue string_wrapper = 6;\
+  google.protobuf.Int64Value int64_wrapper = 7;\
+  google.protobuf.BytesValue bytes_wrapper = 8;\
+  google.protobuf.FieldMask field_mask = 9;\
+  google.protobuf.Empty empty = 10;\
+  google.protobuf.Duration duration = 11;\
+  google.protobuf.Timestamp timestamp = 12;\
+  bytes bytes_field = 13;\
+}\
+message NullMsg {\
+  int32 value = 1;\
+  repeated string names = 2;\
+  map<string, string> labels = 3;\
+  google.protobuf.Duration duration = 4;\
+  google.protobuf.StringValue string_wrapper = 5;\
+  google.protobuf.Value value_msg = 6;\
+}", root);
+    return root.resolveAll();
+}
+
+var wktRoot = createWktRoot(),
+    wktRoots = [
+        { name: "parsed proto", root: wktRoot },
+        { name: "JSON descriptor", root: protobuf.Root.fromJSON(wktRoot.toJSON()).resolveAll() }
+    ];
+
+tape.test("protojson - installs reflected Type convenience methods", function(test) {
+    delete protobuf.Type.prototype.fromJson;
+    delete protobuf.Type.prototype.fromJsonString;
+    delete protobuf.Type.prototype.toJson;
+    delete protobuf.Type.prototype.toJsonString;
+
+    protojson.install();
+    test.equal(typeof protobuf.Type.prototype.fromJson, "function", "installs fromJson");
+    test.equal(typeof protobuf.Type.prototype.fromJsonString, "function", "installs fromJsonString");
+    test.equal(typeof protobuf.Type.prototype.toJson, "function", "installs toJson");
+    test.equal(typeof protobuf.Type.prototype.toJsonString, "function", "installs toJsonString");
+    test.end();
+});
+
+tape.test("protojson - rejects duplicate keys in string input", function(test) {
+    test.throws(function() {
+        protojson.fromJsonString(Msg, "{\"value\":1,\"value\":2}");
+    }, /duplicate key/, "rejects duplicate keys through fromJsonString");
+
+    test.throws(function() {
+        protojson.fromJsonString(Msg, "{\"value\":1,\"\\u0076alue\":2}");
+    }, /duplicate key/, "rejects duplicate escaped keys through fromJsonString");
+
+    test.throws(function() {
+        Msg.fromJsonString("{\"value\":1,\"value\":2}");
+    }, /duplicate key/, "rejects duplicate keys through Type#fromJsonString");
+
+    test.end();
+});
+
+tape.test("protojson - accepts already-parsed input", function(test) {
+    var message = protojson.fromJson(Msg, { value: 1 });
+    test.equal(message.value, 1, "parses object input");
+    test.end();
+});
+
+tape.test("protojson - rejects JSON name collisions", function(test) {
+    var Collision = protobuf.Root.fromJSON({
+        nested: {
+            Collision: {
+                fields: {
+                    first: { type: "int32", id: 1, jsonName: "same" },
+                    second: { type: "int32", id: 2, jsonName: "same" }
+                }
+            }
+        }
+    }).resolveAll().lookupType("Collision");
+
+    test.throws(function() {
+        protojson.fromJson(Collision, { same: 1 });
+    }, /duplicate ProtoJSON field name "same"/, "rejects ambiguous JSON name lookup");
+
+    test.end();
+});
+
+tape.test("protojson - reads legacy json_name reflection options", function(test) {
+    var Legacy = protobuf.Root.fromJSON({
+        nested: {
+            Legacy: {
+                fields: {
+                    value: {
+                        type: "int32",
+                        id: 1,
+                        options: { json_name: "customValue" }
+                    },
+                    labels: {
+                        keyType: "string",
+                        type: "string",
+                        id: 2,
+                        options: { json_name: "customLabels" }
+                    }
+                }
+            }
+        }
+    }).resolveAll().lookupType("Legacy");
+
+    var message = protojson.fromJson(Legacy, {
+        customValue: 1,
+        customLabels: { key: "value" }
+    });
+
+    test.equal(message.value, 1, "uses json_name option for ordinary fields");
+    test.equal(message.labels.key, "value", "uses json_name option for map fields");
+    test.deepEqual(protojson.toJson(Legacy, message), {
+        customValue: 1,
+        customLabels: { key: "value" }
+    }, "emits lifted json_name values");
+    test.end();
+});
+
+tape.test("protojson - separates parsed values from document strings", function(test) {
+    var message = protojson.fromJsonString(Msg, "{\"value\":1}");
+    test.equal(message.value, 1, "parses JSON document strings explicitly");
+    test.equal(protojson.toJsonString(Msg, message), "{\"value\":1}", "formats JSON document strings explicitly");
+
+    test.throws(function() {
+        protojson.fromJson(Msg, "{\"value\":1}");
+    }, /expected object/, "fromJson treats strings as already-parsed JSON string values");
+
+    for (var i = 0; i < wktRoots.length; ++i) {
+        var root = wktRoots[i].root,
+            label = wktRoots[i].name,
+            Timestamp = root.lookupType("google.protobuf.Timestamp"),
+            StringValue = root.lookupType("google.protobuf.StringValue"),
+            Value = root.lookupType("google.protobuf.Value"),
+            timestamp = protojson.fromJson(Timestamp, "1970-01-01T00:00:00Z"),
+            timestampString = protojson.fromJsonString(Timestamp, "\"1970-01-01T00:00:00Z\""),
+            stringValue = protojson.fromJson(StringValue, "{}"),
+            value = protojson.fromJson(Value, "{}");
+
+        test.equal(String(timestamp.seconds), "0", label + ": parses already-parsed Timestamp string values");
+        test.equal(String(timestampString.seconds), "0", label + ": parses Timestamp document strings");
+        test.equal(stringValue.value, "{}", label + ": parses already-parsed StringValue string values");
+        test.equal(protojson.toJson(StringValue, stringValue), "{}", label + ": emits parsed StringValue string values");
+        test.equal(protojson.toJsonString(StringValue, stringValue), "\"{}\"", label + ": emits StringValue document strings");
+        test.equal(value.stringValue, "{}", label + ": parses already-parsed Value string values");
+    }
+
+    test.end();
+});
+
+tape.test("protojson - passes ignoreUnknownFields through options", function(test) {
+    test.throws(function() {
+        protojson.fromJson(Outer, { inner: { value: 1, extra: 2 } });
+    }, /unknown field/, "rejects nested unknown fields by default");
+
+    var message = protojson.fromJson(Outer, {
+        inner: { value: 1, extra: 2 },
+        choice: "NOPE",
+        choices: ["A", "NOPE", "B"],
+        choiceMap: { keep: "B", drop: "NOPE" }
+    }, { ignoreUnknownFields: true });
+
+    test.equal(message.inner.value, 1, "ignores nested unknown fields");
+    test.equal(Object.prototype.hasOwnProperty.call(message, "choice"), false, "ignores unknown singular enum strings");
+    test.deepEqual(message.choices, [0, 1], "drops unknown repeated enum strings");
+    test.deepEqual(message.choiceMap, { keep: 1 }, "drops map entries with unknown enum strings");
+
+    test.throws(function() {
+        protojson.fromJson(Outer, { nope: 1 });
+    }, /unknown field/, "does not leak ignoreUnknownFields to later calls");
+
+    test.end();
+});
+
+tape.test("protojson - validates and canonicalizes map keys", function(test) {
+    var message = protojson.fromJson(MapMsg, {
+        int32Map: { "-0": "zero", "01": "one" },
+        uint64Map: { "18446744073709551615": "max" },
+        boolMap: { "true": "yes", "false": "no" },
+        stringMap: { "name": "value" }
+    });
+
+    test.equal(message.int32Map["0"], "zero", "canonicalizes signed zero map key");
+    test.equal(message.int32Map["1"], "one", "canonicalizes integer map key");
+    test.equal(message.uint64Map["18446744073709551615"], "max", "accepts max uint64 map key");
+    test.equal(message.boolMap["true"], "yes", "accepts true bool map key");
+    test.equal(message.boolMap["false"], "no", "accepts false bool map key");
+
+    test.throws(function() {
+        protojson.fromJson(MapMsg, { int32Map: { "1.2": "bad" } });
+    }, /invalid int32 map key/, "rejects non-integer map key");
+
+    test.throws(function() {
+        protojson.fromJson(MapMsg, { int32Map: { "2147483648": "bad" } });
+    }, /out of range for int32 map key/, "rejects out-of-range int32 map key");
+
+    test.throws(function() {
+        protojson.fromJson(MapMsg, { uint64Map: { "-1": "bad" } });
+    }, /invalid uint64 map key/, "rejects negative uint64 map key");
+
+    test.throws(function() {
+        protojson.fromJson(MapMsg, { uint64Map: { "18446744073709551616": "bad" } });
+    }, /out of range for uint64 map key/, "rejects out-of-range uint64 map key");
+
+    test.throws(function() {
+        protojson.fromJson(MapMsg, { boolMap: { "1": "bad" } });
+    }, /invalid bool map key/, "rejects numeric bool map key");
+
+    test.throws(function() {
+        protojson.fromJson(MapMsg, { stringMap: { "\ud800": "bad" } });
+    }, /unpaired high surrogate/, "rejects invalid UTF-16 string map key");
+
+    test.throws(function() {
+        protojson.fromJson(MapMsg, { int32Map: { "01": "one", "1": "other" } });
+    }, /duplicate map key/, "rejects map keys that canonicalize to the same value");
+
+    test.end();
+});
+
+tape.test("protojson - preserves reserved object keys as data", function(test) {
+    var mapMessage = protojson.fromJson(MapMsg, {
+        stringMap: JSON.parse("{\"__proto__\":\"value\"}")
+    });
+    var mapOut = protojson.toJson(MapMsg, mapMessage).stringMap;
+    test.equal(owns(mapOut, "__proto__"), true, "emits __proto__ as an own map key");
+    test.equal(mapOut.__proto__, "value", "keeps map key value");
+    test.equal(Object.getPrototypeOf(mapOut), Object.prototype, "does not mutate map output prototype");
+
+    for (var i = 0; i < wktRoots.length; ++i) {
+        var Struct = wktRoots[i].root.lookupType("google.protobuf.Struct"),
+            label = wktRoots[i].name,
+            structMessage = protojson.fromJson(Struct, JSON.parse("{\"__proto__\":{\"polluted\":true}}")),
+            structOut = protojson.toJson(Struct, structMessage);
+
+        test.equal(owns(structOut, "__proto__"), true, label + ": emits __proto__ as an own Struct key");
+        test.deepEqual(structOut.__proto__, { polluted: true }, label + ": keeps Struct key value");
+        test.equal(Object.getPrototypeOf(structOut), Object.prototype, label + ": does not mutate Struct output prototype");
+    }
+
+    test.end();
+});
+
+tape.test("protojson - round trips well-known types", function(test) {
+    var json = {
+        any: {
+            "@type": "type.googleapis.com/test.Payload",
+            name: "alpha",
+            count: 7
+        },
+        durationAny: {
+            "@type": "type.googleapis.com/google.protobuf.Duration",
+            value: "2s"
+        },
+        value: {
+            nested: ["x", null, true],
+            count: 1.5
+        },
+        struct: {
+            ok: true,
+            name: "struct"
+        },
+        list: ["x", null, { child: false }],
+        stringWrapper: "wrapped",
+        int64Wrapper: "9007199254740993",
+        bytesWrapper: "AQI=",
+        fieldMask: "fooBar,baz.qux",
+        empty: {},
+        duration: "1.500s",
+        timestamp: "1970-01-01T00:00:00.000000001Z",
+        bytesField: "-_8"
+    };
+    var expected = {
+        any: json.any,
+        durationAny: json.durationAny,
+        value: json.value,
+        struct: json.struct,
+        list: json.list,
+        stringWrapper: json.stringWrapper,
+        int64Wrapper: json.int64Wrapper,
+        bytesWrapper: json.bytesWrapper,
+        fieldMask: json.fieldMask,
+        empty: json.empty,
+        duration: json.duration,
+        timestamp: json.timestamp,
+        bytesField: "+/8="
+    };
+
+    for (var i = 0; i < wktRoots.length; ++i) {
+        var root = wktRoots[i].root,
+            label = wktRoots[i].name,
+            WktMsg = root.lookupType("test.WktMsg"),
+            Payload = root.lookupType("test.Payload"),
+            Duration = root.lookupType("google.protobuf.Duration"),
+            message = protojson.fromJson(WktMsg, json),
+            payload = Payload.decode(message.any.value),
+            duration = Duration.decode(message.durationAny.value);
+
+        test.equal(payload.name, "alpha", label + ": decodes regular Any payload");
+        test.equal(payload.count, 7, label + ": decodes regular Any payload fields");
+        test.equal(String(duration.seconds), "2", label + ": decodes WKT Any payload");
+        test.equal(message.timestamp.nanos, 1, label + ": parses timestamp nanos");
+        test.deepEqual(protojson.toJson(WktMsg, message), expected, label + ": emits canonical ProtoJSON");
+    }
+
+    test.end();
+});
+
+tape.test("protojson - accepts null fields as absent", function(test) {
+    var message = protojson.fromJson(Msg, { value: null });
+    test.equal(owns(message, "value"), false, "singular scalar null is absent");
+
+    message = protojson.fromJson(Outer, {
+        inner: null,
+        choice: null,
+        choices: null,
+        choiceMap: null
+    });
+    test.equal(owns(message, "inner"), false, "singular message null is absent");
+    test.equal(owns(message, "choice"), false, "singular enum null is absent");
+    test.deepEqual(protojson.toJson(Outer, message), {}, "repeated and map field nulls are absent in JSON output");
+
+    for (var i = 0; i < wktRoots.length; ++i) {
+        var NullMsg = wktRoots[i].root.lookupType("test.NullMsg"),
+            label = wktRoots[i].name,
+            nulls = protojson.fromJson(NullMsg, {
+                value: null,
+                names: null,
+                labels: null,
+                duration: null,
+                stringWrapper: null,
+                valueMsg: null
+            });
+        test.equal(owns(nulls, "value"), false, label + ": scalar null is absent");
+        test.equal(owns(nulls, "duration"), false, label + ": WKT message null is absent");
+        test.equal(owns(nulls, "stringWrapper"), false, label + ": wrapper null is absent");
+        test.equal(nulls.valueMsg.nullValue, 0, label + ": google.protobuf.Value null is NULL_VALUE");
+        test.deepEqual(protojson.toJson(NullMsg, nulls), { valueMsg: null }, label + ": null fields emit only google.protobuf.Value");
+    }
+
+    test.end();
+});
+
+tape.test("protojson - rejects null repeated elements and map values", function(test) {
+    test.throws(function() {
+        protojson.fromJson(Outer, { choices: ["A", null] });
+    }, /null element/, "rejects null repeated enum element");
+
+    test.throws(function() {
+        protojson.fromJson(MapMsg, { stringMap: { key: null } });
+    }, /expected string/, "rejects null map value");
+
+    test.end();
+});
+
+tape.test("protojson - rejects invalid UTF-16 in well-known values", function(test) {
+    for (var i = 0; i < wktRoots.length; ++i) {
+        var root = wktRoots[i].root,
+            label = wktRoots[i].name,
+            Value = root.lookupType("google.protobuf.Value"),
+            Struct = root.lookupType("google.protobuf.Struct");
+
+        test.throws(function() {
+            protojson.fromJson(Value, JSON.parse("\"\\ud800\""));
+        }, /unpaired high surrogate/, label + ": rejects invalid google.protobuf.Value string");
+
+        test.throws(function() {
+            protojson.fromJson(Struct, JSON.parse("{\"\\ud800\":1}"));
+        }, /unpaired high surrogate/, label + ": rejects invalid google.protobuf.Struct key");
+    }
+
+    test.end();
+});
+
+tape.test("protojson - parses timestamp string shape strictly", function(test) {
+    var message = protojson.fromJson(WithTimestamp, {
+        ts: "1970-01-01T00:00:00.000000001Z"
+    });
+    test.equal(message.ts.seconds, 0, "parses timestamp seconds");
+    test.equal(message.ts.nanos, 1, "parses timestamp nanos");
+
+    test.throws(function() {
+        protojson.fromJson(WithTimestamp, { ts: "1970-01-01T00:00:00.1234567890Z" });
+    }, /invalid timestamp/, "rejects timestamp fractions beyond nanos precision");
+
+    test.throws(function() {
+        protojson.fromJson(WithTimestamp, { ts: "2020-01-01T24:00:00Z" });
+    }, /invalid timestamp/, "rejects normalized timestamp hours");
+
+    test.throws(function() {
+        protojson.fromJson(WithTimestamp, { ts: "1970-01-01t00:00:00Z" });
+    }, /invalid timestamp/, "rejects lowercase timestamp separator");
+
+    var leapDay = protojson.fromJson(WithTimestamp, { ts: "2020-02-29T00:00:00Z" });
+    test.equal(leapDay.ts.seconds, 1582934400, "accepts valid leap day");
+
+    test.throws(function() {
+        protojson.fromJson(WithTimestamp, { ts: "2019-02-29T00:00:00Z" });
+    }, /invalid timestamp date/, "rejects invalid leap day");
+
+    test.end();
+});
+
+tape.test("protojson - parses duration string shape strictly", function(test) {
+    var message = protojson.fromJson(WithDuration, {
+        duration: "1.5s"
+    });
+    test.equal(message.duration.seconds, 1, "parses duration seconds");
+    test.equal(message.duration.nanos, 500000000, "parses duration nanos");
+
+    var negative = protojson.fromJson(WithDuration, {
+        duration: "-0.5s"
+    });
+    test.equal(negative.duration.seconds, 0, "parses negative zero duration seconds");
+    test.equal(negative.duration.nanos, -500000000, "parses negative duration nanos");
+
+    test.throws(function() {
+        protojson.fromJson(WithDuration, { duration: "s" });
+    }, /invalid duration/, "rejects missing duration seconds");
+
+    test.throws(function() {
+        protojson.fromJson(WithDuration, { duration: ".s" });
+    }, /invalid duration/, "rejects empty duration");
+
+    test.throws(function() {
+        protojson.fromJson(WithDuration, { duration: "1.s" });
+    }, /invalid duration/, "rejects empty duration fraction");
+
+    test.throws(function() {
+        protojson.fromJson(WithDuration, { duration: "1.1234567890s" });
+    }, /invalid duration/, "rejects duration fractions beyond nanos precision");
+
+    test.throws(function() {
+        protojson.fromJson(WithDuration, { duration: "315576000001.000000000s" });
+    }, /duration out of range/, "rejects duration seconds out of range");
+
+    test.end();
+});

--- a/tests/api_protojson.js
+++ b/tests/api_protojson.js
@@ -17,6 +17,11 @@ message Outer {\
   repeated Choice choices = 3;\
   map<string, Choice> choice_map = 4;\
 }\
+message OneofDefault {\
+  oneof kind {\
+    int32 value = 1;\
+  }\
+}\
 message MapMsg {\
   map<int32, string> int32_map = 1;\
   map<uint64, string> uint64_map = 2;\
@@ -27,6 +32,7 @@ message MapMsg {\
 var root = protobuf.parse(proto).root,
     Msg = root.lookupType("Msg"),
     Outer = root.lookupType("Outer"),
+    OneofDefault = root.lookupType("OneofDefault"),
     MapMsg = root.lookupType("MapMsg"),
     timestampRoot = protobuf.Root.fromJSON({
         nested: {
@@ -158,6 +164,12 @@ tape.test("protojson - rejects duplicate keys in string input", function(test) {
 tape.test("protojson - accepts already-parsed input", function(test) {
     var message = protojson.fromJson(Msg, { value: 1 });
     test.equal(message.value, 1, "parses object input");
+    test.end();
+});
+
+tape.test("protojson - omits implicit default values", function(test) {
+    test.deepEqual(protojson.toJson(Msg, Msg.create({ value: 0 })), {}, "omits owned implicit scalar defaults");
+    test.deepEqual(protojson.toJson(OneofDefault, OneofDefault.create({ value: 0 })), { value: 0 }, "emits explicit oneof defaults");
     test.end();
 });
 
@@ -490,6 +502,13 @@ tape.test("protojson - parses timestamp string shape strictly", function(test) {
 
     var leapDay = protojson.fromJson(WithTimestamp, { ts: "2020-02-29T00:00:00Z" });
     test.equal(leapDay.ts.seconds, 1582934400, "accepts valid leap day");
+
+    var offset = protojson.fromJson(WithTimestamp, { ts: "2026-06-03T09:19:00.000-07:00" });
+    test.deepEqual(protojson.toJson(WithTimestamp, offset), { ts: "2026-06-03T16:19:00Z" }, "accepts RFC 3339 timestamp offsets");
+
+    test.throws(function() {
+        protojson.fromJson(WithTimestamp, { ts: "2026-06-03T09:19:00.000-0700" });
+    }, /invalid timestamp/, "rejects timestamp offsets without an RFC 3339 colon");
 
     test.throws(function() {
         protojson.fromJson(WithTimestamp, { ts: "2019-02-29T00:00:00Z" });

--- a/tests/api_textformat.js
+++ b/tests/api_textformat.js
@@ -1,7 +1,7 @@
 var tape = require("tape");
 
 var protobuf = require("..");
-require("../ext/textformat");
+var textformat = require("../ext/textformat");
 
 var proto = "syntax = \"proto3\";\
 message Child { string name = 1; }\
@@ -29,6 +29,16 @@ var root = protobuf.parse(proto).root,
     Msg = root.lookupType("Msg"),
     Child = root.lookupType("Child"),
     Kind = root.lookupEnum("Kind");
+
+tape.test("textformat - installs reflected Type convenience methods", function(test) {
+    delete protobuf.Type.prototype.fromText;
+    delete protobuf.Type.prototype.toText;
+
+    textformat.install();
+    test.equal(typeof protobuf.Type.prototype.fromText, "function", "installs fromText");
+    test.equal(typeof protobuf.Type.prototype.toText, "function", "installs toText");
+    test.end();
+});
 
 tape.test("textformat - parses scalar, repeated, map and nested fields", function(test) {
     var msg = Msg.fromText(

--- a/tests/comp_protojson.ts
+++ b/tests/comp_protojson.ts
@@ -1,0 +1,30 @@
+import * as protobuf from "../index";
+import protojson = require("../ext/protojson");
+
+const root = protobuf.Root.fromJSON({
+    nested: {
+        Message: {
+            fields: {
+                value: {
+                    type: "int32",
+                    id: 1
+                }
+            }
+        }
+    }
+});
+root.resolveAll();
+
+const type = root.lookupType("Message");
+protojson.install();
+const parsed = type.fromJson({ value: 1 });
+const parsedString = type.fromJsonString("{\"value\":1}");
+const json: any = type.toJson(parsed);
+const jsonString: string = type.toJsonString(parsedString);
+const parsedViaModule = protojson.fromJson(type, json, { ignoreUnknownFields: true });
+const parsedStringViaModule = protojson.fromJsonString(type, jsonString);
+const jsonViaModule: any = protojson.toJson(type, parsedViaModule);
+const jsonStringViaModule: string = protojson.toJsonString(type, parsedStringViaModule);
+
+if (!jsonViaModule || jsonStringViaModule.length < 0)
+    throw Error("unreachable");

--- a/tests/comp_textformat.ts
+++ b/tests/comp_textformat.ts
@@ -16,6 +16,7 @@ const root = protobuf.Root.fromJSON({
 root.resolveAll();
 
 const type = root.lookupType("Message");
+textformat.install();
 const message = type.fromText("value: 1");
 const text: string = type.toText(message, { unknowns: true });
 

--- a/tests/conformance/report.js
+++ b/tests/conformance/report.js
@@ -6,6 +6,7 @@ var fs = require("fs"),
 
 var args = process.argv.slice(2),
     jsonFile = null,
+    binaryOnly = false,
     files = [],
     report,
     runnerSummary,
@@ -14,6 +15,8 @@ var args = process.argv.slice(2),
 args.forEach(function(arg, index) {
     if (arg === "--json") {
         jsonFile = args[index + 1];
+    } else if (arg === "--binary-only") {
+        binaryOnly = true;
     } else if (index === 0 || args[index - 1] !== "--json") {
         files.push(arg);
     }
@@ -42,18 +45,18 @@ if (!runnerSummary) {
 }
 
 totals = report.totals;
-if (printTable("Wire format by syntax", "Syntax", [
-    binarySyntax("proto2"),
-    binarySyntax("proto3"),
-    binarySyntax("editions")
-].filter(Boolean)))
-    console.log("");
-printTable("By harness category", "Category", [
-    suite("Binary", "binary"),
-    suite("ProtoJSON", "json"),
-    suite("TextFormat", "textFormat"),
-    ["Overall", formatResult(totals.overall), formatResult(totals.byRequirement.required), formatResult(totals.byRequirement.recommended)]
-].filter(Boolean));
+printTable(null, "Category", conformanceRows());
+
+function conformanceRows() {
+    var rows = [suite("Binary", "binary")].concat(binarySyntaxRows());
+    if (!binaryOnly)
+        rows = rows.concat([
+            suite("ProtoJSON", "json"),
+            suite("TextFormat", "textFormat"),
+            ["Overall", formatResult(totals.overall), formatResult(totals.byRequirement.required), formatResult(totals.byRequirement.recommended)]
+        ]);
+    return rows.filter(Boolean);
+}
 
 function binarySyntax(syntax) {
     var byRequirement = totals.byBinarySyntaxRequirement && totals.byBinarySyntaxRequirement[syntax],
@@ -66,6 +69,18 @@ function binarySyntax(syntax) {
         formatResult(byRequirement && byRequirement.required),
         formatResult(byRequirement && byRequirement.recommended)
     ];
+}
+
+function binarySyntaxRows() {
+    var rows = [
+        binarySyntax("proto2"),
+        binarySyntax("proto3"),
+        binarySyntax("editions")
+    ].filter(Boolean);
+    rows.forEach(function(row) {
+        row[0] = "\u21b3 " + row[0];
+    });
+    return rows;
 }
 
 function suite(label, format) {
@@ -97,8 +112,10 @@ function printTable(title, firstColumn, rows) {
     if (!rows.length)
         return false;
 
-    console.log(title + ":");
-    console.log("");
+    if (title) {
+        console.log(title + ":");
+        console.log("");
+    }
     console.log("| " + padRight(firstColumn, suiteWidth) + " | " + padLeft("Total", totalWidth) + " | " + padLeft("Required", requiredWidth) + " | " + padLeft("Recommended", recommendedWidth) + " |");
     console.log("| " + repeat("-", suiteWidth) + " | " + repeat("-", totalWidth - 1) + ": | " + repeat("-", requiredWidth - 1) + ": | " + repeat("-", recommendedWidth - 1) + ": |");
     rows.forEach(function(row) {

--- a/tests/conformance/report.js
+++ b/tests/conformance/report.js
@@ -23,7 +23,7 @@ args.forEach(function(arg, index) {
 });
 
 if (!files[0]) {
-    console.error("usage: node tests/conformance/report.js <conformance-log> [test-list-log] [--json <summary-json>]");
+    console.error("usage: node tests/conformance/report.js <conformance-log> [test-list-log] [--binary-only] [--json <summary-json>]");
     process.exit(1);
 }
 
@@ -45,7 +45,7 @@ if (!runnerSummary) {
 }
 
 totals = report.totals;
-printTable(null, "Category", conformanceRows());
+printTable("Category", conformanceRows());
 
 function conformanceRows() {
     var rows = [suite("Binary", "binary")].concat(binarySyntaxRows());
@@ -95,7 +95,7 @@ function suite(label, format) {
     ];
 }
 
-function printTable(title, firstColumn, rows) {
+function printTable(firstColumn, rows) {
     var suiteWidth = maxWidth([firstColumn].concat(rows.map(function(row) {
             return row[0];
         }))),
@@ -112,10 +112,6 @@ function printTable(title, firstColumn, rows) {
     if (!rows.length)
         return false;
 
-    if (title) {
-        console.log(title + ":");
-        console.log("");
-    }
     console.log("| " + padRight(firstColumn, suiteWidth) + " | " + padLeft("Total", totalWidth) + " | " + padLeft("Required", requiredWidth) + " | " + padLeft("Recommended", recommendedWidth) + " |");
     console.log("| " + repeat("-", suiteWidth) + " | " + repeat("-", totalWidth - 1) + ": | " + repeat("-", requiredWidth - 1) + ": | " + repeat("-", recommendedWidth - 1) + ": |");
     rows.forEach(function(row) {

--- a/tests/conformance/summary.js
+++ b/tests/conformance/summary.js
@@ -104,8 +104,7 @@ function summarize(tests, failures, skips) {
         byFormat: summarizeGroups(tests, failures, skips, "format", formatOrder()),
         byFormatRequirement: summarizeMatrix(tests, failures, skips, "format", "requirement", formatOrder(), requirementOrder()),
         byBinarySyntax: summarizeGroups(binaryTests, failures, skips, "syntax", syntaxOrder()),
-        byBinarySyntaxRequirement: summarizeMatrix(binaryTests, failures, skips, "syntax", "requirement", syntaxOrder(), requirementOrder()),
-        bySyntax: summarizeGroups(tests, failures, skips, "syntax", syntaxOrder())
+        byBinarySyntaxRequirement: summarizeMatrix(binaryTests, failures, skips, "syntax", "requirement", syntaxOrder(), requirementOrder())
     };
 }
 

--- a/tests/conformance/summary.js
+++ b/tests/conformance/summary.js
@@ -18,7 +18,7 @@ exports.readText = readText;
 function readTests(file) {
     var log,
         tests = Object.create(null),
-        pattern = /SKIPPED, test=([^\r\n ]+)/g,
+        pattern = /SKIPPED,\s*test=([^\s]+)/g,
         match,
         name;
 
@@ -40,7 +40,7 @@ function readTests(file) {
 function readFailures(file) {
     var log,
         failures = Object.create(null),
-        pattern = /ERROR, test=([^\r\n :]+)/g,
+        pattern = /ERROR,\s*test=([^\s:]+)/g,
         match;
 
     if (!file || !fs.existsSync(file))
@@ -55,7 +55,7 @@ function readFailures(file) {
 function readSkips(file) {
     var log,
         skips = Object.create(null),
-        pattern = /SKIPPED, test=([^\r\n ]+)/g,
+        pattern = /SKIPPED,\s*test=([^\s]+)/g,
         match;
 
     if (!file || !fs.existsSync(file))

--- a/tests/conformance/testee.js
+++ b/tests/conformance/testee.js
@@ -5,10 +5,14 @@ var fs = require("fs"),
     generated = require("./generated/messages.js"),
     reflectionRoot = protobuf.Root.fromJSON(require("./generated/messages.json")).resolveAll(),
     conformance = generated.conformance,
+    protojson = require("../../ext/protojson"),
+    textformat = require("../../ext/textformat"),
     list = process.argv.indexOf("--list") >= 0,
+    mode = process.env.PROTOBUFJS_CONFORMANCE_MODE || "reflect",
     testTypes = Object.create(null);
 
-require("../../ext/textformat");
+if (mode !== "static" && mode !== "reflect")
+    throw Error("unsupported PROTOBUFJS_CONFORMANCE_MODE: " + mode);
 
 var TEST_TYPES = [
     makeTestType("protobuf_test_messages.proto2.TestAllTypesProto2", generated.protobuf_test_messages.proto2.TestAllTypesProto2),
@@ -40,6 +44,11 @@ function makeTestType(name, type) {
         type: type,
         textType: reflectionRoot.lookupType(name)
     };
+}
+
+function isStaticSupported(request) {
+    return request.payload === "protobufPayload"
+        && request.requestedOutputFormat === conformance.WireFormat.PROTOBUF;
 }
 
 // Keep stdout synchronous because it carries the framed testee protocol.
@@ -78,12 +87,14 @@ try {
             };
         } else if (list) {
             response = { skipped: "list mode" };
+        } else if (mode === "static" && !isStaticSupported(request)) {
+            response = { skipped: "static mode supports protobuf input/output only" };
         } else {
             testCase = testTypes[request.messageType];
             if (!testCase) {
                 response = { runtimeError: "unknown message type: " + request.messageType };
             } else {
-                type = testCase.type;
+                type = mode === "reflect" ? testCase.textType : testCase.type;
                 // Parse the request payload into the requested generated type.
                 try {
                     switch (request.payload) {
@@ -91,13 +102,16 @@ try {
                             message = type.decode(request.protobufPayload);
                             break;
                         case "jsonPayload":
-                            message = type.fromObject(JSON.parse(request.jsonPayload));
+                            message = protojson.fromJsonString(type, request.jsonPayload, {
+                                ignoreUnknownFields: request.testCategory
+                                    === conformance.TestCategory.JSON_IGNORE_UNKNOWN_PARSING_TEST
+                            });
                             break;
                         case "jspbPayload":
-                            response = { parseError: "JSPB not supported" };
+                            response = { skipped: "JSPB not supported" };
                             break;
                         case "textPayload":
-                            message = testCase.textType.fromText(request.textPayload);
+                            message = textformat.fromText(type, request.textPayload);
                             break;
                         default:
                             response = { parseError: "unsupported format" };
@@ -115,21 +129,14 @@ try {
                                 response = { protobufPayload: type.encode(message).finish() };
                                 break;
                             case conformance.WireFormat.JSON:
-                                response = {
-                                    jsonPayload: JSON.stringify(type.toObject(message, {
-                                        json: true,
-                                        bytes: String,
-                                        longs: String,
-                                        enums: String
-                                    }))
-                                };
+                                response = { jsonPayload: protojson.toJsonString(type, message) };
                                 break;
                             case conformance.WireFormat.JSPB:
                                 response = { skipped: "JSPB not supported" };
                                 break;
                             case conformance.WireFormat.TEXT_FORMAT:
                                 response = {
-                                    textPayload: testCase.textType.toText(message, {
+                                    textPayload: textformat.toText(type, message, {
                                         unknowns: request.printUnknownFields
                                     })
                                 };

--- a/tests/conformance/testee.js
+++ b/tests/conformance/testee.js
@@ -31,9 +31,9 @@ if (generated.protobuf_test_messages.edition_unstable) {
 }
 
 TEST_TYPES.forEach(function(testCase) {
-    if (!testCase.type)
+    if (!testCase.staticType)
         throw Error("missing generated test type: " + testCase.name);
-    if (!testCase.textType)
+    if (!testCase.reflectType)
         throw Error("missing reflected test type: " + testCase.name);
     testTypes[testCase.name] = testCase;
 });
@@ -41,8 +41,8 @@ TEST_TYPES.forEach(function(testCase) {
 function makeTestType(name, type) {
     return {
         name: name,
-        type: type,
-        textType: reflectionRoot.lookupType(name)
+        staticType: type,
+        reflectType: reflectionRoot.lookupType(name)
     };
 }
 
@@ -94,7 +94,7 @@ try {
             if (!testCase) {
                 response = { runtimeError: "unknown message type: " + request.messageType };
             } else {
-                type = mode === "reflect" ? testCase.textType : testCase.type;
+                type = mode === "reflect" ? testCase.reflectType : testCase.staticType;
                 // Parse the request payload into the requested generated type.
                 try {
                     switch (request.payload) {

--- a/tsconfig.test-types.json
+++ b/tsconfig.test-types.json
@@ -12,6 +12,7 @@
     },
     "include": [
         "tests/comp_descriptor.ts",
+        "tests/comp_protojson.ts",
         "tests/comp_textformat.ts",
         "tests/data/*.ts"
     ]


### PR DESCRIPTION
Adds a spec-compliant ProtoJSON extension derived from [proto3-json-serializer](https://www.npmjs.com/package/proto3-json-serializer). Cc @alexander-fenster as the original author.

ProtoJSON is exposed via `ext/protojson` with explicit `fromJson`, `fromJsonString`, `toJson`, and `toJsonString` APIs, plus an optional `install()` helper for reflected `Type` convenience methods.

Example usage:

```js
import protobuf from "protobufjs";
import protojson from "protobufjs/ext/protojson.js";

const root = ...;
const MyType = root.lookupType("MyType");
const message = protojson.fromJson(MyType, { value: 1 });
const json = protojson.toJson(MyType, message);
```

Also updates conformance reporting and README documentation to show binary, ProtoJSON, and Text Format coverage.

A future major release may move some of this functionality into the main library, but keeping it as an extension is the cleanest way to support ProtoJSON for now.

Fixes #677
Fixes #839
Fixes #916
Fixes #1108
Fixes #1304
Fixes #1312
Fixes #1922

Supersedes #1265

Also covers the reflection/runtime ProtoJSON parts of #2201. Static-module integration may become relevant again if we decide to move ProtoJSON support closer to the main library.