### PR TITLE
fix(cli): preserve true-prefixed pbts type names

### DIFF
--- a/cli/lib/tsd-jsdoc/patch.js
+++ b/cli/lib/tsd-jsdoc/patch.js
@@ -3,9 +3,40 @@
 var typeParserPatched = false;
 var typeLinkerPatched = false;
 var typeScriptTypePattern = /[&;]|\?:|=>|\bkeyof\b|\btypeof\b/;
+var typeNamePattern = /^[A-Za-z_$][0-9A-Za-z_$]*(?:\.[A-Za-z_$][0-9A-Za-z_$]*)*=?$/;
 
 function normalizeType(type) {
     return type.replace(/\r?\n|\r/g, "\n");
+}
+
+function parseTagName(text) {
+    text = text.trim();
+    if (!text)
+        return {};
+
+    var result = {};
+    if (text.charAt(0) === "[") {
+        var close = text.indexOf("]");
+        if (close >= 0) {
+            var name = text.substring(1, close),
+                equal = name.indexOf("=");
+            result.optional = true;
+            if (equal >= 0) {
+                result.defaultvalue = name.substring(equal + 1);
+                name = name.substring(0, equal);
+            }
+            result.name = name;
+            result.text = text.substring(close + 1).trim();
+            return result;
+        }
+    }
+
+    var match = /^(\S+)(?:\s+([\s\S]*))?$/.exec(text);
+    if (match) {
+        result.name = match[1];
+        result.text = match[2] || "";
+    }
+    return result;
 }
 
 function patchTypeExpressionParser(dictionary) {
@@ -57,15 +88,38 @@ function patchTypeExpressionParser(dictionary) {
                 throw e;
 
             var expression = normalizeType(text.substring(open + 1, close)).trim();
-            if (!typeScriptTypePattern.test(expression) && !/^\s*\{/.test(expression))
+            if (!typeScriptTypePattern.test(expression) && !/^\s*\{/.test(expression) && !typeNamePattern.test(expression))
                 throw e;
 
-            var name = canHaveName ? text.substring(close + 1).trim() : "";
-            return {
-                type: [ expression ],
-                typeExpression: expression,
-                name: name
+            var expressionType = expression,
+                typeOptional = false;
+            if (typeNamePattern.test(expression) && expression.charAt(expression.length - 1) === "=") {
+                expressionType = expression.substring(0, expression.length - 1);
+                typeOptional = true;
+            }
+
+            var tag = canHaveName ? parseTagName(text.substring(close + 1)) : {};
+            var parsed = {
+                type: [ expressionType ],
+                typeExpression: expression
             };
+            if (tag.name)
+                parsed.name = tag.name;
+            if (tag.text)
+                parsed.text = tag.text;
+            if (tag.optional || typeOptional)
+                parsed.optional = true;
+            if (tag.defaultvalue)
+                parsed.defaultvalue = tag.defaultvalue;
+            if (typeNamePattern.test(expression)) {
+                parsed.parsedType = {
+                    type: "NameExpression",
+                    name: expressionType
+                };
+                if (typeOptional)
+                    parsed.parsedType.optional = true;
+            }
+            return parsed;
         }
     };
 }

--- a/tests/cli-pbts.js
+++ b/tests/cli-pbts.js
@@ -167,6 +167,25 @@ tape.test("pbts preserves qualified Object type names", function(test) {
     });
 });
 
+tape.test("pbts preserves generated type names starting with true", function(test) {
+    var pbts = require("../cli/pbts");
+
+    pbts.process([
+        "/** @class */",
+        "function trueWireless() {}",
+        "",
+        "/**",
+        " * @param {trueWireless.$Properties=} [properties] Properties to set",
+        " * @returns {trueWireless} trueWireless instance",
+        " */",
+        "trueWireless.create = function(properties) { return new trueWireless(properties); };"
+    ].join("\n"), [], function(err, tsCode) {
+        test.error(err, "definition generation worked");
+        test.ok(tsCode.indexOf("static create(properties?: trueWireless.$Properties): trueWireless;") >= 0, "keeps true-prefixed generated types");
+        test.end();
+    });
+});
+
 tape.test("pbts ignores unknown JSDoc tags", function(test) {
     var pbts = require("../cli/pbts");
 


### PR DESCRIPTION
Fixes #1703

## Summary
- preserve plain qualified type names when JSDoc/catharsis rejects generated names such as `trueWireless`
- parse fallback parameter names so optional generated params like `{trueWireless.$Properties=} [properties]` still emit valid declarations
- add a pbts regression for generated type names that start with `true`

## Verification
- Before the fix, the reported `pbjs` then `pbts` flow failed for `message trueWireless {}` with `Invalid type expression "trueWireless"` and a `publish.js` crash
- `node cli/bin/pbjs -o .tmp/issue1703/sample.js -w es6 -t static-module .tmp/issue1703/sample.proto && node cli/bin/pbts -o .tmp/issue1703/sample.d.ts .tmp/issue1703/sample.js`
- `npm_config_cache=/tmp/protobufjs-1703-npm-cache npx tape -r ./lib/tape-adapter tests/cli-pbts.js tests/cli-pbjs.js`
- `npm_config_cache=/tmp/protobufjs-1703-npm-cache npm run lint:sources`
- `npm_config_cache=/tmp/protobufjs-1703-npm-cache npm test`
- `git diff --check`

I used AI assistance to help prepare this patch.