### PR TITLE
fix(cli): Consistently wait for pbts output before JSDoc exit

### DIFF
--- a/cli/lib/tsd-jsdoc/publish.js
+++ b/cli/lib/tsd-jsdoc/publish.js
@@ -2,7 +2,7 @@
 
 var fs = require("fs");
 
-// output stream
+// output chunks
 var out = null;
 
 // documentation data
@@ -53,13 +53,9 @@ exports.publish = function publish(taffy, opts) {
     if (!options.private)
         taffy({ access: "private" }).remove();
 
-    // setup output
-    out = options.destination
-        ? fs.createWriteStream(options.destination)
-        : process.stdout;
-
     try {
         // setup environment
+        out = [];
         data = taffy().get();
         indent = 0;
         indentWritten = false;
@@ -85,9 +81,19 @@ exports.publish = function publish(taffy, opts) {
             writeln("}");
         }
 
-        // close file output
-        if (out !== process.stdout)
-            out.end();
+        // Let JSDoc wait for stdout to flush before exiting
+        return new Promise(function(resolve, reject) {
+            function done(err) {
+                if (err)
+                    reject(err);
+                else
+                    resolve();
+            }
+            if (options.destination)
+                fs.writeFile(options.destination, out.join(""), "utf8", done);
+            else
+                process.stdout.write(out.join(""), done);
+        });
 
     } finally {
         // gc environment objects
@@ -108,7 +114,7 @@ function write() {
             s = "    " + s;
         indentWritten = true;
     }
-    out.write(s);
+    out.push(s);
     firstLine = false;
 }
 
@@ -118,7 +124,7 @@ function writeln() {
     if (s.length)
         write(s, "\n");
     else if (!firstLine)
-        out.write("\n");
+        out.push("\n");
     indentWritten = false;
 }
 

--- a/cli/lib/tsd-jsdoc/publish.js
+++ b/cli/lib/tsd-jsdoc/publish.js
@@ -81,7 +81,7 @@ exports.publish = function publish(taffy, opts) {
             writeln("}");
         }
 
-        // Let JSDoc wait for stdout to flush before exiting
+        // Let JSDoc wait for output to flush before exiting
         return new Promise(function(resolve, reject) {
             function done(err) {
                 if (err)
@@ -89,10 +89,9 @@ exports.publish = function publish(taffy, opts) {
                 else
                     resolve();
             }
-            if (options.destination)
-                fs.writeFile(options.destination, out.join(""), "utf8", done);
-            else
-                process.stdout.write(out.join(""), done);
+            // Use stdout fd 1 directly because uv_guess_handle can fail to classify
+            // sandboxed stdout handles when getsockname/getsockopt raises EPERM.
+            fs.writeFile(options.destination || 1, out.join(""), "utf8", done);
         });
 
     } finally {

--- a/tests/cli-pbjs.js
+++ b/tests/cli-pbjs.js
@@ -738,6 +738,8 @@ tape.test("pbjs --dts writes module declarations", function(test) {
                     var jsonEsmTypes = fs.readFileSync(jsonEsmDts, "utf8");
                     test.ok(jsonEsmTypes.indexOf("declare const _default: $protobuf.Root;") >= 0, "declares the default root export");
                     test.ok(jsonEsmTypes.indexOf("export default _default;") >= 0, "exports the default root declaration");
+                    test.ok(jsonEsmTypes.indexOf("export class Package") >= 0, "emits message declarations");
+                    test.ok(jsonEsmTypes.indexOf("class Repository") >= 0, "emits nested message declarations");
 
                     pbjs.main([
                         "--target", "json-module",


### PR DESCRIPTION
Makes sure that JSDoc waits for generated `pbts` output to flush before exiting. Turns out that otherwise, piped output can produce incomplete declarations in some sandboxed environments.