### PR TITLE
fix: Avoid name collisions in generated code (7.x)

### DIFF
--- a/cli/targets/static.js
+++ b/cli/targets/static.js
@@ -769,7 +769,7 @@ function buildService(ref, service) {
         ]);
         push("Object.defineProperty(" + escapeName(service.name) + ".prototype" + util.safeProp(lcName) + " = function " + escapeName(lcName) + "(request, callback) {");
             ++indent;
-            push("return this.rpcCall(" + escapeName(lcName) + ", $root." + exportName(method.resolvedRequestType) + ", $root." + exportName(method.resolvedResponseType) + ", request, callback);");
+            push("return $protobuf.rpc.Service.prototype.rpcCall.call(this, " + escapeName(lcName) + ", $root." + exportName(method.resolvedRequestType) + ", $root." + exportName(method.resolvedResponseType) + ", request, callback);");
             --indent;
         push("}, \"name\", { value: " + JSON.stringify(method.name) + " });");
         if (config.comments)

--- a/src/converter.js
+++ b/src/converter.js
@@ -302,7 +302,7 @@ converter.toObject = function toObject(mtype) {
             genValuePartial_toObject(gen, field, /* sorted */ index, prop + "[j]")
         ("}");
         } else { gen
-    ("if(m%s!=null&&m.hasOwnProperty(%j)){", prop, field.name); // !== undefined && !== null
+    ("if(m%s!=null&&Object.hasOwnProperty.call(m,%j)){", prop, field.name); // !== undefined && !== null
         genValuePartial_toObject(gen, field, /* sorted */ index, prop);
         if (field.partOf) gen
         ("if(o.oneofs)")

--- a/src/decoder.js
+++ b/src/decoder.js
@@ -125,7 +125,7 @@ function decoder(mtype) {
     for (i = 0; i < mtype._fieldsArray.length; ++i) {
         var rfield = mtype._fieldsArray[i];
         if (rfield.required) gen
-    ("if(!m.hasOwnProperty(%j))", rfield.name)
+            ("if(!Object.hasOwnProperty.call(m,%j))", rfield.name)
         ("throw util.ProtocolError(%j,{instance:m})", missing(rfield));
     }
 

--- a/src/service.js
+++ b/src/service.js
@@ -9,8 +9,6 @@ var Method = require("./method"),
     util   = require("./util"),
     rpc    = require("./rpc");
 
-var reservedRe = util.patterns.reservedRe;
-
 /**
  * Constructs a new service instance.
  * @classdesc Reflected service.

--- a/src/service.js
+++ b/src/service.js
@@ -185,11 +185,11 @@ Service.prototype.create = function create(rpcImpl, requestDelimited, responseDe
     var rpcService = new rpc.Service(rpcImpl, requestDelimited, responseDelimited);
     for (var i = 0, method; i < /* initializes */ this.methodsArray.length; ++i) {
         var methodName = util.lcFirst((method = this._methodsArray[i]).resolve().name).replace(/[^$\w_]/g, "");
-        rpcService[methodName] = util.codegen(["r","c"], reservedRe.test(methodName) ? methodName + "_" : methodName)("return this.rpcCall(m,q,s,r,c)")({
-            m: method,
-            q: method.resolvedRequestType.ctor,
-            s: method.resolvedResponseType.ctor
-        });
+        rpcService[methodName] = (function(method, requestType, responseType) {
+            return function rpcMethod(request, callback) {
+                return rpc.Service.prototype.rpcCall.call(this, method, requestType, responseType, request, callback);
+            };
+        })(method, method.resolvedRequestType.ctor, method.resolvedResponseType.ctor);
     }
     return rpcService;
 };

--- a/src/type.js
+++ b/src/type.js
@@ -373,7 +373,7 @@ Type.prototype.add = function add(object) {
             throw Error("duplicate id " + object.id + " in " + this);
         if (this.isReservedId(object.id))
             throw Error("id " + object.id + " is reserved in " + this);
-        if (this.isReservedName(object.name))
+        if (this.isReservedName(object.name) || object.name.charAt(0) === "$")
             throw Error("name '" + object.name + "' is reserved in " + this);
         if (object.name === "__proto__")
             return this;
@@ -386,6 +386,8 @@ Type.prototype.add = function add(object) {
         return clearCache(this);
     }
     if (object instanceof OneOf) {
+        if (object.name.charAt(0) === "$")
+            throw Error("name '" + object.name + "' is reserved in " + this);
         if (object.name === "__proto__")
             return this;
         if (!this.oneofs)

--- a/src/util/minimal.js
+++ b/src/util/minimal.js
@@ -119,7 +119,7 @@ util.isset =
  */
 util.isSet = function isSet(obj, prop) {
     var value = obj[prop];
-    if (value != null && obj.hasOwnProperty(prop)) // eslint-disable-line eqeqeq, no-prototype-builtins
+    if (value != null && Object.hasOwnProperty.call(obj, prop)) // eslint-disable-line eqeqeq
         return typeof value !== "object" || (Array.isArray(value) ? value.length : Object.keys(value).length) > 0;
     return false;
 };

--- a/src/verifier.js
+++ b/src/verifier.js
@@ -138,7 +138,7 @@ function verifier(mtype) {
             ref   = "m" + util.safeProp(field.name);
 
         if (field.optional) gen
-        ("if(%s!=null&&m.hasOwnProperty(%j)){", ref, field.name); // !== undefined && !== null
+        ("if(%s!=null&&Object.hasOwnProperty.call(m,%j)){", ref, field.name); // !== undefined && !== null
 
         // map fields
         if (field.map) { gen

--- a/tests/api_converters.js
+++ b/tests/api_converters.js
@@ -337,3 +337,19 @@ tape.test("converters", function(test) {
     });
 
 });
+
+tape.test("converters - runtime-significant field names", function(test) {
+    var root = protobuf.parse("syntax = \"proto3\";\n"
+        + "message Singular { string hasOwnProperty = 1; }\n"
+        + "message Repeated { repeated string hasOwnProperty = 1; }\n").root;
+
+    var Singular = root.lookupType("Singular"),
+        Repeated = root.lookupType("Repeated"),
+        singular = Singular.create({ hasOwnProperty: "value" }),
+        repeated = Repeated.decode(Repeated.encode({ hasOwnProperty: [ "a", "b" ] }).finish());
+
+    test.equal(Singular.verify({ hasOwnProperty: "value" }), null, "verify should not call a shadowed hasOwnProperty field");
+    test.same(Singular.toObject(singular), { hasOwnProperty: "value" }, "toObject should not call a shadowed hasOwnProperty field");
+    test.same(repeated.hasOwnProperty, [ "a", "b" ], "decode should not call a shadowed hasOwnProperty field");
+    test.end();
+});

--- a/tests/api_service.js
+++ b/tests/api_service.js
@@ -48,6 +48,22 @@ tape.test("reflected services", function(test) {
     test.end();
 });
 
+tape.test("reflected services can call runtime-significant method names", function(test) {
+    var root = protobuf.parse("syntax = \"proto3\"; message Req {} message Res {} service S { rpc rpcCall(Req) returns (Res); }").root;
+    root.resolveAll();
+
+    var Res = root.lookupType("Res"),
+        service = root.lookupService("S").create(function(method, request, callback) {
+            callback(null, Res.encode({}).finish());
+        });
+
+    service.rpcCall({}, function(err, response) {
+        test.error(err, "should call method named rpcCall");
+        test.ok(response instanceof Res.ctor, "should decode the response");
+        test.end();
+    });
+});
+
 tape.test("feature resolution legacy proto3", function(test) {
     var json = {
         methods: {

--- a/tests/api_type.js
+++ b/tests/api_type.js
@@ -97,6 +97,13 @@ tape.test("reflected types", function(test) {
         type.add(new protobuf.Field("b", 2, "uint32"));
     }, Error, "should throw when trying to add reserved names");
 
+    test.throws(function() {
+        type.add(new protobuf.Field("$type", 2, "uint32"));
+    }, Error, "should throw when trying to add fields with runtime-reserved names");
+
+    test.throws(function() {
+        type.add(new protobuf.OneOf("$kind", [ "a" ]));
+    }, Error, "should throw when trying to add oneofs with runtime-reserved names");
 
     test.end();
 });

--- a/tests/api_util.js
+++ b/tests/api_util.js
@@ -86,6 +86,9 @@ tape.test("util", function(test) {
             test.notOk(util.isSet(instance, "p"), "should return that " + name + " on the prototype are not present");
             test.ok(util.isSet(instance, "i"), "should return that " + name + " on the instance ARE present");
         });
+        var nullProto = Object.create(null);
+        nullProto.i = "value";
+        test.ok(util.isSet(nullProto, "i"), "should support null-prototype objects");
 
          test.end();
     });

--- a/tests/cli.js
+++ b/tests/cli.js
@@ -266,6 +266,41 @@ tape.test("pbjs supports dictionary generated root names", function(test) {
     });
 });
 
+tape.test("pbjs static services can call runtime-significant method names", function(test) {
+    cliTest(test, function() {
+        var root = protobuf.parse("syntax = \"proto3\"; message Req {} message Res {} service S { rpc rpcCall(Req) returns (Res); }").root;
+        root.resolveAll();
+
+        var staticTarget = require("../cli/targets/static");
+        staticTarget(root, {
+            decode: true,
+            encode: true,
+            convert: true,
+            service: true,
+            root: "staticServiceShadow"
+        }, function(err, jsCode) {
+            test.error(err, "static code generation worked");
+
+            delete protobuf.roots.staticServiceShadow;
+            var $protobuf = protobuf;
+            eval(jsCode);
+
+            var S = protobuf.roots.staticServiceShadow.S,
+                Res = protobuf.roots.staticServiceShadow.Res,
+                service = new S(function(method, request, callback) {
+                    callback(null, Res.encode({}).finish());
+                });
+
+            service.rpcCall({}, function(callErr, response) {
+                test.error(callErr, "should call method named rpcCall");
+                test.ok(response instanceof Res, "should decode the response");
+                delete protobuf.roots.staticServiceShadow;
+                test.end();
+            });
+        });
+    });
+});
+
 tape.test("pbjs rejects static target escaped name collisions", function(test) {
     cliTest(test, function() {
         var root = protobuf.Root.fromJSON({

--- a/tests/data/comments.js
+++ b/tests/data/comments.js
@@ -187,13 +187,13 @@ $root.Test1 = (function() {
             long = 0;
         if (long > $util.recursionLimit)
             return "maximum nesting depth exceeded";
-        if (message.field1 != null && message.hasOwnProperty("field1"))
+        if (message.field1 != null && Object.hasOwnProperty.call(message, "field1"))
             if (!$util.isString(message.field1))
                 return "field1: string expected";
-        if (message.field2 != null && message.hasOwnProperty("field2"))
+        if (message.field2 != null && Object.hasOwnProperty.call(message, "field2"))
             if (!$util.isInteger(message.field2))
                 return "field2: integer expected";
-        if (message.field3 != null && message.hasOwnProperty("field3"))
+        if (message.field3 != null && Object.hasOwnProperty.call(message, "field3"))
             if (typeof message.field3 !== "boolean")
                 return "field3: boolean expected";
         return null;
@@ -248,11 +248,11 @@ $root.Test1 = (function() {
             object.field2 = 0;
             object.field3 = false;
         }
-        if (message.field1 != null && message.hasOwnProperty("field1"))
+        if (message.field1 != null && Object.hasOwnProperty.call(message, "field1"))
             object.field1 = message.field1;
-        if (message.field2 != null && message.hasOwnProperty("field2"))
+        if (message.field2 != null && Object.hasOwnProperty.call(message, "field2"))
             object.field2 = message.field2;
-        if (message.field3 != null && message.hasOwnProperty("field3"))
+        if (message.field3 != null && Object.hasOwnProperty.call(message, "field3"))
             object.field3 = message.field3;
         return object;
     };

--- a/tests/data/convert.js
+++ b/tests/data/convert.js
@@ -329,37 +329,37 @@ $root.Message = (function() {
             long = 0;
         if (long > $util.recursionLimit)
             return "maximum nesting depth exceeded";
-        if (message.stringVal != null && message.hasOwnProperty("stringVal"))
+        if (message.stringVal != null && Object.hasOwnProperty.call(message, "stringVal"))
             if (!$util.isString(message.stringVal))
                 return "stringVal: string expected";
-        if (message.stringRepeated != null && message.hasOwnProperty("stringRepeated")) {
+        if (message.stringRepeated != null && Object.hasOwnProperty.call(message, "stringRepeated")) {
             if (!Array.isArray(message.stringRepeated))
                 return "stringRepeated: array expected";
             for (var i = 0; i < message.stringRepeated.length; ++i)
                 if (!$util.isString(message.stringRepeated[i]))
                     return "stringRepeated: string[] expected";
         }
-        if (message.uint64Val != null && message.hasOwnProperty("uint64Val"))
+        if (message.uint64Val != null && Object.hasOwnProperty.call(message, "uint64Val"))
             if (!$util.isInteger(message.uint64Val) && !(message.uint64Val && $util.isInteger(message.uint64Val.low) && $util.isInteger(message.uint64Val.high)))
                 return "uint64Val: integer|Long expected";
-        if (message.uint64Repeated != null && message.hasOwnProperty("uint64Repeated")) {
+        if (message.uint64Repeated != null && Object.hasOwnProperty.call(message, "uint64Repeated")) {
             if (!Array.isArray(message.uint64Repeated))
                 return "uint64Repeated: array expected";
             for (var i = 0; i < message.uint64Repeated.length; ++i)
                 if (!$util.isInteger(message.uint64Repeated[i]) && !(message.uint64Repeated[i] && $util.isInteger(message.uint64Repeated[i].low) && $util.isInteger(message.uint64Repeated[i].high)))
                     return "uint64Repeated: integer|Long[] expected";
         }
-        if (message.bytesVal != null && message.hasOwnProperty("bytesVal"))
+        if (message.bytesVal != null && Object.hasOwnProperty.call(message, "bytesVal"))
             if (!(message.bytesVal && typeof message.bytesVal.length === "number" || $util.isString(message.bytesVal)))
                 return "bytesVal: buffer expected";
-        if (message.bytesRepeated != null && message.hasOwnProperty("bytesRepeated")) {
+        if (message.bytesRepeated != null && Object.hasOwnProperty.call(message, "bytesRepeated")) {
             if (!Array.isArray(message.bytesRepeated))
                 return "bytesRepeated: array expected";
             for (var i = 0; i < message.bytesRepeated.length; ++i)
                 if (!(message.bytesRepeated[i] && typeof message.bytesRepeated[i].length === "number" || $util.isString(message.bytesRepeated[i])))
                     return "bytesRepeated: buffer[] expected";
         }
-        if (message.enumVal != null && message.hasOwnProperty("enumVal"))
+        if (message.enumVal != null && Object.hasOwnProperty.call(message, "enumVal"))
             switch (message.enumVal) {
             default:
                 return "enumVal: enum value expected";
@@ -367,7 +367,7 @@ $root.Message = (function() {
             case 2:
                 break;
             }
-        if (message.enumRepeated != null && message.hasOwnProperty("enumRepeated")) {
+        if (message.enumRepeated != null && Object.hasOwnProperty.call(message, "enumRepeated")) {
             if (!Array.isArray(message.enumRepeated))
                 return "enumRepeated: array expected";
             for (var i = 0; i < message.enumRepeated.length; ++i)
@@ -379,7 +379,7 @@ $root.Message = (function() {
                     break;
                 }
         }
-        if (message.int64Map != null && message.hasOwnProperty("int64Map")) {
+        if (message.int64Map != null && Object.hasOwnProperty.call(message, "int64Map")) {
             if (!$util.isObject(message.int64Map))
                 return "int64Map: object expected";
             var key = Object.keys(message.int64Map);
@@ -553,14 +553,14 @@ $root.Message = (function() {
             }
             object.enumVal = options.enums === String ? "ONE" : 1;
         }
-        if (message.stringVal != null && message.hasOwnProperty("stringVal"))
+        if (message.stringVal != null && Object.hasOwnProperty.call(message, "stringVal"))
             object.stringVal = message.stringVal;
         if (message.stringRepeated && message.stringRepeated.length) {
             object.stringRepeated = [];
             for (var j = 0; j < message.stringRepeated.length; ++j)
                 object.stringRepeated[j] = message.stringRepeated[j];
         }
-        if (message.uint64Val != null && message.hasOwnProperty("uint64Val"))
+        if (message.uint64Val != null && Object.hasOwnProperty.call(message, "uint64Val"))
             if (typeof BigInt !== "undefined" && options.longs === BigInt)
                 object.uint64Val = typeof message.uint64Val === "number" ? BigInt(message.uint64Val) : $util.Long.fromBits(message.uint64Val.low >>> 0, message.uint64Val.high >>> 0, true).toBigInt();
             else if (typeof message.uint64Val === "number")
@@ -577,14 +577,14 @@ $root.Message = (function() {
                 else
                     object.uint64Repeated[j] = options.longs === String ? $util.Long.prototype.toString.call(message.uint64Repeated[j]) : options.longs === Number ? new $util.LongBits(message.uint64Repeated[j].low >>> 0, message.uint64Repeated[j].high >>> 0).toNumber(true) : message.uint64Repeated[j];
         }
-        if (message.bytesVal != null && message.hasOwnProperty("bytesVal"))
+        if (message.bytesVal != null && Object.hasOwnProperty.call(message, "bytesVal"))
             object.bytesVal = options.bytes === String ? $util.base64.encode(message.bytesVal, 0, message.bytesVal.length) : options.bytes === Array ? Array.prototype.slice.call(message.bytesVal) : message.bytesVal;
         if (message.bytesRepeated && message.bytesRepeated.length) {
             object.bytesRepeated = [];
             for (var j = 0; j < message.bytesRepeated.length; ++j)
                 object.bytesRepeated[j] = options.bytes === String ? $util.base64.encode(message.bytesRepeated[j], 0, message.bytesRepeated[j].length) : options.bytes === Array ? Array.prototype.slice.call(message.bytesRepeated[j]) : message.bytesRepeated[j];
         }
-        if (message.enumVal != null && message.hasOwnProperty("enumVal"))
+        if (message.enumVal != null && Object.hasOwnProperty.call(message, "enumVal"))
             object.enumVal = options.enums === String ? $root.Message.SomeEnum[message.enumVal] === undefined ? message.enumVal : $root.Message.SomeEnum[message.enumVal] : message.enumVal;
         if (message.enumRepeated && message.enumRepeated.length) {
             object.enumRepeated = [];

--- a/tests/data/mapbox/vector_tile.js
+++ b/tests/data/mapbox/vector_tile.js
@@ -167,7 +167,7 @@ $root.vector_tile = (function() {
                 long = 0;
             if (long > $util.recursionLimit)
                 return "maximum nesting depth exceeded";
-            if (message.layers != null && message.hasOwnProperty("layers")) {
+            if (message.layers != null && Object.hasOwnProperty.call(message, "layers")) {
                 if (!Array.isArray(message.layers))
                     return "layers: array expected";
                 for (var i = 0; i < message.layers.length; ++i) {
@@ -516,25 +516,25 @@ $root.vector_tile = (function() {
                     long = 0;
                 if (long > $util.recursionLimit)
                     return "maximum nesting depth exceeded";
-                if (message.stringValue != null && message.hasOwnProperty("stringValue"))
+                if (message.stringValue != null && Object.hasOwnProperty.call(message, "stringValue"))
                     if (!$util.isString(message.stringValue))
                         return "stringValue: string expected";
-                if (message.floatValue != null && message.hasOwnProperty("floatValue"))
+                if (message.floatValue != null && Object.hasOwnProperty.call(message, "floatValue"))
                     if (typeof message.floatValue !== "number")
                         return "floatValue: number expected";
-                if (message.doubleValue != null && message.hasOwnProperty("doubleValue"))
+                if (message.doubleValue != null && Object.hasOwnProperty.call(message, "doubleValue"))
                     if (typeof message.doubleValue !== "number")
                         return "doubleValue: number expected";
-                if (message.intValue != null && message.hasOwnProperty("intValue"))
+                if (message.intValue != null && Object.hasOwnProperty.call(message, "intValue"))
                     if (!$util.isInteger(message.intValue) && !(message.intValue && $util.isInteger(message.intValue.low) && $util.isInteger(message.intValue.high)))
                         return "intValue: integer|Long expected";
-                if (message.uintValue != null && message.hasOwnProperty("uintValue"))
+                if (message.uintValue != null && Object.hasOwnProperty.call(message, "uintValue"))
                     if (!$util.isInteger(message.uintValue) && !(message.uintValue && $util.isInteger(message.uintValue.low) && $util.isInteger(message.uintValue.high)))
                         return "uintValue: integer|Long expected";
-                if (message.sintValue != null && message.hasOwnProperty("sintValue"))
+                if (message.sintValue != null && Object.hasOwnProperty.call(message, "sintValue"))
                     if (!$util.isInteger(message.sintValue) && !(message.sintValue && $util.isInteger(message.sintValue.low) && $util.isInteger(message.sintValue.high)))
                         return "sintValue: integer|Long expected";
-                if (message.boolValue != null && message.hasOwnProperty("boolValue"))
+                if (message.boolValue != null && Object.hasOwnProperty.call(message, "boolValue"))
                     if (typeof message.boolValue !== "boolean")
                         return "boolValue: boolean expected";
                 return null;
@@ -634,34 +634,34 @@ $root.vector_tile = (function() {
                         object.sintValue = options.longs === String ? "0" : typeof BigInt !== "undefined" && options.longs === BigInt ? BigInt("0") : 0;
                     object.boolValue = false;
                 }
-                if (message.stringValue != null && message.hasOwnProperty("stringValue"))
+                if (message.stringValue != null && Object.hasOwnProperty.call(message, "stringValue"))
                     object.stringValue = message.stringValue;
-                if (message.floatValue != null && message.hasOwnProperty("floatValue"))
+                if (message.floatValue != null && Object.hasOwnProperty.call(message, "floatValue"))
                     object.floatValue = options.json && !isFinite(message.floatValue) ? String(message.floatValue) : message.floatValue;
-                if (message.doubleValue != null && message.hasOwnProperty("doubleValue"))
+                if (message.doubleValue != null && Object.hasOwnProperty.call(message, "doubleValue"))
                     object.doubleValue = options.json && !isFinite(message.doubleValue) ? String(message.doubleValue) : message.doubleValue;
-                if (message.intValue != null && message.hasOwnProperty("intValue"))
+                if (message.intValue != null && Object.hasOwnProperty.call(message, "intValue"))
                     if (typeof BigInt !== "undefined" && options.longs === BigInt)
                         object.intValue = typeof message.intValue === "number" ? BigInt(message.intValue) : $util.Long.fromBits(message.intValue.low >>> 0, message.intValue.high >>> 0, false).toBigInt();
                     else if (typeof message.intValue === "number")
                         object.intValue = options.longs === String ? String(message.intValue) : message.intValue;
                     else
                         object.intValue = options.longs === String ? $util.Long.prototype.toString.call(message.intValue) : options.longs === Number ? new $util.LongBits(message.intValue.low >>> 0, message.intValue.high >>> 0).toNumber() : message.intValue;
-                if (message.uintValue != null && message.hasOwnProperty("uintValue"))
+                if (message.uintValue != null && Object.hasOwnProperty.call(message, "uintValue"))
                     if (typeof BigInt !== "undefined" && options.longs === BigInt)
                         object.uintValue = typeof message.uintValue === "number" ? BigInt(message.uintValue) : $util.Long.fromBits(message.uintValue.low >>> 0, message.uintValue.high >>> 0, true).toBigInt();
                     else if (typeof message.uintValue === "number")
                         object.uintValue = options.longs === String ? String(message.uintValue) : message.uintValue;
                     else
                         object.uintValue = options.longs === String ? $util.Long.prototype.toString.call(message.uintValue) : options.longs === Number ? new $util.LongBits(message.uintValue.low >>> 0, message.uintValue.high >>> 0).toNumber(true) : message.uintValue;
-                if (message.sintValue != null && message.hasOwnProperty("sintValue"))
+                if (message.sintValue != null && Object.hasOwnProperty.call(message, "sintValue"))
                     if (typeof BigInt !== "undefined" && options.longs === BigInt)
                         object.sintValue = typeof message.sintValue === "number" ? BigInt(message.sintValue) : $util.Long.fromBits(message.sintValue.low >>> 0, message.sintValue.high >>> 0, false).toBigInt();
                     else if (typeof message.sintValue === "number")
                         object.sintValue = options.longs === String ? String(message.sintValue) : message.sintValue;
                     else
                         object.sintValue = options.longs === String ? $util.Long.prototype.toString.call(message.sintValue) : options.longs === Number ? new $util.LongBits(message.sintValue.low >>> 0, message.sintValue.high >>> 0).toNumber() : message.sintValue;
-                if (message.boolValue != null && message.hasOwnProperty("boolValue"))
+                if (message.boolValue != null && Object.hasOwnProperty.call(message, "boolValue"))
                     object.boolValue = message.boolValue;
                 return object;
             };
@@ -909,17 +909,17 @@ $root.vector_tile = (function() {
                     long = 0;
                 if (long > $util.recursionLimit)
                     return "maximum nesting depth exceeded";
-                if (message.id != null && message.hasOwnProperty("id"))
+                if (message.id != null && Object.hasOwnProperty.call(message, "id"))
                     if (!$util.isInteger(message.id) && !(message.id && $util.isInteger(message.id.low) && $util.isInteger(message.id.high)))
                         return "id: integer|Long expected";
-                if (message.tags != null && message.hasOwnProperty("tags")) {
+                if (message.tags != null && Object.hasOwnProperty.call(message, "tags")) {
                     if (!Array.isArray(message.tags))
                         return "tags: array expected";
                     for (var i = 0; i < message.tags.length; ++i)
                         if (!$util.isInteger(message.tags[i]))
                             return "tags: integer[] expected";
                 }
-                if (message.type != null && message.hasOwnProperty("type"))
+                if (message.type != null && Object.hasOwnProperty.call(message, "type"))
                     switch (message.type) {
                     default:
                         return "type: enum value expected";
@@ -929,7 +929,7 @@ $root.vector_tile = (function() {
                     case 3:
                         break;
                     }
-                if (message.geometry != null && message.hasOwnProperty("geometry")) {
+                if (message.geometry != null && Object.hasOwnProperty.call(message, "geometry")) {
                     if (!Array.isArray(message.geometry))
                         return "geometry: array expected";
                     for (var i = 0; i < message.geometry.length; ++i)
@@ -1036,7 +1036,7 @@ $root.vector_tile = (function() {
                         object.id = options.longs === String ? "0" : typeof BigInt !== "undefined" && options.longs === BigInt ? BigInt("0") : 0;
                     object.type = options.enums === String ? "UNKNOWN" : 0;
                 }
-                if (message.id != null && message.hasOwnProperty("id"))
+                if (message.id != null && Object.hasOwnProperty.call(message, "id"))
                     if (typeof BigInt !== "undefined" && options.longs === BigInt)
                         object.id = typeof message.id === "number" ? BigInt(message.id) : $util.Long.fromBits(message.id.low >>> 0, message.id.high >>> 0, true).toBigInt();
                     else if (typeof message.id === "number")
@@ -1048,7 +1048,7 @@ $root.vector_tile = (function() {
                     for (var j = 0; j < message.tags.length; ++j)
                         object.tags[j] = message.tags[j];
                 }
-                if (message.type != null && message.hasOwnProperty("type"))
+                if (message.type != null && Object.hasOwnProperty.call(message, "type"))
                     object.type = options.enums === String ? $root.vector_tile.Tile.GeomType[message.type] === undefined ? message.type : $root.vector_tile.Tile.GeomType[message.type] : message.type;
                 if (message.geometry && message.geometry.length) {
                     object.geometry = [];
@@ -1283,9 +1283,9 @@ $root.vector_tile = (function() {
                         break;
                     }
                 }
-                if (!message.hasOwnProperty("version"))
+                if (!Object.hasOwnProperty.call(message, "version"))
                     throw $util.ProtocolError("missing required 'version'", { instance: message });
-                if (!message.hasOwnProperty("name"))
+                if (!Object.hasOwnProperty.call(message, "name"))
                     throw $util.ProtocolError("missing required 'name'", { instance: message });
                 return message;
             };
@@ -1325,7 +1325,7 @@ $root.vector_tile = (function() {
                     return "version: integer expected";
                 if (!$util.isString(message.name))
                     return "name: string expected";
-                if (message.features != null && message.hasOwnProperty("features")) {
+                if (message.features != null && Object.hasOwnProperty.call(message, "features")) {
                     if (!Array.isArray(message.features))
                         return "features: array expected";
                     for (var i = 0; i < message.features.length; ++i) {
@@ -1334,14 +1334,14 @@ $root.vector_tile = (function() {
                             return "features." + error;
                     }
                 }
-                if (message.keys != null && message.hasOwnProperty("keys")) {
+                if (message.keys != null && Object.hasOwnProperty.call(message, "keys")) {
                     if (!Array.isArray(message.keys))
                         return "keys: array expected";
                     for (var i = 0; i < message.keys.length; ++i)
                         if (!$util.isString(message.keys[i]))
                             return "keys: string[] expected";
                 }
-                if (message.values != null && message.hasOwnProperty("values")) {
+                if (message.values != null && Object.hasOwnProperty.call(message, "values")) {
                     if (!Array.isArray(message.values))
                         return "values: array expected";
                     for (var i = 0; i < message.values.length; ++i) {
@@ -1350,7 +1350,7 @@ $root.vector_tile = (function() {
                             return "values." + error;
                     }
                 }
-                if (message.extent != null && message.hasOwnProperty("extent"))
+                if (message.extent != null && Object.hasOwnProperty.call(message, "extent"))
                     if (!$util.isInteger(message.extent))
                         return "extent: integer expected";
                 return null;
@@ -1437,7 +1437,7 @@ $root.vector_tile = (function() {
                     object.extent = 4096;
                     object.version = 1;
                 }
-                if (message.name != null && message.hasOwnProperty("name"))
+                if (message.name != null && Object.hasOwnProperty.call(message, "name"))
                     object.name = message.name;
                 if (message.features && message.features.length) {
                     object.features = [];
@@ -1454,9 +1454,9 @@ $root.vector_tile = (function() {
                     for (var j = 0; j < message.values.length; ++j)
                         object.values[j] = $root.vector_tile.Tile.Value.toObject(message.values[j], options, q + 1);
                 }
-                if (message.extent != null && message.hasOwnProperty("extent"))
+                if (message.extent != null && Object.hasOwnProperty.call(message, "extent"))
                     object.extent = message.extent;
-                if (message.version != null && message.hasOwnProperty("version"))
+                if (message.version != null && Object.hasOwnProperty.call(message, "version"))
                     object.version = message.version;
                 return object;
             };

--- a/tests/data/package.js
+++ b/tests/data/package.js
@@ -494,46 +494,46 @@ $root.Package = (function() {
             long = 0;
         if (long > $util.recursionLimit)
             return "maximum nesting depth exceeded";
-        if (message.name != null && message.hasOwnProperty("name"))
+        if (message.name != null && Object.hasOwnProperty.call(message, "name"))
             if (!$util.isString(message.name))
                 return "name: string expected";
-        if (message.version != null && message.hasOwnProperty("version"))
+        if (message.version != null && Object.hasOwnProperty.call(message, "version"))
             if (!$util.isString(message.version))
                 return "version: string expected";
-        if (message.versionScheme != null && message.hasOwnProperty("versionScheme"))
+        if (message.versionScheme != null && Object.hasOwnProperty.call(message, "versionScheme"))
             if (!$util.isString(message.versionScheme))
                 return "versionScheme: string expected";
-        if (message.description != null && message.hasOwnProperty("description"))
+        if (message.description != null && Object.hasOwnProperty.call(message, "description"))
             if (!$util.isString(message.description))
                 return "description: string expected";
-        if (message.author != null && message.hasOwnProperty("author"))
+        if (message.author != null && Object.hasOwnProperty.call(message, "author"))
             if (!$util.isString(message.author))
                 return "author: string expected";
-        if (message.license != null && message.hasOwnProperty("license"))
+        if (message.license != null && Object.hasOwnProperty.call(message, "license"))
             if (!$util.isString(message.license))
                 return "license: string expected";
-        if (message.repository != null && message.hasOwnProperty("repository")) {
+        if (message.repository != null && Object.hasOwnProperty.call(message, "repository")) {
             var error = $root.Package.Repository.verify(message.repository, long + 1);
             if (error)
                 return "repository." + error;
         }
-        if (message.bugs != null && message.hasOwnProperty("bugs"))
+        if (message.bugs != null && Object.hasOwnProperty.call(message, "bugs"))
             if (!$util.isString(message.bugs))
                 return "bugs: string expected";
-        if (message.homepage != null && message.hasOwnProperty("homepage"))
+        if (message.homepage != null && Object.hasOwnProperty.call(message, "homepage"))
             if (!$util.isString(message.homepage))
                 return "homepage: string expected";
-        if (message.keywords != null && message.hasOwnProperty("keywords")) {
+        if (message.keywords != null && Object.hasOwnProperty.call(message, "keywords")) {
             if (!Array.isArray(message.keywords))
                 return "keywords: array expected";
             for (var i = 0; i < message.keywords.length; ++i)
                 if (!$util.isString(message.keywords[i]))
                     return "keywords: string[] expected";
         }
-        if (message.main != null && message.hasOwnProperty("main"))
+        if (message.main != null && Object.hasOwnProperty.call(message, "main"))
             if (!$util.isString(message.main))
                 return "main: string expected";
-        if (message.bin != null && message.hasOwnProperty("bin")) {
+        if (message.bin != null && Object.hasOwnProperty.call(message, "bin")) {
             if (!$util.isObject(message.bin))
                 return "bin: object expected";
             var key = Object.keys(message.bin);
@@ -541,7 +541,7 @@ $root.Package = (function() {
                 if (!$util.isString(message.bin[key[i]]))
                     return "bin: string{k:string} expected";
         }
-        if (message.scripts != null && message.hasOwnProperty("scripts")) {
+        if (message.scripts != null && Object.hasOwnProperty.call(message, "scripts")) {
             if (!$util.isObject(message.scripts))
                 return "scripts: object expected";
             var key = Object.keys(message.scripts);
@@ -549,7 +549,7 @@ $root.Package = (function() {
                 if (!$util.isString(message.scripts[key[i]]))
                     return "scripts: string{k:string} expected";
         }
-        if (message.dependencies != null && message.hasOwnProperty("dependencies")) {
+        if (message.dependencies != null && Object.hasOwnProperty.call(message, "dependencies")) {
             if (!$util.isObject(message.dependencies))
                 return "dependencies: object expected";
             var key = Object.keys(message.dependencies);
@@ -557,7 +557,7 @@ $root.Package = (function() {
                 if (!$util.isString(message.dependencies[key[i]]))
                     return "dependencies: string{k:string} expected";
         }
-        if (message.devDependencies != null && message.hasOwnProperty("devDependencies")) {
+        if (message.devDependencies != null && Object.hasOwnProperty.call(message, "devDependencies")) {
             if (!$util.isObject(message.devDependencies))
                 return "devDependencies: object expected";
             var key = Object.keys(message.devDependencies);
@@ -565,10 +565,10 @@ $root.Package = (function() {
                 if (!$util.isString(message.devDependencies[key[i]]))
                     return "devDependencies: string{k:string} expected";
         }
-        if (message.types != null && message.hasOwnProperty("types"))
+        if (message.types != null && Object.hasOwnProperty.call(message, "types"))
             if (!$util.isString(message.types))
                 return "types: string expected";
-        if (message.cliDependencies != null && message.hasOwnProperty("cliDependencies")) {
+        if (message.cliDependencies != null && Object.hasOwnProperty.call(message, "cliDependencies")) {
             if (!Array.isArray(message.cliDependencies))
                 return "cliDependencies: array expected";
             for (var i = 0; i < message.cliDependencies.length; ++i)
@@ -718,28 +718,28 @@ $root.Package = (function() {
             object.types = "";
             object.versionScheme = "";
         }
-        if (message.name != null && message.hasOwnProperty("name"))
+        if (message.name != null && Object.hasOwnProperty.call(message, "name"))
             object.name = message.name;
-        if (message.version != null && message.hasOwnProperty("version"))
+        if (message.version != null && Object.hasOwnProperty.call(message, "version"))
             object.version = message.version;
-        if (message.description != null && message.hasOwnProperty("description"))
+        if (message.description != null && Object.hasOwnProperty.call(message, "description"))
             object.description = message.description;
-        if (message.author != null && message.hasOwnProperty("author"))
+        if (message.author != null && Object.hasOwnProperty.call(message, "author"))
             object.author = message.author;
-        if (message.license != null && message.hasOwnProperty("license"))
+        if (message.license != null && Object.hasOwnProperty.call(message, "license"))
             object.license = message.license;
-        if (message.repository != null && message.hasOwnProperty("repository"))
+        if (message.repository != null && Object.hasOwnProperty.call(message, "repository"))
             object.repository = $root.Package.Repository.toObject(message.repository, options, q + 1);
-        if (message.bugs != null && message.hasOwnProperty("bugs"))
+        if (message.bugs != null && Object.hasOwnProperty.call(message, "bugs"))
             object.bugs = message.bugs;
-        if (message.homepage != null && message.hasOwnProperty("homepage"))
+        if (message.homepage != null && Object.hasOwnProperty.call(message, "homepage"))
             object.homepage = message.homepage;
         if (message.keywords && message.keywords.length) {
             object.keywords = [];
             for (var j = 0; j < message.keywords.length; ++j)
                 object.keywords[j] = message.keywords[j];
         }
-        if (message.main != null && message.hasOwnProperty("main"))
+        if (message.main != null && Object.hasOwnProperty.call(message, "main"))
             object.main = message.main;
         var keys2;
         if (message.bin && (keys2 = Object.keys(message.bin)).length) {
@@ -774,14 +774,14 @@ $root.Package = (function() {
                 object.devDependencies[keys2[j]] = message.devDependencies[keys2[j]];
             }
         }
-        if (message.types != null && message.hasOwnProperty("types"))
+        if (message.types != null && Object.hasOwnProperty.call(message, "types"))
             object.types = message.types;
         if (message.cliDependencies && message.cliDependencies.length) {
             object.cliDependencies = [];
             for (var j = 0; j < message.cliDependencies.length; ++j)
                 object.cliDependencies[j] = message.cliDependencies[j];
         }
-        if (message.versionScheme != null && message.hasOwnProperty("versionScheme"))
+        if (message.versionScheme != null && Object.hasOwnProperty.call(message, "versionScheme"))
             object.versionScheme = message.versionScheme;
         return object;
     };
@@ -972,10 +972,10 @@ $root.Package = (function() {
                 long = 0;
             if (long > $util.recursionLimit)
                 return "maximum nesting depth exceeded";
-            if (message.type != null && message.hasOwnProperty("type"))
+            if (message.type != null && Object.hasOwnProperty.call(message, "type"))
                 if (!$util.isString(message.type))
                     return "type: string expected";
-            if (message.url != null && message.hasOwnProperty("url"))
+            if (message.url != null && Object.hasOwnProperty.call(message, "url"))
                 if (!$util.isString(message.url))
                     return "url: string expected";
             return null;
@@ -1027,9 +1027,9 @@ $root.Package = (function() {
                 object.type = "";
                 object.url = "";
             }
-            if (message.type != null && message.hasOwnProperty("type"))
+            if (message.type != null && Object.hasOwnProperty.call(message, "type"))
                 object.type = message.type;
-            if (message.url != null && message.hasOwnProperty("url"))
+            if (message.url != null && Object.hasOwnProperty.call(message, "url"))
                 object.url = message.url;
             return object;
         };

--- a/tests/data/rpc-es6.js
+++ b/tests/data/rpc-es6.js
@@ -59,7 +59,7 @@ export const MyService = $root.MyService = (() => {
      * @variation 1
      */
     Object.defineProperty(MyService.prototype.myMethod = function myMethod(request, callback) {
-        return this.rpcCall(myMethod, $root.MyRequest, $root.MyResponse, request, callback);
+        return $protobuf.rpc.Service.prototype.rpcCall.call(this, myMethod, $root.MyRequest, $root.MyResponse, request, callback);
     }, "name", { value: "MyMethod" });
 
     /**
@@ -220,7 +220,7 @@ export const MyRequest = $root.MyRequest = (() => {
             long = 0;
         if (long > $util.recursionLimit)
             return "maximum nesting depth exceeded";
-        if (message.path != null && message.hasOwnProperty("path"))
+        if (message.path != null && Object.hasOwnProperty.call(message, "path"))
             if (!$util.isString(message.path))
                 return "path: string expected";
         return null;
@@ -268,7 +268,7 @@ export const MyRequest = $root.MyRequest = (() => {
         let object = {};
         if (options.defaults)
             object.path = "";
-        if (message.path != null && message.hasOwnProperty("path"))
+        if (message.path != null && Object.hasOwnProperty.call(message, "path"))
             object.path = message.path;
         return object;
     };
@@ -447,7 +447,7 @@ export const MyResponse = $root.MyResponse = (() => {
             long = 0;
         if (long > $util.recursionLimit)
             return "maximum nesting depth exceeded";
-        if (message.status != null && message.hasOwnProperty("status"))
+        if (message.status != null && Object.hasOwnProperty.call(message, "status"))
             if (!$util.isInteger(message.status))
                 return "status: integer expected";
         return null;
@@ -495,7 +495,7 @@ export const MyResponse = $root.MyResponse = (() => {
         let object = {};
         if (options.defaults)
             object.status = 0;
-        if (message.status != null && message.hasOwnProperty("status"))
+        if (message.status != null && Object.hasOwnProperty.call(message, "status"))
             object.status = message.status;
         return object;
     };

--- a/tests/data/rpc-reserved.js
+++ b/tests/data/rpc-reserved.js
@@ -61,7 +61,7 @@ $root.MyService = (function() {
      * @variation 1
      */
     Object.defineProperty(MyService.prototype["delete"] = function delete_(request, callback) {
-        return this.rpcCall(delete_, $root.MyRequest, $root.MyResponse, request, callback);
+        return $protobuf.rpc.Service.prototype.rpcCall.call(this, delete_, $root.MyRequest, $root.MyResponse, request, callback);
     }, "name", { value: "Delete" });
 
     /**
@@ -222,7 +222,7 @@ $root.MyRequest = (function() {
             long = 0;
         if (long > $util.recursionLimit)
             return "maximum nesting depth exceeded";
-        if (message.path != null && message.hasOwnProperty("path"))
+        if (message.path != null && Object.hasOwnProperty.call(message, "path"))
             if (!$util.isString(message.path))
                 return "path: string expected";
         return null;
@@ -270,7 +270,7 @@ $root.MyRequest = (function() {
         var object = {};
         if (options.defaults)
             object.path = "";
-        if (message.path != null && message.hasOwnProperty("path"))
+        if (message.path != null && Object.hasOwnProperty.call(message, "path"))
             object.path = message.path;
         return object;
     };
@@ -449,7 +449,7 @@ $root.MyResponse = (function() {
             long = 0;
         if (long > $util.recursionLimit)
             return "maximum nesting depth exceeded";
-        if (message.status != null && message.hasOwnProperty("status"))
+        if (message.status != null && Object.hasOwnProperty.call(message, "status"))
             if (!$util.isInteger(message.status))
                 return "status: integer expected";
         return null;
@@ -497,7 +497,7 @@ $root.MyResponse = (function() {
         var object = {};
         if (options.defaults)
             object.status = 0;
-        if (message.status != null && message.hasOwnProperty("status"))
+        if (message.status != null && Object.hasOwnProperty.call(message, "status"))
             object.status = message.status;
         return object;
     };

--- a/tests/data/rpc.js
+++ b/tests/data/rpc.js
@@ -61,7 +61,7 @@ $root.MyService = (function() {
      * @variation 1
      */
     Object.defineProperty(MyService.prototype.myMethod = function myMethod(request, callback) {
-        return this.rpcCall(myMethod, $root.MyRequest, $root.MyResponse, request, callback);
+        return $protobuf.rpc.Service.prototype.rpcCall.call(this, myMethod, $root.MyRequest, $root.MyResponse, request, callback);
     }, "name", { value: "MyMethod" });
 
     /**
@@ -222,7 +222,7 @@ $root.MyRequest = (function() {
             long = 0;
         if (long > $util.recursionLimit)
             return "maximum nesting depth exceeded";
-        if (message.path != null && message.hasOwnProperty("path"))
+        if (message.path != null && Object.hasOwnProperty.call(message, "path"))
             if (!$util.isString(message.path))
                 return "path: string expected";
         return null;
@@ -270,7 +270,7 @@ $root.MyRequest = (function() {
         var object = {};
         if (options.defaults)
             object.path = "";
-        if (message.path != null && message.hasOwnProperty("path"))
+        if (message.path != null && Object.hasOwnProperty.call(message, "path"))
             object.path = message.path;
         return object;
     };
@@ -449,7 +449,7 @@ $root.MyResponse = (function() {
             long = 0;
         if (long > $util.recursionLimit)
             return "maximum nesting depth exceeded";
-        if (message.status != null && message.hasOwnProperty("status"))
+        if (message.status != null && Object.hasOwnProperty.call(message, "status"))
             if (!$util.isInteger(message.status))
                 return "status: integer expected";
         return null;
@@ -497,7 +497,7 @@ $root.MyResponse = (function() {
         var object = {};
         if (options.defaults)
             object.status = 0;
-        if (message.status != null && message.hasOwnProperty("status"))
+        if (message.status != null && Object.hasOwnProperty.call(message, "status"))
             object.status = message.status;
         return object;
     };

--- a/tests/data/test.js
+++ b/tests/data/test.js
@@ -381,7 +381,7 @@ $root.jspb = (function() {
                     long = 0;
                 if (long > $util.recursionLimit)
                     return "maximum nesting depth exceeded";
-                if (message.outerEnum != null && message.hasOwnProperty("outerEnum"))
+                if (message.outerEnum != null && Object.hasOwnProperty.call(message, "outerEnum"))
                     switch (message.outerEnum) {
                     default:
                         return "outerEnum: enum value expected";
@@ -448,7 +448,7 @@ $root.jspb = (function() {
                 var object = {};
                 if (options.defaults)
                     object.outerEnum = options.enums === String ? "FOO" : 1;
-                if (message.outerEnum != null && message.hasOwnProperty("outerEnum"))
+                if (message.outerEnum != null && Object.hasOwnProperty.call(message, "outerEnum"))
                     object.outerEnum = options.enums === String ? $root.jspb.test.OuterEnum[message.outerEnum] === undefined ? message.outerEnum : $root.jspb.test.OuterEnum[message.outerEnum] : message.outerEnum;
                 return object;
             };
@@ -626,7 +626,7 @@ $root.jspb = (function() {
                         break;
                     }
                 }
-                if (!message.hasOwnProperty("aString"))
+                if (!Object.hasOwnProperty.call(message, "aString"))
                     throw $util.ProtocolError("missing required 'aString'", { instance: message });
                 return message;
             };
@@ -664,14 +664,14 @@ $root.jspb = (function() {
                     return "maximum nesting depth exceeded";
                 if (!$util.isString(message.aString))
                     return "aString: string expected";
-                if (message.aRepeatedString != null && message.hasOwnProperty("aRepeatedString")) {
+                if (message.aRepeatedString != null && Object.hasOwnProperty.call(message, "aRepeatedString")) {
                     if (!Array.isArray(message.aRepeatedString))
                         return "aRepeatedString: array expected";
                     for (var i = 0; i < message.aRepeatedString.length; ++i)
                         if (!$util.isString(message.aRepeatedString[i]))
                             return "aRepeatedString: string[] expected";
                 }
-                if (message.aBoolean != null && message.hasOwnProperty("aBoolean"))
+                if (message.aBoolean != null && Object.hasOwnProperty.call(message, "aBoolean"))
                     if (typeof message.aBoolean !== "boolean")
                         return "aBoolean: boolean expected";
                 return null;
@@ -732,14 +732,14 @@ $root.jspb = (function() {
                     object.aString = "";
                     object.aBoolean = false;
                 }
-                if (message.aString != null && message.hasOwnProperty("aString"))
+                if (message.aString != null && Object.hasOwnProperty.call(message, "aString"))
                     object.aString = message.aString;
                 if (message.aRepeatedString && message.aRepeatedString.length) {
                     object.aRepeatedString = [];
                     for (var j = 0; j < message.aRepeatedString.length; ++j)
                         object.aRepeatedString[j] = message.aRepeatedString[j];
                 }
-                if (message.aBoolean != null && message.hasOwnProperty("aBoolean"))
+                if (message.aBoolean != null && Object.hasOwnProperty.call(message, "aBoolean"))
                     object.aBoolean = message.aBoolean;
                 return object;
             };
@@ -902,7 +902,7 @@ $root.jspb = (function() {
                         break;
                     }
                 }
-                if (!message.hasOwnProperty("aString"))
+                if (!Object.hasOwnProperty.call(message, "aString"))
                     throw $util.ProtocolError("missing required 'aString'", { instance: message });
                 return message;
             };
@@ -940,7 +940,7 @@ $root.jspb = (function() {
                     return "maximum nesting depth exceeded";
                 if (!$util.isString(message.aString))
                     return "aString: string expected";
-                if (message.aRepeatedString != null && message.hasOwnProperty("aRepeatedString")) {
+                if (message.aRepeatedString != null && Object.hasOwnProperty.call(message, "aRepeatedString")) {
                     if (!Array.isArray(message.aRepeatedString))
                         return "aRepeatedString: array expected";
                     for (var i = 0; i < message.aRepeatedString.length; ++i)
@@ -1001,7 +1001,7 @@ $root.jspb = (function() {
                     object.aRepeatedString = [];
                 if (options.defaults)
                     object.aString = "";
-                if (message.aString != null && message.hasOwnProperty("aString"))
+                if (message.aString != null && Object.hasOwnProperty.call(message, "aString"))
                     object.aString = message.aString;
                 if (message.aRepeatedString && message.aRepeatedString.length) {
                     object.aRepeatedString = [];
@@ -1192,13 +1192,13 @@ $root.jspb = (function() {
                         break;
                     }
                 }
-                if (!message.hasOwnProperty("normal"))
+                if (!Object.hasOwnProperty.call(message, "normal"))
                     throw $util.ProtocolError("missing required 'normal'", { instance: message });
-                if (!message.hasOwnProperty("default"))
+                if (!Object.hasOwnProperty.call(message, "default"))
                     throw $util.ProtocolError("missing required 'default'", { instance: message });
-                if (!message.hasOwnProperty("function"))
+                if (!Object.hasOwnProperty.call(message, "function"))
                     throw $util.ProtocolError("missing required 'function'", { instance: message });
-                if (!message.hasOwnProperty("var"))
+                if (!Object.hasOwnProperty.call(message, "var"))
                     throw $util.ProtocolError("missing required 'var'", { instance: message });
                 return message;
             };
@@ -1297,13 +1297,13 @@ $root.jspb = (function() {
                     object["function"] = "";
                     object["var"] = "";
                 }
-                if (message.normal != null && message.hasOwnProperty("normal"))
+                if (message.normal != null && Object.hasOwnProperty.call(message, "normal"))
                     object.normal = message.normal;
-                if (message["default"] != null && message.hasOwnProperty("default"))
+                if (message["default"] != null && Object.hasOwnProperty.call(message, "default"))
                     object["default"] = message["default"];
-                if (message["function"] != null && message.hasOwnProperty("function"))
+                if (message["function"] != null && Object.hasOwnProperty.call(message, "function"))
                     object["function"] = message["function"];
-                if (message["var"] != null && message.hasOwnProperty("var"))
+                if (message["var"] != null && Object.hasOwnProperty.call(message, "var"))
                     object["var"] = message["var"];
                 return object;
             };
@@ -1515,7 +1515,7 @@ $root.jspb = (function() {
                         break;
                     }
                 }
-                if (!message.hasOwnProperty("aBool"))
+                if (!Object.hasOwnProperty.call(message, "aBool"))
                     throw $util.ProtocolError("missing required 'aBool'", { instance: message });
                 return message;
             };
@@ -1551,17 +1551,17 @@ $root.jspb = (function() {
                     long = 0;
                 if (long > $util.recursionLimit)
                     return "maximum nesting depth exceeded";
-                if (message.aString != null && message.hasOwnProperty("aString"))
+                if (message.aString != null && Object.hasOwnProperty.call(message, "aString"))
                     if (!$util.isString(message.aString))
                         return "aString: string expected";
                 if (typeof message.aBool !== "boolean")
                     return "aBool: boolean expected";
-                if (message.aNestedMessage != null && message.hasOwnProperty("aNestedMessage")) {
+                if (message.aNestedMessage != null && Object.hasOwnProperty.call(message, "aNestedMessage")) {
                     var error = $root.jspb.test.OptionalFields.Nested.verify(message.aNestedMessage, long + 1);
                     if (error)
                         return "aNestedMessage." + error;
                 }
-                if (message.aRepeatedMessage != null && message.hasOwnProperty("aRepeatedMessage")) {
+                if (message.aRepeatedMessage != null && Object.hasOwnProperty.call(message, "aRepeatedMessage")) {
                     if (!Array.isArray(message.aRepeatedMessage))
                         return "aRepeatedMessage: array expected";
                     for (var i = 0; i < message.aRepeatedMessage.length; ++i) {
@@ -1570,7 +1570,7 @@ $root.jspb = (function() {
                             return "aRepeatedMessage." + error;
                     }
                 }
-                if (message.aRepeatedString != null && message.hasOwnProperty("aRepeatedString")) {
+                if (message.aRepeatedString != null && Object.hasOwnProperty.call(message, "aRepeatedString")) {
                     if (!Array.isArray(message.aRepeatedString))
                         return "aRepeatedString: array expected";
                     for (var i = 0; i < message.aRepeatedString.length; ++i)
@@ -1653,11 +1653,11 @@ $root.jspb = (function() {
                     object.aBool = false;
                     object.aNestedMessage = null;
                 }
-                if (message.aString != null && message.hasOwnProperty("aString"))
+                if (message.aString != null && Object.hasOwnProperty.call(message, "aString"))
                     object.aString = message.aString;
-                if (message.aBool != null && message.hasOwnProperty("aBool"))
+                if (message.aBool != null && Object.hasOwnProperty.call(message, "aBool"))
                     object.aBool = message.aBool;
-                if (message.aNestedMessage != null && message.hasOwnProperty("aNestedMessage"))
+                if (message.aNestedMessage != null && Object.hasOwnProperty.call(message, "aNestedMessage"))
                     object.aNestedMessage = $root.jspb.test.OptionalFields.Nested.toObject(message.aNestedMessage, options, q + 1);
                 if (message.aRepeatedMessage && message.aRepeatedMessage.length) {
                     object.aRepeatedMessage = [];
@@ -1843,7 +1843,7 @@ $root.jspb = (function() {
                         long = 0;
                     if (long > $util.recursionLimit)
                         return "maximum nesting depth exceeded";
-                    if (message.anInt != null && message.hasOwnProperty("anInt"))
+                    if (message.anInt != null && Object.hasOwnProperty.call(message, "anInt"))
                         if (!$util.isInteger(message.anInt))
                             return "anInt: integer expected";
                     return null;
@@ -1891,7 +1891,7 @@ $root.jspb = (function() {
                     var object = {};
                     if (options.defaults)
                         object.anInt = 0;
-                    if (message.anInt != null && message.hasOwnProperty("anInt"))
+                    if (message.anInt != null && Object.hasOwnProperty.call(message, "anInt"))
                         object.anInt = message.anInt;
                     return object;
                 };
@@ -2201,36 +2201,36 @@ $root.jspb = (function() {
                     long = 0;
                 if (long > $util.recursionLimit)
                     return "maximum nesting depth exceeded";
-                if (message.str1 != null && message.hasOwnProperty("str1"))
+                if (message.str1 != null && Object.hasOwnProperty.call(message, "str1"))
                     if (!$util.isString(message.str1))
                         return "str1: string expected";
-                if (message.str2 != null && message.hasOwnProperty("str2"))
+                if (message.str2 != null && Object.hasOwnProperty.call(message, "str2"))
                     if (!$util.isString(message.str2))
                         return "str2: string expected";
-                if (message.str3 != null && message.hasOwnProperty("str3"))
+                if (message.str3 != null && Object.hasOwnProperty.call(message, "str3"))
                     if (!$util.isString(message.str3))
                         return "str3: string expected";
-                if (message[".jspb.test.IsExtension.extField"] != null && message.hasOwnProperty(".jspb.test.IsExtension.extField")) {
+                if (message[".jspb.test.IsExtension.extField"] != null && Object.hasOwnProperty.call(message, ".jspb.test.IsExtension.extField")) {
                     var error = $root.jspb.test.IsExtension.verify(message[".jspb.test.IsExtension.extField"], long + 1);
                     if (error)
                         return ".jspb.test.IsExtension.extField." + error;
                 }
-                if (message[".jspb.test.IndirectExtension.simple"] != null && message.hasOwnProperty(".jspb.test.IndirectExtension.simple")) {
+                if (message[".jspb.test.IndirectExtension.simple"] != null && Object.hasOwnProperty.call(message, ".jspb.test.IndirectExtension.simple")) {
                     var error = $root.jspb.test.Simple1.verify(message[".jspb.test.IndirectExtension.simple"], long + 1);
                     if (error)
                         return ".jspb.test.IndirectExtension.simple." + error;
                 }
-                if (message[".jspb.test.IndirectExtension.str"] != null && message.hasOwnProperty(".jspb.test.IndirectExtension.str"))
+                if (message[".jspb.test.IndirectExtension.str"] != null && Object.hasOwnProperty.call(message, ".jspb.test.IndirectExtension.str"))
                     if (!$util.isString(message[".jspb.test.IndirectExtension.str"]))
                         return ".jspb.test.IndirectExtension.str: string expected";
-                if (message[".jspb.test.IndirectExtension.repeatedStr"] != null && message.hasOwnProperty(".jspb.test.IndirectExtension.repeatedStr")) {
+                if (message[".jspb.test.IndirectExtension.repeatedStr"] != null && Object.hasOwnProperty.call(message, ".jspb.test.IndirectExtension.repeatedStr")) {
                     if (!Array.isArray(message[".jspb.test.IndirectExtension.repeatedStr"]))
                         return ".jspb.test.IndirectExtension.repeatedStr: array expected";
                     for (var i = 0; i < message[".jspb.test.IndirectExtension.repeatedStr"].length; ++i)
                         if (!$util.isString(message[".jspb.test.IndirectExtension.repeatedStr"][i]))
                             return ".jspb.test.IndirectExtension.repeatedStr: string[] expected";
                 }
-                if (message[".jspb.test.IndirectExtension.repeatedSimple"] != null && message.hasOwnProperty(".jspb.test.IndirectExtension.repeatedSimple")) {
+                if (message[".jspb.test.IndirectExtension.repeatedSimple"] != null && Object.hasOwnProperty.call(message, ".jspb.test.IndirectExtension.repeatedSimple")) {
                     if (!Array.isArray(message[".jspb.test.IndirectExtension.repeatedSimple"]))
                         return ".jspb.test.IndirectExtension.repeatedSimple: array expected";
                     for (var i = 0; i < message[".jspb.test.IndirectExtension.repeatedSimple"].length; ++i) {
@@ -2239,7 +2239,7 @@ $root.jspb = (function() {
                             return ".jspb.test.IndirectExtension.repeatedSimple." + error;
                     }
                 }
-                if (message[".jspb.test.simple1"] != null && message.hasOwnProperty(".jspb.test.simple1")) {
+                if (message[".jspb.test.simple1"] != null && Object.hasOwnProperty.call(message, ".jspb.test.simple1")) {
                     var error = $root.jspb.test.Simple1.verify(message[".jspb.test.simple1"], long + 1);
                     if (error)
                         return ".jspb.test.simple1." + error;
@@ -2338,17 +2338,17 @@ $root.jspb = (function() {
                     object[".jspb.test.IndirectExtension.str"] = "";
                     object[".jspb.test.simple1"] = null;
                 }
-                if (message.str1 != null && message.hasOwnProperty("str1"))
+                if (message.str1 != null && Object.hasOwnProperty.call(message, "str1"))
                     object.str1 = message.str1;
-                if (message.str2 != null && message.hasOwnProperty("str2"))
+                if (message.str2 != null && Object.hasOwnProperty.call(message, "str2"))
                     object.str2 = message.str2;
-                if (message.str3 != null && message.hasOwnProperty("str3"))
+                if (message.str3 != null && Object.hasOwnProperty.call(message, "str3"))
                     object.str3 = message.str3;
-                if (message[".jspb.test.IsExtension.extField"] != null && message.hasOwnProperty(".jspb.test.IsExtension.extField"))
+                if (message[".jspb.test.IsExtension.extField"] != null && Object.hasOwnProperty.call(message, ".jspb.test.IsExtension.extField"))
                     object[".jspb.test.IsExtension.extField"] = $root.jspb.test.IsExtension.toObject(message[".jspb.test.IsExtension.extField"], options, q + 1);
-                if (message[".jspb.test.IndirectExtension.simple"] != null && message.hasOwnProperty(".jspb.test.IndirectExtension.simple"))
+                if (message[".jspb.test.IndirectExtension.simple"] != null && Object.hasOwnProperty.call(message, ".jspb.test.IndirectExtension.simple"))
                     object[".jspb.test.IndirectExtension.simple"] = $root.jspb.test.Simple1.toObject(message[".jspb.test.IndirectExtension.simple"], options, q + 1);
-                if (message[".jspb.test.IndirectExtension.str"] != null && message.hasOwnProperty(".jspb.test.IndirectExtension.str"))
+                if (message[".jspb.test.IndirectExtension.str"] != null && Object.hasOwnProperty.call(message, ".jspb.test.IndirectExtension.str"))
                     object[".jspb.test.IndirectExtension.str"] = message[".jspb.test.IndirectExtension.str"];
                 if (message[".jspb.test.IndirectExtension.repeatedStr"] && message[".jspb.test.IndirectExtension.repeatedStr"].length) {
                     object[".jspb.test.IndirectExtension.repeatedStr"] = [];
@@ -2360,7 +2360,7 @@ $root.jspb = (function() {
                     for (var j = 0; j < message[".jspb.test.IndirectExtension.repeatedSimple"].length; ++j)
                         object[".jspb.test.IndirectExtension.repeatedSimple"][j] = $root.jspb.test.Simple1.toObject(message[".jspb.test.IndirectExtension.repeatedSimple"][j], options, q + 1);
                 }
-                if (message[".jspb.test.simple1"] != null && message.hasOwnProperty(".jspb.test.simple1"))
+                if (message[".jspb.test.simple1"] != null && Object.hasOwnProperty.call(message, ".jspb.test.simple1"))
                     object[".jspb.test.simple1"] = $root.jspb.test.Simple1.toObject(message[".jspb.test.simple1"], options, q + 1);
                 return object;
             };
@@ -2571,9 +2571,9 @@ $root.jspb = (function() {
                         break;
                     }
                 }
-                if (!message.hasOwnProperty("aString"))
+                if (!Object.hasOwnProperty.call(message, "aString"))
                     throw $util.ProtocolError("missing required 'aString'", { instance: message });
-                if (!message.hasOwnProperty("anOutOfOrderBool"))
+                if (!Object.hasOwnProperty.call(message, "anOutOfOrderBool"))
                     throw $util.ProtocolError("missing required 'anOutOfOrderBool'", { instance: message });
                 return message;
             };
@@ -2613,12 +2613,12 @@ $root.jspb = (function() {
                     return "aString: string expected";
                 if (typeof message.anOutOfOrderBool !== "boolean")
                     return "anOutOfOrderBool: boolean expected";
-                if (message.aNestedMessage != null && message.hasOwnProperty("aNestedMessage")) {
+                if (message.aNestedMessage != null && Object.hasOwnProperty.call(message, "aNestedMessage")) {
                     var error = $root.jspb.test.Complex.Nested.verify(message.aNestedMessage, long + 1);
                     if (error)
                         return "aNestedMessage." + error;
                 }
-                if (message.aRepeatedMessage != null && message.hasOwnProperty("aRepeatedMessage")) {
+                if (message.aRepeatedMessage != null && Object.hasOwnProperty.call(message, "aRepeatedMessage")) {
                     if (!Array.isArray(message.aRepeatedMessage))
                         return "aRepeatedMessage: array expected";
                     for (var i = 0; i < message.aRepeatedMessage.length; ++i) {
@@ -2627,7 +2627,7 @@ $root.jspb = (function() {
                             return "aRepeatedMessage." + error;
                     }
                 }
-                if (message.aRepeatedString != null && message.hasOwnProperty("aRepeatedString")) {
+                if (message.aRepeatedString != null && Object.hasOwnProperty.call(message, "aRepeatedString")) {
                     if (!Array.isArray(message.aRepeatedString))
                         return "aRepeatedString: array expected";
                     for (var i = 0; i < message.aRepeatedString.length; ++i)
@@ -2710,9 +2710,9 @@ $root.jspb = (function() {
                     object.aNestedMessage = null;
                     object.anOutOfOrderBool = false;
                 }
-                if (message.aString != null && message.hasOwnProperty("aString"))
+                if (message.aString != null && Object.hasOwnProperty.call(message, "aString"))
                     object.aString = message.aString;
-                if (message.aNestedMessage != null && message.hasOwnProperty("aNestedMessage"))
+                if (message.aNestedMessage != null && Object.hasOwnProperty.call(message, "aNestedMessage"))
                     object.aNestedMessage = $root.jspb.test.Complex.Nested.toObject(message.aNestedMessage, options, q + 1);
                 if (message.aRepeatedMessage && message.aRepeatedMessage.length) {
                     object.aRepeatedMessage = [];
@@ -2724,7 +2724,7 @@ $root.jspb = (function() {
                     for (var j = 0; j < message.aRepeatedString.length; ++j)
                         object.aRepeatedString[j] = message.aRepeatedString[j];
                 }
-                if (message.anOutOfOrderBool != null && message.hasOwnProperty("anOutOfOrderBool"))
+                if (message.anOutOfOrderBool != null && Object.hasOwnProperty.call(message, "anOutOfOrderBool"))
                     object.anOutOfOrderBool = message.anOutOfOrderBool;
                 return object;
             };
@@ -2865,7 +2865,7 @@ $root.jspb = (function() {
                             break;
                         }
                     }
-                    if (!message.hasOwnProperty("anInt"))
+                    if (!Object.hasOwnProperty.call(message, "anInt"))
                         throw $util.ProtocolError("missing required 'anInt'", { instance: message });
                     return message;
                 };
@@ -2948,7 +2948,7 @@ $root.jspb = (function() {
                     var object = {};
                     if (options.defaults)
                         object.anInt = 0;
-                    if (message.anInt != null && message.hasOwnProperty("anInt"))
+                    if (message.anInt != null && Object.hasOwnProperty.call(message, "anInt"))
                         object.anInt = message.anInt;
                     return object;
                 };
@@ -3322,7 +3322,7 @@ $root.jspb = (function() {
                         long = 0;
                     if (long > $util.recursionLimit)
                         return "maximum nesting depth exceeded";
-                    if (message.innerComplexField != null && message.hasOwnProperty("innerComplexField"))
+                    if (message.innerComplexField != null && Object.hasOwnProperty.call(message, "innerComplexField"))
                         if (!$util.isInteger(message.innerComplexField))
                             return "innerComplexField: integer expected";
                     return null;
@@ -3370,7 +3370,7 @@ $root.jspb = (function() {
                     var object = {};
                     if (options.defaults)
                         object.innerComplexField = 0;
-                    if (message.innerComplexField != null && message.hasOwnProperty("innerComplexField"))
+                    if (message.innerComplexField != null && Object.hasOwnProperty.call(message, "innerComplexField"))
                         object.innerComplexField = message.innerComplexField;
                     return object;
                 };
@@ -3552,7 +3552,7 @@ $root.jspb = (function() {
                     long = 0;
                 if (long > $util.recursionLimit)
                     return "maximum nesting depth exceeded";
-                if (message.ext1 != null && message.hasOwnProperty("ext1"))
+                if (message.ext1 != null && Object.hasOwnProperty.call(message, "ext1"))
                     if (!$util.isString(message.ext1))
                         return "ext1: string expected";
                 return null;
@@ -3600,7 +3600,7 @@ $root.jspb = (function() {
                 var object = {};
                 if (options.defaults)
                     object.ext1 = "";
-                if (message.ext1 != null && message.hasOwnProperty("ext1"))
+                if (message.ext1 != null && Object.hasOwnProperty.call(message, "ext1"))
                     object.ext1 = message.ext1;
                 return object;
             };
@@ -4049,16 +4049,16 @@ $root.jspb = (function() {
                     long = 0;
                 if (long > $util.recursionLimit)
                     return "maximum nesting depth exceeded";
-                if (message.stringField != null && message.hasOwnProperty("stringField"))
+                if (message.stringField != null && Object.hasOwnProperty.call(message, "stringField"))
                     if (!$util.isString(message.stringField))
                         return "stringField: string expected";
-                if (message.boolField != null && message.hasOwnProperty("boolField"))
+                if (message.boolField != null && Object.hasOwnProperty.call(message, "boolField"))
                     if (typeof message.boolField !== "boolean")
                         return "boolField: boolean expected";
-                if (message.intField != null && message.hasOwnProperty("intField"))
+                if (message.intField != null && Object.hasOwnProperty.call(message, "intField"))
                     if (!$util.isInteger(message.intField) && !(message.intField && $util.isInteger(message.intField.low) && $util.isInteger(message.intField.high)))
                         return "intField: integer|Long expected";
-                if (message.enumField != null && message.hasOwnProperty("enumField"))
+                if (message.enumField != null && Object.hasOwnProperty.call(message, "enumField"))
                     switch (message.enumField) {
                     default:
                         return "enumField: enum value expected";
@@ -4066,10 +4066,10 @@ $root.jspb = (function() {
                     case 77:
                         break;
                     }
-                if (message.emptyField != null && message.hasOwnProperty("emptyField"))
+                if (message.emptyField != null && Object.hasOwnProperty.call(message, "emptyField"))
                     if (!$util.isString(message.emptyField))
                         return "emptyField: string expected";
-                if (message.bytesField != null && message.hasOwnProperty("bytesField"))
+                if (message.bytesField != null && Object.hasOwnProperty.call(message, "bytesField"))
                     if (!(message.bytesField && typeof message.bytesField.length === "number" || $util.isString(message.bytesField)))
                         return "bytesField: buffer expected";
                 return null;
@@ -4171,22 +4171,22 @@ $root.jspb = (function() {
                             object.bytesField = $util.newBuffer(object.bytesField);
                     }
                 }
-                if (message.stringField != null && message.hasOwnProperty("stringField"))
+                if (message.stringField != null && Object.hasOwnProperty.call(message, "stringField"))
                     object.stringField = message.stringField;
-                if (message.boolField != null && message.hasOwnProperty("boolField"))
+                if (message.boolField != null && Object.hasOwnProperty.call(message, "boolField"))
                     object.boolField = message.boolField;
-                if (message.intField != null && message.hasOwnProperty("intField"))
+                if (message.intField != null && Object.hasOwnProperty.call(message, "intField"))
                     if (typeof BigInt !== "undefined" && options.longs === BigInt)
                         object.intField = typeof message.intField === "number" ? BigInt(message.intField) : $util.Long.fromBits(message.intField.low >>> 0, message.intField.high >>> 0, false).toBigInt();
                     else if (typeof message.intField === "number")
                         object.intField = options.longs === String ? String(message.intField) : message.intField;
                     else
                         object.intField = options.longs === String ? $util.Long.prototype.toString.call(message.intField) : options.longs === Number ? new $util.LongBits(message.intField.low >>> 0, message.intField.high >>> 0).toNumber() : message.intField;
-                if (message.enumField != null && message.hasOwnProperty("enumField"))
+                if (message.enumField != null && Object.hasOwnProperty.call(message, "enumField"))
                     object.enumField = options.enums === String ? $root.jspb.test.DefaultValues.Enum[message.enumField] === undefined ? message.enumField : $root.jspb.test.DefaultValues.Enum[message.enumField] : message.enumField;
-                if (message.emptyField != null && message.hasOwnProperty("emptyField"))
+                if (message.emptyField != null && Object.hasOwnProperty.call(message, "emptyField"))
                     object.emptyField = message.emptyField;
-                if (message.bytesField != null && message.hasOwnProperty("bytesField"))
+                if (message.bytesField != null && Object.hasOwnProperty.call(message, "bytesField"))
                     object.bytesField = options.bytes === String ? $util.base64.encode(message.bytesField, 0, message.bytesField.length) : options.bytes === Array ? Array.prototype.slice.call(message.bytesField) : message.bytesField;
                 return object;
             };
@@ -4466,9 +4466,9 @@ $root.jspb = (function() {
                         break;
                     }
                 }
-                if (!message.hasOwnProperty("requiredFloatField"))
+                if (!Object.hasOwnProperty.call(message, "requiredFloatField"))
                     throw $util.ProtocolError("missing required 'requiredFloatField'", { instance: message });
-                if (!message.hasOwnProperty("requiredDoubleField"))
+                if (!Object.hasOwnProperty.call(message, "requiredDoubleField"))
                     throw $util.ProtocolError("missing required 'requiredDoubleField'", { instance: message });
                 return message;
             };
@@ -4504,34 +4504,34 @@ $root.jspb = (function() {
                     long = 0;
                 if (long > $util.recursionLimit)
                     return "maximum nesting depth exceeded";
-                if (message.optionalFloatField != null && message.hasOwnProperty("optionalFloatField"))
+                if (message.optionalFloatField != null && Object.hasOwnProperty.call(message, "optionalFloatField"))
                     if (typeof message.optionalFloatField !== "number")
                         return "optionalFloatField: number expected";
                 if (typeof message.requiredFloatField !== "number")
                     return "requiredFloatField: number expected";
-                if (message.repeatedFloatField != null && message.hasOwnProperty("repeatedFloatField")) {
+                if (message.repeatedFloatField != null && Object.hasOwnProperty.call(message, "repeatedFloatField")) {
                     if (!Array.isArray(message.repeatedFloatField))
                         return "repeatedFloatField: array expected";
                     for (var i = 0; i < message.repeatedFloatField.length; ++i)
                         if (typeof message.repeatedFloatField[i] !== "number")
                             return "repeatedFloatField: number[] expected";
                 }
-                if (message.defaultFloatField != null && message.hasOwnProperty("defaultFloatField"))
+                if (message.defaultFloatField != null && Object.hasOwnProperty.call(message, "defaultFloatField"))
                     if (typeof message.defaultFloatField !== "number")
                         return "defaultFloatField: number expected";
-                if (message.optionalDoubleField != null && message.hasOwnProperty("optionalDoubleField"))
+                if (message.optionalDoubleField != null && Object.hasOwnProperty.call(message, "optionalDoubleField"))
                     if (typeof message.optionalDoubleField !== "number")
                         return "optionalDoubleField: number expected";
                 if (typeof message.requiredDoubleField !== "number")
                     return "requiredDoubleField: number expected";
-                if (message.repeatedDoubleField != null && message.hasOwnProperty("repeatedDoubleField")) {
+                if (message.repeatedDoubleField != null && Object.hasOwnProperty.call(message, "repeatedDoubleField")) {
                     if (!Array.isArray(message.repeatedDoubleField))
                         return "repeatedDoubleField: array expected";
                     for (var i = 0; i < message.repeatedDoubleField.length; ++i)
                         if (typeof message.repeatedDoubleField[i] !== "number")
                             return "repeatedDoubleField: number[] expected";
                 }
-                if (message.defaultDoubleField != null && message.hasOwnProperty("defaultDoubleField"))
+                if (message.defaultDoubleField != null && Object.hasOwnProperty.call(message, "defaultDoubleField"))
                     if (typeof message.defaultDoubleField !== "number")
                         return "defaultDoubleField: number expected";
                 return null;
@@ -4613,27 +4613,27 @@ $root.jspb = (function() {
                     object.requiredDoubleField = 0;
                     object.defaultDoubleField = 2;
                 }
-                if (message.optionalFloatField != null && message.hasOwnProperty("optionalFloatField"))
+                if (message.optionalFloatField != null && Object.hasOwnProperty.call(message, "optionalFloatField"))
                     object.optionalFloatField = options.json && !isFinite(message.optionalFloatField) ? String(message.optionalFloatField) : message.optionalFloatField;
-                if (message.requiredFloatField != null && message.hasOwnProperty("requiredFloatField"))
+                if (message.requiredFloatField != null && Object.hasOwnProperty.call(message, "requiredFloatField"))
                     object.requiredFloatField = options.json && !isFinite(message.requiredFloatField) ? String(message.requiredFloatField) : message.requiredFloatField;
                 if (message.repeatedFloatField && message.repeatedFloatField.length) {
                     object.repeatedFloatField = [];
                     for (var j = 0; j < message.repeatedFloatField.length; ++j)
                         object.repeatedFloatField[j] = options.json && !isFinite(message.repeatedFloatField[j]) ? String(message.repeatedFloatField[j]) : message.repeatedFloatField[j];
                 }
-                if (message.defaultFloatField != null && message.hasOwnProperty("defaultFloatField"))
+                if (message.defaultFloatField != null && Object.hasOwnProperty.call(message, "defaultFloatField"))
                     object.defaultFloatField = options.json && !isFinite(message.defaultFloatField) ? String(message.defaultFloatField) : message.defaultFloatField;
-                if (message.optionalDoubleField != null && message.hasOwnProperty("optionalDoubleField"))
+                if (message.optionalDoubleField != null && Object.hasOwnProperty.call(message, "optionalDoubleField"))
                     object.optionalDoubleField = options.json && !isFinite(message.optionalDoubleField) ? String(message.optionalDoubleField) : message.optionalDoubleField;
-                if (message.requiredDoubleField != null && message.hasOwnProperty("requiredDoubleField"))
+                if (message.requiredDoubleField != null && Object.hasOwnProperty.call(message, "requiredDoubleField"))
                     object.requiredDoubleField = options.json && !isFinite(message.requiredDoubleField) ? String(message.requiredDoubleField) : message.requiredDoubleField;
                 if (message.repeatedDoubleField && message.repeatedDoubleField.length) {
                     object.repeatedDoubleField = [];
                     for (var j = 0; j < message.repeatedDoubleField.length; ++j)
                         object.repeatedDoubleField[j] = options.json && !isFinite(message.repeatedDoubleField[j]) ? String(message.repeatedDoubleField[j]) : message.repeatedDoubleField[j];
                 }
-                if (message.defaultDoubleField != null && message.hasOwnProperty("defaultDoubleField"))
+                if (message.defaultDoubleField != null && Object.hasOwnProperty.call(message, "defaultDoubleField"))
                     object.defaultDoubleField = options.json && !isFinite(message.defaultDoubleField) ? String(message.defaultDoubleField) : message.defaultDoubleField;
                 return object;
             };
@@ -4891,15 +4891,15 @@ $root.jspb = (function() {
                     long = 0;
                 if (long > $util.recursionLimit)
                     return "maximum nesting depth exceeded";
-                if (message.str != null && message.hasOwnProperty("str"))
+                if (message.str != null && Object.hasOwnProperty.call(message, "str"))
                     if (!$util.isString(message.str))
                         return "str: string expected";
-                if (message.simple1 != null && message.hasOwnProperty("simple1")) {
+                if (message.simple1 != null && Object.hasOwnProperty.call(message, "simple1")) {
                     var error = $root.jspb.test.Simple1.verify(message.simple1, long + 1);
                     if (error)
                         return "simple1." + error;
                 }
-                if (message.simple2 != null && message.hasOwnProperty("simple2")) {
+                if (message.simple2 != null && Object.hasOwnProperty.call(message, "simple2")) {
                     if (!Array.isArray(message.simple2))
                         return "simple2: array expected";
                     for (var i = 0; i < message.simple2.length; ++i) {
@@ -4908,13 +4908,13 @@ $root.jspb = (function() {
                             return "simple2." + error;
                     }
                 }
-                if (message.bytesField != null && message.hasOwnProperty("bytesField"))
+                if (message.bytesField != null && Object.hasOwnProperty.call(message, "bytesField"))
                     if (!(message.bytesField && typeof message.bytesField.length === "number" || $util.isString(message.bytesField)))
                         return "bytesField: buffer expected";
-                if (message.unused != null && message.hasOwnProperty("unused"))
+                if (message.unused != null && Object.hasOwnProperty.call(message, "unused"))
                     if (!$util.isString(message.unused))
                         return "unused: string expected";
-                if (message[".jspb.test.CloneExtension.extField"] != null && message.hasOwnProperty(".jspb.test.CloneExtension.extField")) {
+                if (message[".jspb.test.CloneExtension.extField"] != null && Object.hasOwnProperty.call(message, ".jspb.test.CloneExtension.extField")) {
                     var error = $root.jspb.test.CloneExtension.verify(message[".jspb.test.CloneExtension.extField"], long + 1);
                     if (error)
                         return ".jspb.test.CloneExtension.extField." + error;
@@ -5004,20 +5004,20 @@ $root.jspb = (function() {
                     object.unused = "";
                     object[".jspb.test.CloneExtension.extField"] = null;
                 }
-                if (message.str != null && message.hasOwnProperty("str"))
+                if (message.str != null && Object.hasOwnProperty.call(message, "str"))
                     object.str = message.str;
-                if (message.simple1 != null && message.hasOwnProperty("simple1"))
+                if (message.simple1 != null && Object.hasOwnProperty.call(message, "simple1"))
                     object.simple1 = $root.jspb.test.Simple1.toObject(message.simple1, options, q + 1);
                 if (message.simple2 && message.simple2.length) {
                     object.simple2 = [];
                     for (var j = 0; j < message.simple2.length; ++j)
                         object.simple2[j] = $root.jspb.test.Simple1.toObject(message.simple2[j], options, q + 1);
                 }
-                if (message.bytesField != null && message.hasOwnProperty("bytesField"))
+                if (message.bytesField != null && Object.hasOwnProperty.call(message, "bytesField"))
                     object.bytesField = options.bytes === String ? $util.base64.encode(message.bytesField, 0, message.bytesField.length) : options.bytes === Array ? Array.prototype.slice.call(message.bytesField) : message.bytesField;
-                if (message.unused != null && message.hasOwnProperty("unused"))
+                if (message.unused != null && Object.hasOwnProperty.call(message, "unused"))
                     object.unused = message.unused;
-                if (message[".jspb.test.CloneExtension.extField"] != null && message.hasOwnProperty(".jspb.test.CloneExtension.extField"))
+                if (message[".jspb.test.CloneExtension.extField"] != null && Object.hasOwnProperty.call(message, ".jspb.test.CloneExtension.extField"))
                     object[".jspb.test.CloneExtension.extField"] = $root.jspb.test.CloneExtension.toObject(message[".jspb.test.CloneExtension.extField"], options, q + 1);
                 return object;
             };
@@ -5196,7 +5196,7 @@ $root.jspb = (function() {
                     long = 0;
                 if (long > $util.recursionLimit)
                     return "maximum nesting depth exceeded";
-                if (message.ext != null && message.hasOwnProperty("ext"))
+                if (message.ext != null && Object.hasOwnProperty.call(message, "ext"))
                     if (!$util.isString(message.ext))
                         return "ext: string expected";
                 return null;
@@ -5244,7 +5244,7 @@ $root.jspb = (function() {
                 var object = {};
                 if (options.defaults)
                     object.ext = "";
-                if (message.ext != null && message.hasOwnProperty("ext"))
+                if (message.ext != null && Object.hasOwnProperty.call(message, "ext"))
                     object.ext = message.ext;
                 return object;
             };
@@ -5496,9 +5496,9 @@ $root.jspb = (function() {
                         break;
                     }
                 }
-                if (!message.hasOwnProperty("requiredGroup"))
+                if (!Object.hasOwnProperty.call(message, "requiredGroup"))
                     throw $util.ProtocolError("missing required 'requiredGroup'", { instance: message });
-                if (!message.hasOwnProperty("requiredSimple"))
+                if (!Object.hasOwnProperty.call(message, "requiredSimple"))
                     throw $util.ProtocolError("missing required 'requiredSimple'", { instance: message });
                 return message;
             };
@@ -5534,7 +5534,7 @@ $root.jspb = (function() {
                     long = 0;
                 if (long > $util.recursionLimit)
                     return "maximum nesting depth exceeded";
-                if (message.repeatedGroup != null && message.hasOwnProperty("repeatedGroup")) {
+                if (message.repeatedGroup != null && Object.hasOwnProperty.call(message, "repeatedGroup")) {
                     if (!Array.isArray(message.repeatedGroup))
                         return "repeatedGroup: array expected";
                     for (var i = 0; i < message.repeatedGroup.length; ++i) {
@@ -5548,22 +5548,22 @@ $root.jspb = (function() {
                     if (error)
                         return "requiredGroup." + error;
                 }
-                if (message.optionalGroup != null && message.hasOwnProperty("optionalGroup")) {
+                if (message.optionalGroup != null && Object.hasOwnProperty.call(message, "optionalGroup")) {
                     var error = $root.jspb.test.TestGroup.OptionalGroup.verify(message.optionalGroup, long + 1);
                     if (error)
                         return "optionalGroup." + error;
                 }
-                if (message.messageInGroup != null && message.hasOwnProperty("messageInGroup")) {
+                if (message.messageInGroup != null && Object.hasOwnProperty.call(message, "messageInGroup")) {
                     var error = $root.jspb.test.TestGroup.MessageInGroup.verify(message.messageInGroup, long + 1);
                     if (error)
                         return "messageInGroup." + error;
                 }
-                if (message.enumInGroup != null && message.hasOwnProperty("enumInGroup")) {
+                if (message.enumInGroup != null && Object.hasOwnProperty.call(message, "enumInGroup")) {
                     var error = $root.jspb.test.TestGroup.EnumInGroup.verify(message.enumInGroup, long + 1);
                     if (error)
                         return "enumInGroup." + error;
                 }
-                if (message.id != null && message.hasOwnProperty("id"))
+                if (message.id != null && Object.hasOwnProperty.call(message, "id"))
                     if (!$util.isString(message.id))
                         return "id: string expected";
                 {
@@ -5571,7 +5571,7 @@ $root.jspb = (function() {
                     if (error)
                         return "requiredSimple." + error;
                 }
-                if (message.optionalSimple != null && message.hasOwnProperty("optionalSimple")) {
+                if (message.optionalSimple != null && Object.hasOwnProperty.call(message, "optionalSimple")) {
                     var error = $root.jspb.test.Simple2.verify(message.optionalSimple, long + 1);
                     if (error)
                         return "optionalSimple." + error;
@@ -5675,19 +5675,19 @@ $root.jspb = (function() {
                     for (var j = 0; j < message.repeatedGroup.length; ++j)
                         object.repeatedGroup[j] = $root.jspb.test.TestGroup.RepeatedGroup.toObject(message.repeatedGroup[j], options, q + 1);
                 }
-                if (message.requiredGroup != null && message.hasOwnProperty("requiredGroup"))
+                if (message.requiredGroup != null && Object.hasOwnProperty.call(message, "requiredGroup"))
                     object.requiredGroup = $root.jspb.test.TestGroup.RequiredGroup.toObject(message.requiredGroup, options, q + 1);
-                if (message.optionalGroup != null && message.hasOwnProperty("optionalGroup"))
+                if (message.optionalGroup != null && Object.hasOwnProperty.call(message, "optionalGroup"))
                     object.optionalGroup = $root.jspb.test.TestGroup.OptionalGroup.toObject(message.optionalGroup, options, q + 1);
-                if (message.messageInGroup != null && message.hasOwnProperty("messageInGroup"))
+                if (message.messageInGroup != null && Object.hasOwnProperty.call(message, "messageInGroup"))
                     object.messageInGroup = $root.jspb.test.TestGroup.MessageInGroup.toObject(message.messageInGroup, options, q + 1);
-                if (message.enumInGroup != null && message.hasOwnProperty("enumInGroup"))
+                if (message.enumInGroup != null && Object.hasOwnProperty.call(message, "enumInGroup"))
                     object.enumInGroup = $root.jspb.test.TestGroup.EnumInGroup.toObject(message.enumInGroup, options, q + 1);
-                if (message.id != null && message.hasOwnProperty("id"))
+                if (message.id != null && Object.hasOwnProperty.call(message, "id"))
                     object.id = message.id;
-                if (message.requiredSimple != null && message.hasOwnProperty("requiredSimple"))
+                if (message.requiredSimple != null && Object.hasOwnProperty.call(message, "requiredSimple"))
                     object.requiredSimple = $root.jspb.test.Simple2.toObject(message.requiredSimple, options, q + 1);
-                if (message.optionalSimple != null && message.hasOwnProperty("optionalSimple"))
+                if (message.optionalSimple != null && Object.hasOwnProperty.call(message, "optionalSimple"))
                     object.optionalSimple = $root.jspb.test.Simple2.toObject(message.optionalSimple, options, q + 1);
                 return object;
             };
@@ -5852,7 +5852,7 @@ $root.jspb = (function() {
                             break;
                         }
                     }
-                    if (!message.hasOwnProperty("id"))
+                    if (!Object.hasOwnProperty.call(message, "id"))
                         throw $util.ProtocolError("missing required 'id'", { instance: message });
                     return message;
                 };
@@ -5890,7 +5890,7 @@ $root.jspb = (function() {
                         return "maximum nesting depth exceeded";
                     if (!$util.isString(message.id))
                         return "id: string expected";
-                    if (message.someBool != null && message.hasOwnProperty("someBool")) {
+                    if (message.someBool != null && Object.hasOwnProperty.call(message, "someBool")) {
                         if (!Array.isArray(message.someBool))
                             return "someBool: array expected";
                         for (var i = 0; i < message.someBool.length; ++i)
@@ -5951,7 +5951,7 @@ $root.jspb = (function() {
                         object.someBool = [];
                     if (options.defaults)
                         object.id = "";
-                    if (message.id != null && message.hasOwnProperty("id"))
+                    if (message.id != null && Object.hasOwnProperty.call(message, "id"))
                         object.id = message.id;
                     if (message.someBool && message.someBool.length) {
                         object.someBool = [];
@@ -6100,7 +6100,7 @@ $root.jspb = (function() {
                             break;
                         }
                     }
-                    if (!message.hasOwnProperty("id"))
+                    if (!Object.hasOwnProperty.call(message, "id"))
                         throw $util.ProtocolError("missing required 'id'", { instance: message });
                     return message;
                 };
@@ -6183,7 +6183,7 @@ $root.jspb = (function() {
                     var object = {};
                     if (options.defaults)
                         object.id = "";
-                    if (message.id != null && message.hasOwnProperty("id"))
+                    if (message.id != null && Object.hasOwnProperty.call(message, "id"))
                         object.id = message.id;
                     return object;
                 };
@@ -6327,7 +6327,7 @@ $root.jspb = (function() {
                             break;
                         }
                     }
-                    if (!message.hasOwnProperty("id"))
+                    if (!Object.hasOwnProperty.call(message, "id"))
                         throw $util.ProtocolError("missing required 'id'", { instance: message });
                     return message;
                 };
@@ -6410,7 +6410,7 @@ $root.jspb = (function() {
                     var object = {};
                     if (options.defaults)
                         object.id = "";
-                    if (message.id != null && message.hasOwnProperty("id"))
+                    if (message.id != null && Object.hasOwnProperty.call(message, "id"))
                         object.id = message.id;
                     return object;
                 };
@@ -6554,7 +6554,7 @@ $root.jspb = (function() {
                             break;
                         }
                     }
-                    if (!message.hasOwnProperty("id"))
+                    if (!Object.hasOwnProperty.call(message, "id"))
                         throw $util.ProtocolError("missing required 'id'", { instance: message });
                     return message;
                 };
@@ -6643,7 +6643,7 @@ $root.jspb = (function() {
                     var object = {};
                     if (options.defaults)
                         object.id = null;
-                    if (message.id != null && message.hasOwnProperty("id"))
+                    if (message.id != null && Object.hasOwnProperty.call(message, "id"))
                         object.id = $root.jspb.test.TestGroup.MessageInGroup.NestedMessage.toObject(message.id, options, q + 1);
                     return object;
                 };
@@ -6819,7 +6819,7 @@ $root.jspb = (function() {
                             long = 0;
                         if (long > $util.recursionLimit)
                             return "maximum nesting depth exceeded";
-                        if (message.id != null && message.hasOwnProperty("id"))
+                        if (message.id != null && Object.hasOwnProperty.call(message, "id"))
                             if (!$util.isString(message.id))
                                 return "id: string expected";
                         return null;
@@ -6867,7 +6867,7 @@ $root.jspb = (function() {
                         var object = {};
                         if (options.defaults)
                             object.id = "";
-                        if (message.id != null && message.hasOwnProperty("id"))
+                        if (message.id != null && Object.hasOwnProperty.call(message, "id"))
                             object.id = message.id;
                         return object;
                     };
@@ -7014,7 +7014,7 @@ $root.jspb = (function() {
                             break;
                         }
                     }
-                    if (!message.hasOwnProperty("id"))
+                    if (!Object.hasOwnProperty.call(message, "id"))
                         throw $util.ProtocolError("missing required 'id'", { instance: message });
                     return message;
                 };
@@ -7116,7 +7116,7 @@ $root.jspb = (function() {
                     var object = {};
                     if (options.defaults)
                         object.id = options.enums === String ? "first" : 0;
-                    if (message.id != null && message.hasOwnProperty("id"))
+                    if (message.id != null && Object.hasOwnProperty.call(message, "id"))
                         object.id = options.enums === String ? $root.jspb.test.TestGroup.EnumInGroup.NestedEnum[message.id] === undefined ? message.id : $root.jspb.test.TestGroup.EnumInGroup.NestedEnum[message.id] : message.id;
                     return object;
                 };
@@ -7312,7 +7312,7 @@ $root.jspb = (function() {
                     long = 0;
                 if (long > $util.recursionLimit)
                     return "maximum nesting depth exceeded";
-                if (message.group != null && message.hasOwnProperty("group")) {
+                if (message.group != null && Object.hasOwnProperty.call(message, "group")) {
                     var error = $root.jspb.test.TestGroup.RepeatedGroup.verify(message.group, long + 1);
                     if (error)
                         return "group." + error;
@@ -7365,7 +7365,7 @@ $root.jspb = (function() {
                 var object = {};
                 if (options.defaults)
                     object.group = null;
-                if (message.group != null && message.hasOwnProperty("group"))
+                if (message.group != null && Object.hasOwnProperty.call(message, "group"))
                     object.group = $root.jspb.test.TestGroup.RepeatedGroup.toObject(message.group, options, q + 1);
                 return object;
             };
@@ -7559,10 +7559,10 @@ $root.jspb = (function() {
                     long = 0;
                 if (long > $util.recursionLimit)
                     return "maximum nesting depth exceeded";
-                if (message.extension != null && message.hasOwnProperty("extension"))
+                if (message.extension != null && Object.hasOwnProperty.call(message, "extension"))
                     if (!$util.isInteger(message.extension))
                         return "extension: integer expected";
-                if (message[".jspb.test.TestReservedNamesExtension.foo"] != null && message.hasOwnProperty(".jspb.test.TestReservedNamesExtension.foo"))
+                if (message[".jspb.test.TestReservedNamesExtension.foo"] != null && Object.hasOwnProperty.call(message, ".jspb.test.TestReservedNamesExtension.foo"))
                     if (!$util.isInteger(message[".jspb.test.TestReservedNamesExtension.foo"]))
                         return ".jspb.test.TestReservedNamesExtension.foo: integer expected";
                 return null;
@@ -7614,9 +7614,9 @@ $root.jspb = (function() {
                     object.extension = 0;
                     object[".jspb.test.TestReservedNamesExtension.foo"] = 0;
                 }
-                if (message.extension != null && message.hasOwnProperty("extension"))
+                if (message.extension != null && Object.hasOwnProperty.call(message, "extension"))
                     object.extension = message.extension;
-                if (message[".jspb.test.TestReservedNamesExtension.foo"] != null && message.hasOwnProperty(".jspb.test.TestReservedNamesExtension.foo"))
+                if (message[".jspb.test.TestReservedNamesExtension.foo"] != null && Object.hasOwnProperty.call(message, ".jspb.test.TestReservedNamesExtension.foo"))
                     object[".jspb.test.TestReservedNamesExtension.foo"] = message[".jspb.test.TestReservedNamesExtension.foo"];
                 return object;
             };
@@ -8177,19 +8177,19 @@ $root.jspb = (function() {
                 if (long > $util.recursionLimit)
                     return "maximum nesting depth exceeded";
                 var properties = {};
-                if (message.pone != null && message.hasOwnProperty("pone")) {
+                if (message.pone != null && Object.hasOwnProperty.call(message, "pone")) {
                     properties.partialOneof = 1;
                     if (!$util.isString(message.pone))
                         return "pone: string expected";
                 }
-                if (message.pthree != null && message.hasOwnProperty("pthree")) {
+                if (message.pthree != null && Object.hasOwnProperty.call(message, "pthree")) {
                     if (properties.partialOneof === 1)
                         return "partialOneof: multiple values";
                     properties.partialOneof = 1;
                     if (!$util.isString(message.pthree))
                         return "pthree: string expected";
                 }
-                if (message.rone != null && message.hasOwnProperty("rone")) {
+                if (message.rone != null && Object.hasOwnProperty.call(message, "rone")) {
                     properties.recursiveOneof = 1;
                     {
                         var error = $root.jspb.test.TestMessageWithOneof.verify(message.rone, long + 1);
@@ -8197,41 +8197,41 @@ $root.jspb = (function() {
                             return "rone." + error;
                     }
                 }
-                if (message.rtwo != null && message.hasOwnProperty("rtwo")) {
+                if (message.rtwo != null && Object.hasOwnProperty.call(message, "rtwo")) {
                     if (properties.recursiveOneof === 1)
                         return "recursiveOneof: multiple values";
                     properties.recursiveOneof = 1;
                     if (!$util.isString(message.rtwo))
                         return "rtwo: string expected";
                 }
-                if (message.normalField != null && message.hasOwnProperty("normalField"))
+                if (message.normalField != null && Object.hasOwnProperty.call(message, "normalField"))
                     if (typeof message.normalField !== "boolean")
                         return "normalField: boolean expected";
-                if (message.repeatedField != null && message.hasOwnProperty("repeatedField")) {
+                if (message.repeatedField != null && Object.hasOwnProperty.call(message, "repeatedField")) {
                     if (!Array.isArray(message.repeatedField))
                         return "repeatedField: array expected";
                     for (var i = 0; i < message.repeatedField.length; ++i)
                         if (!$util.isString(message.repeatedField[i]))
                             return "repeatedField: string[] expected";
                 }
-                if (message.aone != null && message.hasOwnProperty("aone")) {
+                if (message.aone != null && Object.hasOwnProperty.call(message, "aone")) {
                     properties.defaultOneofA = 1;
                     if (!$util.isInteger(message.aone))
                         return "aone: integer expected";
                 }
-                if (message.atwo != null && message.hasOwnProperty("atwo")) {
+                if (message.atwo != null && Object.hasOwnProperty.call(message, "atwo")) {
                     if (properties.defaultOneofA === 1)
                         return "defaultOneofA: multiple values";
                     properties.defaultOneofA = 1;
                     if (!$util.isInteger(message.atwo))
                         return "atwo: integer expected";
                 }
-                if (message.bone != null && message.hasOwnProperty("bone")) {
+                if (message.bone != null && Object.hasOwnProperty.call(message, "bone")) {
                     properties.defaultOneofB = 1;
                     if (!$util.isInteger(message.bone))
                         return "bone: integer expected";
                 }
-                if (message.btwo != null && message.hasOwnProperty("btwo")) {
+                if (message.btwo != null && Object.hasOwnProperty.call(message, "btwo")) {
                     if (properties.defaultOneofB === 1)
                         return "defaultOneofB: multiple values";
                     properties.defaultOneofB = 1;
@@ -8311,49 +8311,49 @@ $root.jspb = (function() {
                     object.repeatedField = [];
                 if (options.defaults)
                     object.normalField = false;
-                if (message.pone != null && message.hasOwnProperty("pone")) {
+                if (message.pone != null && Object.hasOwnProperty.call(message, "pone")) {
                     object.pone = message.pone;
                     if (options.oneofs)
                         object.partialOneof = "pone";
                 }
-                if (message.pthree != null && message.hasOwnProperty("pthree")) {
+                if (message.pthree != null && Object.hasOwnProperty.call(message, "pthree")) {
                     object.pthree = message.pthree;
                     if (options.oneofs)
                         object.partialOneof = "pthree";
                 }
-                if (message.rone != null && message.hasOwnProperty("rone")) {
+                if (message.rone != null && Object.hasOwnProperty.call(message, "rone")) {
                     object.rone = $root.jspb.test.TestMessageWithOneof.toObject(message.rone, options, q + 1);
                     if (options.oneofs)
                         object.recursiveOneof = "rone";
                 }
-                if (message.rtwo != null && message.hasOwnProperty("rtwo")) {
+                if (message.rtwo != null && Object.hasOwnProperty.call(message, "rtwo")) {
                     object.rtwo = message.rtwo;
                     if (options.oneofs)
                         object.recursiveOneof = "rtwo";
                 }
-                if (message.normalField != null && message.hasOwnProperty("normalField"))
+                if (message.normalField != null && Object.hasOwnProperty.call(message, "normalField"))
                     object.normalField = message.normalField;
                 if (message.repeatedField && message.repeatedField.length) {
                     object.repeatedField = [];
                     for (var j = 0; j < message.repeatedField.length; ++j)
                         object.repeatedField[j] = message.repeatedField[j];
                 }
-                if (message.aone != null && message.hasOwnProperty("aone")) {
+                if (message.aone != null && Object.hasOwnProperty.call(message, "aone")) {
                     object.aone = message.aone;
                     if (options.oneofs)
                         object.defaultOneofA = "aone";
                 }
-                if (message.atwo != null && message.hasOwnProperty("atwo")) {
+                if (message.atwo != null && Object.hasOwnProperty.call(message, "atwo")) {
                     object.atwo = message.atwo;
                     if (options.oneofs)
                         object.defaultOneofA = "atwo";
                 }
-                if (message.bone != null && message.hasOwnProperty("bone")) {
+                if (message.bone != null && Object.hasOwnProperty.call(message, "bone")) {
                     object.bone = message.bone;
                     if (options.oneofs)
                         object.defaultOneofB = "bone";
                 }
-                if (message.btwo != null && message.hasOwnProperty("btwo")) {
+                if (message.btwo != null && Object.hasOwnProperty.call(message, "btwo")) {
                     object.btwo = message.btwo;
                     if (options.oneofs)
                         object.defaultOneofB = "btwo";
@@ -8550,10 +8550,10 @@ $root.jspb = (function() {
                     long = 0;
                 if (long > $util.recursionLimit)
                     return "maximum nesting depth exceeded";
-                if (message.value != null && message.hasOwnProperty("value"))
+                if (message.value != null && Object.hasOwnProperty.call(message, "value"))
                     if (!$util.isInteger(message.value))
                         return "value: integer expected";
-                if (message.data != null && message.hasOwnProperty("data"))
+                if (message.data != null && Object.hasOwnProperty.call(message, "data"))
                     if (!(message.data && typeof message.data.length === "number" || $util.isString(message.data)))
                         return "data: buffer expected";
                 return null;
@@ -8614,9 +8614,9 @@ $root.jspb = (function() {
                             object.data = $util.newBuffer(object.data);
                     }
                 }
-                if (message.value != null && message.hasOwnProperty("value"))
+                if (message.value != null && Object.hasOwnProperty.call(message, "value"))
                     object.value = message.value;
-                if (message.data != null && message.hasOwnProperty("data"))
+                if (message.data != null && Object.hasOwnProperty.call(message, "data"))
                     object.data = options.bytes === String ? $util.base64.encode(message.data, 0, message.data.length) : options.bytes === Array ? Array.prototype.slice.call(message.data) : message.data;
                 return object;
             };
@@ -9211,7 +9211,7 @@ $root.jspb = (function() {
                     long = 0;
                 if (long > $util.recursionLimit)
                     return "maximum nesting depth exceeded";
-                if (message.mapStringString != null && message.hasOwnProperty("mapStringString")) {
+                if (message.mapStringString != null && Object.hasOwnProperty.call(message, "mapStringString")) {
                     if (!$util.isObject(message.mapStringString))
                         return "mapStringString: object expected";
                     var key = Object.keys(message.mapStringString);
@@ -9219,7 +9219,7 @@ $root.jspb = (function() {
                         if (!$util.isString(message.mapStringString[key[i]]))
                             return "mapStringString: string{k:string} expected";
                 }
-                if (message.mapStringInt32 != null && message.hasOwnProperty("mapStringInt32")) {
+                if (message.mapStringInt32 != null && Object.hasOwnProperty.call(message, "mapStringInt32")) {
                     if (!$util.isObject(message.mapStringInt32))
                         return "mapStringInt32: object expected";
                     var key = Object.keys(message.mapStringInt32);
@@ -9227,7 +9227,7 @@ $root.jspb = (function() {
                         if (!$util.isInteger(message.mapStringInt32[key[i]]))
                             return "mapStringInt32: integer{k:string} expected";
                 }
-                if (message.mapStringInt64 != null && message.hasOwnProperty("mapStringInt64")) {
+                if (message.mapStringInt64 != null && Object.hasOwnProperty.call(message, "mapStringInt64")) {
                     if (!$util.isObject(message.mapStringInt64))
                         return "mapStringInt64: object expected";
                     var key = Object.keys(message.mapStringInt64);
@@ -9235,7 +9235,7 @@ $root.jspb = (function() {
                         if (!$util.isInteger(message.mapStringInt64[key[i]]) && !(message.mapStringInt64[key[i]] && $util.isInteger(message.mapStringInt64[key[i]].low) && $util.isInteger(message.mapStringInt64[key[i]].high)))
                             return "mapStringInt64: integer|Long{k:string} expected";
                 }
-                if (message.mapStringBool != null && message.hasOwnProperty("mapStringBool")) {
+                if (message.mapStringBool != null && Object.hasOwnProperty.call(message, "mapStringBool")) {
                     if (!$util.isObject(message.mapStringBool))
                         return "mapStringBool: object expected";
                     var key = Object.keys(message.mapStringBool);
@@ -9243,7 +9243,7 @@ $root.jspb = (function() {
                         if (typeof message.mapStringBool[key[i]] !== "boolean")
                             return "mapStringBool: boolean{k:string} expected";
                 }
-                if (message.mapStringDouble != null && message.hasOwnProperty("mapStringDouble")) {
+                if (message.mapStringDouble != null && Object.hasOwnProperty.call(message, "mapStringDouble")) {
                     if (!$util.isObject(message.mapStringDouble))
                         return "mapStringDouble: object expected";
                     var key = Object.keys(message.mapStringDouble);
@@ -9251,7 +9251,7 @@ $root.jspb = (function() {
                         if (typeof message.mapStringDouble[key[i]] !== "number")
                             return "mapStringDouble: number{k:string} expected";
                 }
-                if (message.mapStringEnum != null && message.hasOwnProperty("mapStringEnum")) {
+                if (message.mapStringEnum != null && Object.hasOwnProperty.call(message, "mapStringEnum")) {
                     if (!$util.isObject(message.mapStringEnum))
                         return "mapStringEnum: object expected";
                     var key = Object.keys(message.mapStringEnum);
@@ -9265,7 +9265,7 @@ $root.jspb = (function() {
                             break;
                         }
                 }
-                if (message.mapStringMsg != null && message.hasOwnProperty("mapStringMsg")) {
+                if (message.mapStringMsg != null && Object.hasOwnProperty.call(message, "mapStringMsg")) {
                     if (!$util.isObject(message.mapStringMsg))
                         return "mapStringMsg: object expected";
                     var key = Object.keys(message.mapStringMsg);
@@ -9275,7 +9275,7 @@ $root.jspb = (function() {
                             return "mapStringMsg." + error;
                     }
                 }
-                if (message.mapInt32String != null && message.hasOwnProperty("mapInt32String")) {
+                if (message.mapInt32String != null && Object.hasOwnProperty.call(message, "mapInt32String")) {
                     if (!$util.isObject(message.mapInt32String))
                         return "mapInt32String: object expected";
                     var key = Object.keys(message.mapInt32String);
@@ -9286,7 +9286,7 @@ $root.jspb = (function() {
                             return "mapInt32String: string{k:int32} expected";
                     }
                 }
-                if (message.mapInt64String != null && message.hasOwnProperty("mapInt64String")) {
+                if (message.mapInt64String != null && Object.hasOwnProperty.call(message, "mapInt64String")) {
                     if (!$util.isObject(message.mapInt64String))
                         return "mapInt64String: object expected";
                     var key = Object.keys(message.mapInt64String);
@@ -9297,7 +9297,7 @@ $root.jspb = (function() {
                             return "mapInt64String: string{k:int64} expected";
                     }
                 }
-                if (message.mapBoolString != null && message.hasOwnProperty("mapBoolString")) {
+                if (message.mapBoolString != null && Object.hasOwnProperty.call(message, "mapBoolString")) {
                     if (!$util.isObject(message.mapBoolString))
                         return "mapBoolString: object expected";
                     var key = Object.keys(message.mapBoolString);
@@ -9308,12 +9308,12 @@ $root.jspb = (function() {
                             return "mapBoolString: string{k:bool} expected";
                     }
                 }
-                if (message.testMapFields != null && message.hasOwnProperty("testMapFields")) {
+                if (message.testMapFields != null && Object.hasOwnProperty.call(message, "testMapFields")) {
                     var error = $root.jspb.test.TestMapFieldsNoBinary.verify(message.testMapFields, long + 1);
                     if (error)
                         return "testMapFields." + error;
                 }
-                if (message.mapStringTestmapfields != null && message.hasOwnProperty("mapStringTestmapfields")) {
+                if (message.mapStringTestmapfields != null && Object.hasOwnProperty.call(message, "mapStringTestmapfields")) {
                     if (!$util.isObject(message.mapStringTestmapfields))
                         return "mapStringTestmapfields: object expected";
                     var key = Object.keys(message.mapStringTestmapfields);
@@ -9610,7 +9610,7 @@ $root.jspb = (function() {
                         object.mapBoolString[keys2[j]] = message.mapBoolString[keys2[j]];
                     }
                 }
-                if (message.testMapFields != null && message.hasOwnProperty("testMapFields"))
+                if (message.testMapFields != null && Object.hasOwnProperty.call(message, "testMapFields"))
                     object.testMapFields = $root.jspb.test.TestMapFieldsNoBinary.toObject(message.testMapFields, options, q + 1);
                 if (message.mapStringTestmapfields && (keys2 = Object.keys(message.mapStringTestmapfields)).length) {
                     object.mapStringTestmapfields = {};
@@ -9813,7 +9813,7 @@ $root.jspb = (function() {
                     long = 0;
                 if (long > $util.recursionLimit)
                     return "maximum nesting depth exceeded";
-                if (message.foo != null && message.hasOwnProperty("foo"))
+                if (message.foo != null && Object.hasOwnProperty.call(message, "foo"))
                     if (!$util.isInteger(message.foo))
                         return "foo: integer expected";
                 return null;
@@ -9861,7 +9861,7 @@ $root.jspb = (function() {
                 var object = {};
                 if (options.defaults)
                     object.foo = 0;
-                if (message.foo != null && message.hasOwnProperty("foo"))
+                if (message.foo != null && Object.hasOwnProperty.call(message, "foo"))
                     object.foo = message.foo;
                 return object;
             };
@@ -10424,7 +10424,7 @@ $root.jspb = (function() {
                             long = 0;
                         if (long > $util.recursionLimit)
                             return "maximum nesting depth exceeded";
-                        if (message.count != null && message.hasOwnProperty("count"))
+                        if (message.count != null && Object.hasOwnProperty.call(message, "count"))
                             if (!$util.isInteger(message.count))
                                 return "count: integer expected";
                         return null;
@@ -10472,7 +10472,7 @@ $root.jspb = (function() {
                         var object = {};
                         if (options.defaults)
                             object.count = 0;
-                        if (message.count != null && message.hasOwnProperty("count"))
+                        if (message.count != null && Object.hasOwnProperty.call(message, "count"))
                             object.count = message.count;
                         return object;
                     };
@@ -10685,7 +10685,7 @@ $root.google = (function() {
                     long = 0;
                 if (long > $util.recursionLimit)
                     return "maximum nesting depth exceeded";
-                if (message.file != null && message.hasOwnProperty("file")) {
+                if (message.file != null && Object.hasOwnProperty.call(message, "file")) {
                     if (!Array.isArray(message.file))
                         return "file: array expected";
                     for (var i = 0; i < message.file.length; ++i) {
@@ -11200,41 +11200,41 @@ $root.google = (function() {
                     long = 0;
                 if (long > $util.recursionLimit)
                     return "maximum nesting depth exceeded";
-                if (message.name != null && message.hasOwnProperty("name"))
+                if (message.name != null && Object.hasOwnProperty.call(message, "name"))
                     if (!$util.isString(message.name))
                         return "name: string expected";
-                if (message["package"] != null && message.hasOwnProperty("package"))
+                if (message["package"] != null && Object.hasOwnProperty.call(message, "package"))
                     if (!$util.isString(message["package"]))
                         return "package: string expected";
-                if (message.dependency != null && message.hasOwnProperty("dependency")) {
+                if (message.dependency != null && Object.hasOwnProperty.call(message, "dependency")) {
                     if (!Array.isArray(message.dependency))
                         return "dependency: array expected";
                     for (var i = 0; i < message.dependency.length; ++i)
                         if (!$util.isString(message.dependency[i]))
                             return "dependency: string[] expected";
                 }
-                if (message.publicDependency != null && message.hasOwnProperty("publicDependency")) {
+                if (message.publicDependency != null && Object.hasOwnProperty.call(message, "publicDependency")) {
                     if (!Array.isArray(message.publicDependency))
                         return "publicDependency: array expected";
                     for (var i = 0; i < message.publicDependency.length; ++i)
                         if (!$util.isInteger(message.publicDependency[i]))
                             return "publicDependency: integer[] expected";
                 }
-                if (message.weakDependency != null && message.hasOwnProperty("weakDependency")) {
+                if (message.weakDependency != null && Object.hasOwnProperty.call(message, "weakDependency")) {
                     if (!Array.isArray(message.weakDependency))
                         return "weakDependency: array expected";
                     for (var i = 0; i < message.weakDependency.length; ++i)
                         if (!$util.isInteger(message.weakDependency[i]))
                             return "weakDependency: integer[] expected";
                 }
-                if (message.optionDependency != null && message.hasOwnProperty("optionDependency")) {
+                if (message.optionDependency != null && Object.hasOwnProperty.call(message, "optionDependency")) {
                     if (!Array.isArray(message.optionDependency))
                         return "optionDependency: array expected";
                     for (var i = 0; i < message.optionDependency.length; ++i)
                         if (!$util.isString(message.optionDependency[i]))
                             return "optionDependency: string[] expected";
                 }
-                if (message.messageType != null && message.hasOwnProperty("messageType")) {
+                if (message.messageType != null && Object.hasOwnProperty.call(message, "messageType")) {
                     if (!Array.isArray(message.messageType))
                         return "messageType: array expected";
                     for (var i = 0; i < message.messageType.length; ++i) {
@@ -11243,7 +11243,7 @@ $root.google = (function() {
                             return "messageType." + error;
                     }
                 }
-                if (message.enumType != null && message.hasOwnProperty("enumType")) {
+                if (message.enumType != null && Object.hasOwnProperty.call(message, "enumType")) {
                     if (!Array.isArray(message.enumType))
                         return "enumType: array expected";
                     for (var i = 0; i < message.enumType.length; ++i) {
@@ -11252,7 +11252,7 @@ $root.google = (function() {
                             return "enumType." + error;
                     }
                 }
-                if (message.service != null && message.hasOwnProperty("service")) {
+                if (message.service != null && Object.hasOwnProperty.call(message, "service")) {
                     if (!Array.isArray(message.service))
                         return "service: array expected";
                     for (var i = 0; i < message.service.length; ++i) {
@@ -11261,7 +11261,7 @@ $root.google = (function() {
                             return "service." + error;
                     }
                 }
-                if (message.extension != null && message.hasOwnProperty("extension")) {
+                if (message.extension != null && Object.hasOwnProperty.call(message, "extension")) {
                     if (!Array.isArray(message.extension))
                         return "extension: array expected";
                     for (var i = 0; i < message.extension.length; ++i) {
@@ -11270,20 +11270,20 @@ $root.google = (function() {
                             return "extension." + error;
                     }
                 }
-                if (message.options != null && message.hasOwnProperty("options")) {
+                if (message.options != null && Object.hasOwnProperty.call(message, "options")) {
                     var error = $root.google.protobuf.FileOptions.verify(message.options, long + 1);
                     if (error)
                         return "options." + error;
                 }
-                if (message.sourceCodeInfo != null && message.hasOwnProperty("sourceCodeInfo")) {
+                if (message.sourceCodeInfo != null && Object.hasOwnProperty.call(message, "sourceCodeInfo")) {
                     var error = $root.google.protobuf.SourceCodeInfo.verify(message.sourceCodeInfo, long + 1);
                     if (error)
                         return "sourceCodeInfo." + error;
                 }
-                if (message.syntax != null && message.hasOwnProperty("syntax"))
+                if (message.syntax != null && Object.hasOwnProperty.call(message, "syntax"))
                     if (!$util.isString(message.syntax))
                         return "syntax: string expected";
-                if (message.edition != null && message.hasOwnProperty("edition"))
+                if (message.edition != null && Object.hasOwnProperty.call(message, "edition"))
                     switch (message.edition) {
                     default:
                         return "edition: enum value expected";
@@ -11500,9 +11500,9 @@ $root.google = (function() {
                     object.syntax = "";
                     object.edition = options.enums === String ? "EDITION_UNKNOWN" : 0;
                 }
-                if (message.name != null && message.hasOwnProperty("name"))
+                if (message.name != null && Object.hasOwnProperty.call(message, "name"))
                     object.name = message.name;
-                if (message["package"] != null && message.hasOwnProperty("package"))
+                if (message["package"] != null && Object.hasOwnProperty.call(message, "package"))
                     object["package"] = message["package"];
                 if (message.dependency && message.dependency.length) {
                     object.dependency = [];
@@ -11529,9 +11529,9 @@ $root.google = (function() {
                     for (var j = 0; j < message.extension.length; ++j)
                         object.extension[j] = $root.google.protobuf.FieldDescriptorProto.toObject(message.extension[j], options, q + 1);
                 }
-                if (message.options != null && message.hasOwnProperty("options"))
+                if (message.options != null && Object.hasOwnProperty.call(message, "options"))
                     object.options = $root.google.protobuf.FileOptions.toObject(message.options, options, q + 1);
-                if (message.sourceCodeInfo != null && message.hasOwnProperty("sourceCodeInfo"))
+                if (message.sourceCodeInfo != null && Object.hasOwnProperty.call(message, "sourceCodeInfo"))
                     object.sourceCodeInfo = $root.google.protobuf.SourceCodeInfo.toObject(message.sourceCodeInfo, options, q + 1);
                 if (message.publicDependency && message.publicDependency.length) {
                     object.publicDependency = [];
@@ -11543,9 +11543,9 @@ $root.google = (function() {
                     for (var j = 0; j < message.weakDependency.length; ++j)
                         object.weakDependency[j] = message.weakDependency[j];
                 }
-                if (message.syntax != null && message.hasOwnProperty("syntax"))
+                if (message.syntax != null && Object.hasOwnProperty.call(message, "syntax"))
                     object.syntax = message.syntax;
-                if (message.edition != null && message.hasOwnProperty("edition"))
+                if (message.edition != null && Object.hasOwnProperty.call(message, "edition"))
                     object.edition = options.enums === String ? $root.google.protobuf.Edition[message.edition] === undefined ? message.edition : $root.google.protobuf.Edition[message.edition] : message.edition;
                 if (message.optionDependency && message.optionDependency.length) {
                     object.optionDependency = [];
@@ -11911,10 +11911,10 @@ $root.google = (function() {
                     long = 0;
                 if (long > $util.recursionLimit)
                     return "maximum nesting depth exceeded";
-                if (message.name != null && message.hasOwnProperty("name"))
+                if (message.name != null && Object.hasOwnProperty.call(message, "name"))
                     if (!$util.isString(message.name))
                         return "name: string expected";
-                if (message.field != null && message.hasOwnProperty("field")) {
+                if (message.field != null && Object.hasOwnProperty.call(message, "field")) {
                     if (!Array.isArray(message.field))
                         return "field: array expected";
                     for (var i = 0; i < message.field.length; ++i) {
@@ -11923,7 +11923,7 @@ $root.google = (function() {
                             return "field." + error;
                     }
                 }
-                if (message.extension != null && message.hasOwnProperty("extension")) {
+                if (message.extension != null && Object.hasOwnProperty.call(message, "extension")) {
                     if (!Array.isArray(message.extension))
                         return "extension: array expected";
                     for (var i = 0; i < message.extension.length; ++i) {
@@ -11932,7 +11932,7 @@ $root.google = (function() {
                             return "extension." + error;
                     }
                 }
-                if (message.nestedType != null && message.hasOwnProperty("nestedType")) {
+                if (message.nestedType != null && Object.hasOwnProperty.call(message, "nestedType")) {
                     if (!Array.isArray(message.nestedType))
                         return "nestedType: array expected";
                     for (var i = 0; i < message.nestedType.length; ++i) {
@@ -11941,7 +11941,7 @@ $root.google = (function() {
                             return "nestedType." + error;
                     }
                 }
-                if (message.enumType != null && message.hasOwnProperty("enumType")) {
+                if (message.enumType != null && Object.hasOwnProperty.call(message, "enumType")) {
                     if (!Array.isArray(message.enumType))
                         return "enumType: array expected";
                     for (var i = 0; i < message.enumType.length; ++i) {
@@ -11950,7 +11950,7 @@ $root.google = (function() {
                             return "enumType." + error;
                     }
                 }
-                if (message.extensionRange != null && message.hasOwnProperty("extensionRange")) {
+                if (message.extensionRange != null && Object.hasOwnProperty.call(message, "extensionRange")) {
                     if (!Array.isArray(message.extensionRange))
                         return "extensionRange: array expected";
                     for (var i = 0; i < message.extensionRange.length; ++i) {
@@ -11959,7 +11959,7 @@ $root.google = (function() {
                             return "extensionRange." + error;
                     }
                 }
-                if (message.oneofDecl != null && message.hasOwnProperty("oneofDecl")) {
+                if (message.oneofDecl != null && Object.hasOwnProperty.call(message, "oneofDecl")) {
                     if (!Array.isArray(message.oneofDecl))
                         return "oneofDecl: array expected";
                     for (var i = 0; i < message.oneofDecl.length; ++i) {
@@ -11968,12 +11968,12 @@ $root.google = (function() {
                             return "oneofDecl." + error;
                     }
                 }
-                if (message.options != null && message.hasOwnProperty("options")) {
+                if (message.options != null && Object.hasOwnProperty.call(message, "options")) {
                     var error = $root.google.protobuf.MessageOptions.verify(message.options, long + 1);
                     if (error)
                         return "options." + error;
                 }
-                if (message.reservedRange != null && message.hasOwnProperty("reservedRange")) {
+                if (message.reservedRange != null && Object.hasOwnProperty.call(message, "reservedRange")) {
                     if (!Array.isArray(message.reservedRange))
                         return "reservedRange: array expected";
                     for (var i = 0; i < message.reservedRange.length; ++i) {
@@ -11982,14 +11982,14 @@ $root.google = (function() {
                             return "reservedRange." + error;
                     }
                 }
-                if (message.reservedName != null && message.hasOwnProperty("reservedName")) {
+                if (message.reservedName != null && Object.hasOwnProperty.call(message, "reservedName")) {
                     if (!Array.isArray(message.reservedName))
                         return "reservedName: array expected";
                     for (var i = 0; i < message.reservedName.length; ++i)
                         if (!$util.isString(message.reservedName[i]))
                             return "reservedName: string[] expected";
                 }
-                if (message.visibility != null && message.hasOwnProperty("visibility"))
+                if (message.visibility != null && Object.hasOwnProperty.call(message, "visibility"))
                     switch (message.visibility) {
                     default:
                         return "visibility: enum value expected";
@@ -12158,7 +12158,7 @@ $root.google = (function() {
                     object.options = null;
                     object.visibility = options.enums === String ? "VISIBILITY_UNSET" : 0;
                 }
-                if (message.name != null && message.hasOwnProperty("name"))
+                if (message.name != null && Object.hasOwnProperty.call(message, "name"))
                     object.name = message.name;
                 if (message.field && message.field.length) {
                     object.field = [];
@@ -12185,7 +12185,7 @@ $root.google = (function() {
                     for (var j = 0; j < message.extension.length; ++j)
                         object.extension[j] = $root.google.protobuf.FieldDescriptorProto.toObject(message.extension[j], options, q + 1);
                 }
-                if (message.options != null && message.hasOwnProperty("options"))
+                if (message.options != null && Object.hasOwnProperty.call(message, "options"))
                     object.options = $root.google.protobuf.MessageOptions.toObject(message.options, options, q + 1);
                 if (message.oneofDecl && message.oneofDecl.length) {
                     object.oneofDecl = [];
@@ -12202,7 +12202,7 @@ $root.google = (function() {
                     for (var j = 0; j < message.reservedName.length; ++j)
                         object.reservedName[j] = message.reservedName[j];
                 }
-                if (message.visibility != null && message.hasOwnProperty("visibility"))
+                if (message.visibility != null && Object.hasOwnProperty.call(message, "visibility"))
                     object.visibility = options.enums === String ? $root.google.protobuf.SymbolVisibility[message.visibility] === undefined ? message.visibility : $root.google.protobuf.SymbolVisibility[message.visibility] : message.visibility;
                 return object;
             };
@@ -12408,13 +12408,13 @@ $root.google = (function() {
                         long = 0;
                     if (long > $util.recursionLimit)
                         return "maximum nesting depth exceeded";
-                    if (message.start != null && message.hasOwnProperty("start"))
+                    if (message.start != null && Object.hasOwnProperty.call(message, "start"))
                         if (!$util.isInteger(message.start))
                             return "start: integer expected";
-                    if (message.end != null && message.hasOwnProperty("end"))
+                    if (message.end != null && Object.hasOwnProperty.call(message, "end"))
                         if (!$util.isInteger(message.end))
                             return "end: integer expected";
-                    if (message.options != null && message.hasOwnProperty("options")) {
+                    if (message.options != null && Object.hasOwnProperty.call(message, "options")) {
                         var error = $root.google.protobuf.ExtensionRangeOptions.verify(message.options, long + 1);
                         if (error)
                             return "options." + error;
@@ -12474,11 +12474,11 @@ $root.google = (function() {
                         object.end = 0;
                         object.options = null;
                     }
-                    if (message.start != null && message.hasOwnProperty("start"))
+                    if (message.start != null && Object.hasOwnProperty.call(message, "start"))
                         object.start = message.start;
-                    if (message.end != null && message.hasOwnProperty("end"))
+                    if (message.end != null && Object.hasOwnProperty.call(message, "end"))
                         object.end = message.end;
-                    if (message.options != null && message.hasOwnProperty("options"))
+                    if (message.options != null && Object.hasOwnProperty.call(message, "options"))
                         object.options = $root.google.protobuf.ExtensionRangeOptions.toObject(message.options, options, q + 1);
                     return object;
                 };
@@ -12672,10 +12672,10 @@ $root.google = (function() {
                         long = 0;
                     if (long > $util.recursionLimit)
                         return "maximum nesting depth exceeded";
-                    if (message.start != null && message.hasOwnProperty("start"))
+                    if (message.start != null && Object.hasOwnProperty.call(message, "start"))
                         if (!$util.isInteger(message.start))
                             return "start: integer expected";
-                    if (message.end != null && message.hasOwnProperty("end"))
+                    if (message.end != null && Object.hasOwnProperty.call(message, "end"))
                         if (!$util.isInteger(message.end))
                             return "end: integer expected";
                     return null;
@@ -12727,9 +12727,9 @@ $root.google = (function() {
                         object.start = 0;
                         object.end = 0;
                     }
-                    if (message.start != null && message.hasOwnProperty("start"))
+                    if (message.start != null && Object.hasOwnProperty.call(message, "start"))
                         object.start = message.start;
-                    if (message.end != null && message.hasOwnProperty("end"))
+                    if (message.end != null && Object.hasOwnProperty.call(message, "end"))
                         object.end = message.end;
                     return object;
                 };
@@ -12964,7 +12964,7 @@ $root.google = (function() {
                     long = 0;
                 if (long > $util.recursionLimit)
                     return "maximum nesting depth exceeded";
-                if (message.uninterpretedOption != null && message.hasOwnProperty("uninterpretedOption")) {
+                if (message.uninterpretedOption != null && Object.hasOwnProperty.call(message, "uninterpretedOption")) {
                     if (!Array.isArray(message.uninterpretedOption))
                         return "uninterpretedOption: array expected";
                     for (var i = 0; i < message.uninterpretedOption.length; ++i) {
@@ -12973,7 +12973,7 @@ $root.google = (function() {
                             return "uninterpretedOption." + error;
                     }
                 }
-                if (message.declaration != null && message.hasOwnProperty("declaration")) {
+                if (message.declaration != null && Object.hasOwnProperty.call(message, "declaration")) {
                     if (!Array.isArray(message.declaration))
                         return "declaration: array expected";
                     for (var i = 0; i < message.declaration.length; ++i) {
@@ -12982,12 +12982,12 @@ $root.google = (function() {
                             return "declaration." + error;
                     }
                 }
-                if (message.features != null && message.hasOwnProperty("features")) {
+                if (message.features != null && Object.hasOwnProperty.call(message, "features")) {
                     var error = $root.google.protobuf.FeatureSet.verify(message.features, long + 1);
                     if (error)
                         return "features." + error;
                 }
-                if (message.verification != null && message.hasOwnProperty("verification"))
+                if (message.verification != null && Object.hasOwnProperty.call(message, "verification"))
                     switch (message.verification) {
                     default:
                         return "verification: enum value expected";
@@ -13090,9 +13090,9 @@ $root.google = (function() {
                     for (var j = 0; j < message.declaration.length; ++j)
                         object.declaration[j] = $root.google.protobuf.ExtensionRangeOptions.Declaration.toObject(message.declaration[j], options, q + 1);
                 }
-                if (message.verification != null && message.hasOwnProperty("verification"))
+                if (message.verification != null && Object.hasOwnProperty.call(message, "verification"))
                     object.verification = options.enums === String ? $root.google.protobuf.ExtensionRangeOptions.VerificationState[message.verification] === undefined ? message.verification : $root.google.protobuf.ExtensionRangeOptions.VerificationState[message.verification] : message.verification;
-                if (message.features != null && message.hasOwnProperty("features"))
+                if (message.features != null && Object.hasOwnProperty.call(message, "features"))
                     object.features = $root.google.protobuf.FeatureSet.toObject(message.features, options, q + 1);
                 if (message.uninterpretedOption && message.uninterpretedOption.length) {
                     object.uninterpretedOption = [];
@@ -13333,19 +13333,19 @@ $root.google = (function() {
                         long = 0;
                     if (long > $util.recursionLimit)
                         return "maximum nesting depth exceeded";
-                    if (message.number != null && message.hasOwnProperty("number"))
+                    if (message.number != null && Object.hasOwnProperty.call(message, "number"))
                         if (!$util.isInteger(message.number))
                             return "number: integer expected";
-                    if (message.fullName != null && message.hasOwnProperty("fullName"))
+                    if (message.fullName != null && Object.hasOwnProperty.call(message, "fullName"))
                         if (!$util.isString(message.fullName))
                             return "fullName: string expected";
-                    if (message.type != null && message.hasOwnProperty("type"))
+                    if (message.type != null && Object.hasOwnProperty.call(message, "type"))
                         if (!$util.isString(message.type))
                             return "type: string expected";
-                    if (message.reserved != null && message.hasOwnProperty("reserved"))
+                    if (message.reserved != null && Object.hasOwnProperty.call(message, "reserved"))
                         if (typeof message.reserved !== "boolean")
                             return "reserved: boolean expected";
-                    if (message.repeated != null && message.hasOwnProperty("repeated"))
+                    if (message.repeated != null && Object.hasOwnProperty.call(message, "repeated"))
                         if (typeof message.repeated !== "boolean")
                             return "repeated: boolean expected";
                     return null;
@@ -13406,15 +13406,15 @@ $root.google = (function() {
                         object.reserved = false;
                         object.repeated = false;
                     }
-                    if (message.number != null && message.hasOwnProperty("number"))
+                    if (message.number != null && Object.hasOwnProperty.call(message, "number"))
                         object.number = message.number;
-                    if (message.fullName != null && message.hasOwnProperty("fullName"))
+                    if (message.fullName != null && Object.hasOwnProperty.call(message, "fullName"))
                         object.fullName = message.fullName;
-                    if (message.type != null && message.hasOwnProperty("type"))
+                    if (message.type != null && Object.hasOwnProperty.call(message, "type"))
                         object.type = message.type;
-                    if (message.reserved != null && message.hasOwnProperty("reserved"))
+                    if (message.reserved != null && Object.hasOwnProperty.call(message, "reserved"))
                         object.reserved = message.reserved;
-                    if (message.repeated != null && message.hasOwnProperty("repeated"))
+                    if (message.repeated != null && Object.hasOwnProperty.call(message, "repeated"))
                         object.repeated = message.repeated;
                     return object;
                 };
@@ -13760,13 +13760,13 @@ $root.google = (function() {
                     long = 0;
                 if (long > $util.recursionLimit)
                     return "maximum nesting depth exceeded";
-                if (message.name != null && message.hasOwnProperty("name"))
+                if (message.name != null && Object.hasOwnProperty.call(message, "name"))
                     if (!$util.isString(message.name))
                         return "name: string expected";
-                if (message.number != null && message.hasOwnProperty("number"))
+                if (message.number != null && Object.hasOwnProperty.call(message, "number"))
                     if (!$util.isInteger(message.number))
                         return "number: integer expected";
-                if (message.label != null && message.hasOwnProperty("label"))
+                if (message.label != null && Object.hasOwnProperty.call(message, "label"))
                     switch (message.label) {
                     default:
                         return "label: enum value expected";
@@ -13775,7 +13775,7 @@ $root.google = (function() {
                     case 2:
                         break;
                     }
-                if (message.type != null && message.hasOwnProperty("type"))
+                if (message.type != null && Object.hasOwnProperty.call(message, "type"))
                     switch (message.type) {
                     default:
                         return "type: enum value expected";
@@ -13799,27 +13799,27 @@ $root.google = (function() {
                     case 18:
                         break;
                     }
-                if (message.typeName != null && message.hasOwnProperty("typeName"))
+                if (message.typeName != null && Object.hasOwnProperty.call(message, "typeName"))
                     if (!$util.isString(message.typeName))
                         return "typeName: string expected";
-                if (message.extendee != null && message.hasOwnProperty("extendee"))
+                if (message.extendee != null && Object.hasOwnProperty.call(message, "extendee"))
                     if (!$util.isString(message.extendee))
                         return "extendee: string expected";
-                if (message.defaultValue != null && message.hasOwnProperty("defaultValue"))
+                if (message.defaultValue != null && Object.hasOwnProperty.call(message, "defaultValue"))
                     if (!$util.isString(message.defaultValue))
                         return "defaultValue: string expected";
-                if (message.oneofIndex != null && message.hasOwnProperty("oneofIndex"))
+                if (message.oneofIndex != null && Object.hasOwnProperty.call(message, "oneofIndex"))
                     if (!$util.isInteger(message.oneofIndex))
                         return "oneofIndex: integer expected";
-                if (message.jsonName != null && message.hasOwnProperty("jsonName"))
+                if (message.jsonName != null && Object.hasOwnProperty.call(message, "jsonName"))
                     if (!$util.isString(message.jsonName))
                         return "jsonName: string expected";
-                if (message.options != null && message.hasOwnProperty("options")) {
+                if (message.options != null && Object.hasOwnProperty.call(message, "options")) {
                     var error = $root.google.protobuf.FieldOptions.verify(message.options, long + 1);
                     if (error)
                         return "options." + error;
                 }
-                if (message.proto3Optional != null && message.hasOwnProperty("proto3Optional"))
+                if (message.proto3Optional != null && Object.hasOwnProperty.call(message, "proto3Optional"))
                     if (typeof message.proto3Optional !== "boolean")
                         return "proto3Optional: boolean expected";
                 return null;
@@ -13997,27 +13997,27 @@ $root.google = (function() {
                     object.jsonName = "";
                     object.proto3Optional = false;
                 }
-                if (message.name != null && message.hasOwnProperty("name"))
+                if (message.name != null && Object.hasOwnProperty.call(message, "name"))
                     object.name = message.name;
-                if (message.extendee != null && message.hasOwnProperty("extendee"))
+                if (message.extendee != null && Object.hasOwnProperty.call(message, "extendee"))
                     object.extendee = message.extendee;
-                if (message.number != null && message.hasOwnProperty("number"))
+                if (message.number != null && Object.hasOwnProperty.call(message, "number"))
                     object.number = message.number;
-                if (message.label != null && message.hasOwnProperty("label"))
+                if (message.label != null && Object.hasOwnProperty.call(message, "label"))
                     object.label = options.enums === String ? $root.google.protobuf.FieldDescriptorProto.Label[message.label] === undefined ? message.label : $root.google.protobuf.FieldDescriptorProto.Label[message.label] : message.label;
-                if (message.type != null && message.hasOwnProperty("type"))
+                if (message.type != null && Object.hasOwnProperty.call(message, "type"))
                     object.type = options.enums === String ? $root.google.protobuf.FieldDescriptorProto.Type[message.type] === undefined ? message.type : $root.google.protobuf.FieldDescriptorProto.Type[message.type] : message.type;
-                if (message.typeName != null && message.hasOwnProperty("typeName"))
+                if (message.typeName != null && Object.hasOwnProperty.call(message, "typeName"))
                     object.typeName = message.typeName;
-                if (message.defaultValue != null && message.hasOwnProperty("defaultValue"))
+                if (message.defaultValue != null && Object.hasOwnProperty.call(message, "defaultValue"))
                     object.defaultValue = message.defaultValue;
-                if (message.options != null && message.hasOwnProperty("options"))
+                if (message.options != null && Object.hasOwnProperty.call(message, "options"))
                     object.options = $root.google.protobuf.FieldOptions.toObject(message.options, options, q + 1);
-                if (message.oneofIndex != null && message.hasOwnProperty("oneofIndex"))
+                if (message.oneofIndex != null && Object.hasOwnProperty.call(message, "oneofIndex"))
                     object.oneofIndex = message.oneofIndex;
-                if (message.jsonName != null && message.hasOwnProperty("jsonName"))
+                if (message.jsonName != null && Object.hasOwnProperty.call(message, "jsonName"))
                     object.jsonName = message.jsonName;
-                if (message.proto3Optional != null && message.hasOwnProperty("proto3Optional"))
+                if (message.proto3Optional != null && Object.hasOwnProperty.call(message, "proto3Optional"))
                     object.proto3Optional = message.proto3Optional;
                 return object;
             };
@@ -14273,10 +14273,10 @@ $root.google = (function() {
                     long = 0;
                 if (long > $util.recursionLimit)
                     return "maximum nesting depth exceeded";
-                if (message.name != null && message.hasOwnProperty("name"))
+                if (message.name != null && Object.hasOwnProperty.call(message, "name"))
                     if (!$util.isString(message.name))
                         return "name: string expected";
-                if (message.options != null && message.hasOwnProperty("options")) {
+                if (message.options != null && Object.hasOwnProperty.call(message, "options")) {
                     var error = $root.google.protobuf.OneofOptions.verify(message.options, long + 1);
                     if (error)
                         return "options." + error;
@@ -14333,9 +14333,9 @@ $root.google = (function() {
                     object.name = "";
                     object.options = null;
                 }
-                if (message.name != null && message.hasOwnProperty("name"))
+                if (message.name != null && Object.hasOwnProperty.call(message, "name"))
                     object.name = message.name;
-                if (message.options != null && message.hasOwnProperty("options"))
+                if (message.options != null && Object.hasOwnProperty.call(message, "options"))
                     object.options = $root.google.protobuf.OneofOptions.toObject(message.options, options, q + 1);
                 return object;
             };
@@ -14601,10 +14601,10 @@ $root.google = (function() {
                     long = 0;
                 if (long > $util.recursionLimit)
                     return "maximum nesting depth exceeded";
-                if (message.name != null && message.hasOwnProperty("name"))
+                if (message.name != null && Object.hasOwnProperty.call(message, "name"))
                     if (!$util.isString(message.name))
                         return "name: string expected";
-                if (message.value != null && message.hasOwnProperty("value")) {
+                if (message.value != null && Object.hasOwnProperty.call(message, "value")) {
                     if (!Array.isArray(message.value))
                         return "value: array expected";
                     for (var i = 0; i < message.value.length; ++i) {
@@ -14613,12 +14613,12 @@ $root.google = (function() {
                             return "value." + error;
                     }
                 }
-                if (message.options != null && message.hasOwnProperty("options")) {
+                if (message.options != null && Object.hasOwnProperty.call(message, "options")) {
                     var error = $root.google.protobuf.EnumOptions.verify(message.options, long + 1);
                     if (error)
                         return "options." + error;
                 }
-                if (message.reservedRange != null && message.hasOwnProperty("reservedRange")) {
+                if (message.reservedRange != null && Object.hasOwnProperty.call(message, "reservedRange")) {
                     if (!Array.isArray(message.reservedRange))
                         return "reservedRange: array expected";
                     for (var i = 0; i < message.reservedRange.length; ++i) {
@@ -14627,14 +14627,14 @@ $root.google = (function() {
                             return "reservedRange." + error;
                     }
                 }
-                if (message.reservedName != null && message.hasOwnProperty("reservedName")) {
+                if (message.reservedName != null && Object.hasOwnProperty.call(message, "reservedName")) {
                     if (!Array.isArray(message.reservedName))
                         return "reservedName: array expected";
                     for (var i = 0; i < message.reservedName.length; ++i)
                         if (!$util.isString(message.reservedName[i]))
                             return "reservedName: string[] expected";
                 }
-                if (message.visibility != null && message.hasOwnProperty("visibility"))
+                if (message.visibility != null && Object.hasOwnProperty.call(message, "visibility"))
                     switch (message.visibility) {
                     default:
                         return "visibility: enum value expected";
@@ -14748,14 +14748,14 @@ $root.google = (function() {
                     object.options = null;
                     object.visibility = options.enums === String ? "VISIBILITY_UNSET" : 0;
                 }
-                if (message.name != null && message.hasOwnProperty("name"))
+                if (message.name != null && Object.hasOwnProperty.call(message, "name"))
                     object.name = message.name;
                 if (message.value && message.value.length) {
                     object.value = [];
                     for (var j = 0; j < message.value.length; ++j)
                         object.value[j] = $root.google.protobuf.EnumValueDescriptorProto.toObject(message.value[j], options, q + 1);
                 }
-                if (message.options != null && message.hasOwnProperty("options"))
+                if (message.options != null && Object.hasOwnProperty.call(message, "options"))
                     object.options = $root.google.protobuf.EnumOptions.toObject(message.options, options, q + 1);
                 if (message.reservedRange && message.reservedRange.length) {
                     object.reservedRange = [];
@@ -14767,7 +14767,7 @@ $root.google = (function() {
                     for (var j = 0; j < message.reservedName.length; ++j)
                         object.reservedName[j] = message.reservedName[j];
                 }
-                if (message.visibility != null && message.hasOwnProperty("visibility"))
+                if (message.visibility != null && Object.hasOwnProperty.call(message, "visibility"))
                     object.visibility = options.enums === String ? $root.google.protobuf.SymbolVisibility[message.visibility] === undefined ? message.visibility : $root.google.protobuf.SymbolVisibility[message.visibility] : message.visibility;
                 return object;
             };
@@ -14958,10 +14958,10 @@ $root.google = (function() {
                         long = 0;
                     if (long > $util.recursionLimit)
                         return "maximum nesting depth exceeded";
-                    if (message.start != null && message.hasOwnProperty("start"))
+                    if (message.start != null && Object.hasOwnProperty.call(message, "start"))
                         if (!$util.isInteger(message.start))
                             return "start: integer expected";
-                    if (message.end != null && message.hasOwnProperty("end"))
+                    if (message.end != null && Object.hasOwnProperty.call(message, "end"))
                         if (!$util.isInteger(message.end))
                             return "end: integer expected";
                     return null;
@@ -15013,9 +15013,9 @@ $root.google = (function() {
                         object.start = 0;
                         object.end = 0;
                     }
-                    if (message.start != null && message.hasOwnProperty("start"))
+                    if (message.start != null && Object.hasOwnProperty.call(message, "start"))
                         object.start = message.start;
-                    if (message.end != null && message.hasOwnProperty("end"))
+                    if (message.end != null && Object.hasOwnProperty.call(message, "end"))
                         object.end = message.end;
                     return object;
                 };
@@ -15227,13 +15227,13 @@ $root.google = (function() {
                     long = 0;
                 if (long > $util.recursionLimit)
                     return "maximum nesting depth exceeded";
-                if (message.name != null && message.hasOwnProperty("name"))
+                if (message.name != null && Object.hasOwnProperty.call(message, "name"))
                     if (!$util.isString(message.name))
                         return "name: string expected";
-                if (message.number != null && message.hasOwnProperty("number"))
+                if (message.number != null && Object.hasOwnProperty.call(message, "number"))
                     if (!$util.isInteger(message.number))
                         return "number: integer expected";
-                if (message.options != null && message.hasOwnProperty("options")) {
+                if (message.options != null && Object.hasOwnProperty.call(message, "options")) {
                     var error = $root.google.protobuf.EnumValueOptions.verify(message.options, long + 1);
                     if (error)
                         return "options." + error;
@@ -15293,11 +15293,11 @@ $root.google = (function() {
                     object.number = 0;
                     object.options = null;
                 }
-                if (message.name != null && message.hasOwnProperty("name"))
+                if (message.name != null && Object.hasOwnProperty.call(message, "name"))
                     object.name = message.name;
-                if (message.number != null && message.hasOwnProperty("number"))
+                if (message.number != null && Object.hasOwnProperty.call(message, "number"))
                     object.number = message.number;
-                if (message.options != null && message.hasOwnProperty("options"))
+                if (message.options != null && Object.hasOwnProperty.call(message, "options"))
                     object.options = $root.google.protobuf.EnumValueOptions.toObject(message.options, options, q + 1);
                 return object;
             };
@@ -15510,10 +15510,10 @@ $root.google = (function() {
                     long = 0;
                 if (long > $util.recursionLimit)
                     return "maximum nesting depth exceeded";
-                if (message.name != null && message.hasOwnProperty("name"))
+                if (message.name != null && Object.hasOwnProperty.call(message, "name"))
                     if (!$util.isString(message.name))
                         return "name: string expected";
-                if (message.method != null && message.hasOwnProperty("method")) {
+                if (message.method != null && Object.hasOwnProperty.call(message, "method")) {
                     if (!Array.isArray(message.method))
                         return "method: array expected";
                     for (var i = 0; i < message.method.length; ++i) {
@@ -15522,7 +15522,7 @@ $root.google = (function() {
                             return "method." + error;
                     }
                 }
-                if (message.options != null && message.hasOwnProperty("options")) {
+                if (message.options != null && Object.hasOwnProperty.call(message, "options")) {
                     var error = $root.google.protobuf.ServiceOptions.verify(message.options, long + 1);
                     if (error)
                         return "options." + error;
@@ -15591,14 +15591,14 @@ $root.google = (function() {
                     object.name = "";
                     object.options = null;
                 }
-                if (message.name != null && message.hasOwnProperty("name"))
+                if (message.name != null && Object.hasOwnProperty.call(message, "name"))
                     object.name = message.name;
                 if (message.method && message.method.length) {
                     object.method = [];
                     for (var j = 0; j < message.method.length; ++j)
                         object.method[j] = $root.google.protobuf.MethodDescriptorProto.toObject(message.method[j], options, q + 1);
                 }
-                if (message.options != null && message.hasOwnProperty("options"))
+                if (message.options != null && Object.hasOwnProperty.call(message, "options"))
                     object.options = $root.google.protobuf.ServiceOptions.toObject(message.options, options, q + 1);
                 return object;
             };
@@ -15852,24 +15852,24 @@ $root.google = (function() {
                     long = 0;
                 if (long > $util.recursionLimit)
                     return "maximum nesting depth exceeded";
-                if (message.name != null && message.hasOwnProperty("name"))
+                if (message.name != null && Object.hasOwnProperty.call(message, "name"))
                     if (!$util.isString(message.name))
                         return "name: string expected";
-                if (message.inputType != null && message.hasOwnProperty("inputType"))
+                if (message.inputType != null && Object.hasOwnProperty.call(message, "inputType"))
                     if (!$util.isString(message.inputType))
                         return "inputType: string expected";
-                if (message.outputType != null && message.hasOwnProperty("outputType"))
+                if (message.outputType != null && Object.hasOwnProperty.call(message, "outputType"))
                     if (!$util.isString(message.outputType))
                         return "outputType: string expected";
-                if (message.options != null && message.hasOwnProperty("options")) {
+                if (message.options != null && Object.hasOwnProperty.call(message, "options")) {
                     var error = $root.google.protobuf.MethodOptions.verify(message.options, long + 1);
                     if (error)
                         return "options." + error;
                 }
-                if (message.clientStreaming != null && message.hasOwnProperty("clientStreaming"))
+                if (message.clientStreaming != null && Object.hasOwnProperty.call(message, "clientStreaming"))
                     if (typeof message.clientStreaming !== "boolean")
                         return "clientStreaming: boolean expected";
-                if (message.serverStreaming != null && message.hasOwnProperty("serverStreaming"))
+                if (message.serverStreaming != null && Object.hasOwnProperty.call(message, "serverStreaming"))
                     if (typeof message.serverStreaming !== "boolean")
                         return "serverStreaming: boolean expected";
                 return null;
@@ -15936,17 +15936,17 @@ $root.google = (function() {
                     object.clientStreaming = false;
                     object.serverStreaming = false;
                 }
-                if (message.name != null && message.hasOwnProperty("name"))
+                if (message.name != null && Object.hasOwnProperty.call(message, "name"))
                     object.name = message.name;
-                if (message.inputType != null && message.hasOwnProperty("inputType"))
+                if (message.inputType != null && Object.hasOwnProperty.call(message, "inputType"))
                     object.inputType = message.inputType;
-                if (message.outputType != null && message.hasOwnProperty("outputType"))
+                if (message.outputType != null && Object.hasOwnProperty.call(message, "outputType"))
                     object.outputType = message.outputType;
-                if (message.options != null && message.hasOwnProperty("options"))
+                if (message.options != null && Object.hasOwnProperty.call(message, "options"))
                     object.options = $root.google.protobuf.MethodOptions.toObject(message.options, options, q + 1);
-                if (message.clientStreaming != null && message.hasOwnProperty("clientStreaming"))
+                if (message.clientStreaming != null && Object.hasOwnProperty.call(message, "clientStreaming"))
                     object.clientStreaming = message.clientStreaming;
-                if (message.serverStreaming != null && message.hasOwnProperty("serverStreaming"))
+                if (message.serverStreaming != null && Object.hasOwnProperty.call(message, "serverStreaming"))
                     object.serverStreaming = message.serverStreaming;
                 return object;
             };
@@ -16429,22 +16429,22 @@ $root.google = (function() {
                     long = 0;
                 if (long > $util.recursionLimit)
                     return "maximum nesting depth exceeded";
-                if (message.javaPackage != null && message.hasOwnProperty("javaPackage"))
+                if (message.javaPackage != null && Object.hasOwnProperty.call(message, "javaPackage"))
                     if (!$util.isString(message.javaPackage))
                         return "javaPackage: string expected";
-                if (message.javaOuterClassname != null && message.hasOwnProperty("javaOuterClassname"))
+                if (message.javaOuterClassname != null && Object.hasOwnProperty.call(message, "javaOuterClassname"))
                     if (!$util.isString(message.javaOuterClassname))
                         return "javaOuterClassname: string expected";
-                if (message.javaMultipleFiles != null && message.hasOwnProperty("javaMultipleFiles"))
+                if (message.javaMultipleFiles != null && Object.hasOwnProperty.call(message, "javaMultipleFiles"))
                     if (typeof message.javaMultipleFiles !== "boolean")
                         return "javaMultipleFiles: boolean expected";
-                if (message.javaGenerateEqualsAndHash != null && message.hasOwnProperty("javaGenerateEqualsAndHash"))
+                if (message.javaGenerateEqualsAndHash != null && Object.hasOwnProperty.call(message, "javaGenerateEqualsAndHash"))
                     if (typeof message.javaGenerateEqualsAndHash !== "boolean")
                         return "javaGenerateEqualsAndHash: boolean expected";
-                if (message.javaStringCheckUtf8 != null && message.hasOwnProperty("javaStringCheckUtf8"))
+                if (message.javaStringCheckUtf8 != null && Object.hasOwnProperty.call(message, "javaStringCheckUtf8"))
                     if (typeof message.javaStringCheckUtf8 !== "boolean")
                         return "javaStringCheckUtf8: boolean expected";
-                if (message.optimizeFor != null && message.hasOwnProperty("optimizeFor"))
+                if (message.optimizeFor != null && Object.hasOwnProperty.call(message, "optimizeFor"))
                     switch (message.optimizeFor) {
                     default:
                         return "optimizeFor: enum value expected";
@@ -16453,51 +16453,51 @@ $root.google = (function() {
                     case 3:
                         break;
                     }
-                if (message.goPackage != null && message.hasOwnProperty("goPackage"))
+                if (message.goPackage != null && Object.hasOwnProperty.call(message, "goPackage"))
                     if (!$util.isString(message.goPackage))
                         return "goPackage: string expected";
-                if (message.ccGenericServices != null && message.hasOwnProperty("ccGenericServices"))
+                if (message.ccGenericServices != null && Object.hasOwnProperty.call(message, "ccGenericServices"))
                     if (typeof message.ccGenericServices !== "boolean")
                         return "ccGenericServices: boolean expected";
-                if (message.javaGenericServices != null && message.hasOwnProperty("javaGenericServices"))
+                if (message.javaGenericServices != null && Object.hasOwnProperty.call(message, "javaGenericServices"))
                     if (typeof message.javaGenericServices !== "boolean")
                         return "javaGenericServices: boolean expected";
-                if (message.pyGenericServices != null && message.hasOwnProperty("pyGenericServices"))
+                if (message.pyGenericServices != null && Object.hasOwnProperty.call(message, "pyGenericServices"))
                     if (typeof message.pyGenericServices !== "boolean")
                         return "pyGenericServices: boolean expected";
-                if (message.deprecated != null && message.hasOwnProperty("deprecated"))
+                if (message.deprecated != null && Object.hasOwnProperty.call(message, "deprecated"))
                     if (typeof message.deprecated !== "boolean")
                         return "deprecated: boolean expected";
-                if (message.ccEnableArenas != null && message.hasOwnProperty("ccEnableArenas"))
+                if (message.ccEnableArenas != null && Object.hasOwnProperty.call(message, "ccEnableArenas"))
                     if (typeof message.ccEnableArenas !== "boolean")
                         return "ccEnableArenas: boolean expected";
-                if (message.objcClassPrefix != null && message.hasOwnProperty("objcClassPrefix"))
+                if (message.objcClassPrefix != null && Object.hasOwnProperty.call(message, "objcClassPrefix"))
                     if (!$util.isString(message.objcClassPrefix))
                         return "objcClassPrefix: string expected";
-                if (message.csharpNamespace != null && message.hasOwnProperty("csharpNamespace"))
+                if (message.csharpNamespace != null && Object.hasOwnProperty.call(message, "csharpNamespace"))
                     if (!$util.isString(message.csharpNamespace))
                         return "csharpNamespace: string expected";
-                if (message.swiftPrefix != null && message.hasOwnProperty("swiftPrefix"))
+                if (message.swiftPrefix != null && Object.hasOwnProperty.call(message, "swiftPrefix"))
                     if (!$util.isString(message.swiftPrefix))
                         return "swiftPrefix: string expected";
-                if (message.phpClassPrefix != null && message.hasOwnProperty("phpClassPrefix"))
+                if (message.phpClassPrefix != null && Object.hasOwnProperty.call(message, "phpClassPrefix"))
                     if (!$util.isString(message.phpClassPrefix))
                         return "phpClassPrefix: string expected";
-                if (message.phpNamespace != null && message.hasOwnProperty("phpNamespace"))
+                if (message.phpNamespace != null && Object.hasOwnProperty.call(message, "phpNamespace"))
                     if (!$util.isString(message.phpNamespace))
                         return "phpNamespace: string expected";
-                if (message.phpMetadataNamespace != null && message.hasOwnProperty("phpMetadataNamespace"))
+                if (message.phpMetadataNamespace != null && Object.hasOwnProperty.call(message, "phpMetadataNamespace"))
                     if (!$util.isString(message.phpMetadataNamespace))
                         return "phpMetadataNamespace: string expected";
-                if (message.rubyPackage != null && message.hasOwnProperty("rubyPackage"))
+                if (message.rubyPackage != null && Object.hasOwnProperty.call(message, "rubyPackage"))
                     if (!$util.isString(message.rubyPackage))
                         return "rubyPackage: string expected";
-                if (message.features != null && message.hasOwnProperty("features")) {
+                if (message.features != null && Object.hasOwnProperty.call(message, "features")) {
                     var error = $root.google.protobuf.FeatureSet.verify(message.features, long + 1);
                     if (error)
                         return "features." + error;
                 }
-                if (message.uninterpretedOption != null && message.hasOwnProperty("uninterpretedOption")) {
+                if (message.uninterpretedOption != null && Object.hasOwnProperty.call(message, "uninterpretedOption")) {
                     if (!Array.isArray(message.uninterpretedOption))
                         return "uninterpretedOption: array expected";
                     for (var i = 0; i < message.uninterpretedOption.length; ++i) {
@@ -16642,45 +16642,45 @@ $root.google = (function() {
                     object.rubyPackage = "";
                     object.features = null;
                 }
-                if (message.javaPackage != null && message.hasOwnProperty("javaPackage"))
+                if (message.javaPackage != null && Object.hasOwnProperty.call(message, "javaPackage"))
                     object.javaPackage = message.javaPackage;
-                if (message.javaOuterClassname != null && message.hasOwnProperty("javaOuterClassname"))
+                if (message.javaOuterClassname != null && Object.hasOwnProperty.call(message, "javaOuterClassname"))
                     object.javaOuterClassname = message.javaOuterClassname;
-                if (message.optimizeFor != null && message.hasOwnProperty("optimizeFor"))
+                if (message.optimizeFor != null && Object.hasOwnProperty.call(message, "optimizeFor"))
                     object.optimizeFor = options.enums === String ? $root.google.protobuf.FileOptions.OptimizeMode[message.optimizeFor] === undefined ? message.optimizeFor : $root.google.protobuf.FileOptions.OptimizeMode[message.optimizeFor] : message.optimizeFor;
-                if (message.javaMultipleFiles != null && message.hasOwnProperty("javaMultipleFiles"))
+                if (message.javaMultipleFiles != null && Object.hasOwnProperty.call(message, "javaMultipleFiles"))
                     object.javaMultipleFiles = message.javaMultipleFiles;
-                if (message.goPackage != null && message.hasOwnProperty("goPackage"))
+                if (message.goPackage != null && Object.hasOwnProperty.call(message, "goPackage"))
                     object.goPackage = message.goPackage;
-                if (message.ccGenericServices != null && message.hasOwnProperty("ccGenericServices"))
+                if (message.ccGenericServices != null && Object.hasOwnProperty.call(message, "ccGenericServices"))
                     object.ccGenericServices = message.ccGenericServices;
-                if (message.javaGenericServices != null && message.hasOwnProperty("javaGenericServices"))
+                if (message.javaGenericServices != null && Object.hasOwnProperty.call(message, "javaGenericServices"))
                     object.javaGenericServices = message.javaGenericServices;
-                if (message.pyGenericServices != null && message.hasOwnProperty("pyGenericServices"))
+                if (message.pyGenericServices != null && Object.hasOwnProperty.call(message, "pyGenericServices"))
                     object.pyGenericServices = message.pyGenericServices;
-                if (message.javaGenerateEqualsAndHash != null && message.hasOwnProperty("javaGenerateEqualsAndHash"))
+                if (message.javaGenerateEqualsAndHash != null && Object.hasOwnProperty.call(message, "javaGenerateEqualsAndHash"))
                     object.javaGenerateEqualsAndHash = message.javaGenerateEqualsAndHash;
-                if (message.deprecated != null && message.hasOwnProperty("deprecated"))
+                if (message.deprecated != null && Object.hasOwnProperty.call(message, "deprecated"))
                     object.deprecated = message.deprecated;
-                if (message.javaStringCheckUtf8 != null && message.hasOwnProperty("javaStringCheckUtf8"))
+                if (message.javaStringCheckUtf8 != null && Object.hasOwnProperty.call(message, "javaStringCheckUtf8"))
                     object.javaStringCheckUtf8 = message.javaStringCheckUtf8;
-                if (message.ccEnableArenas != null && message.hasOwnProperty("ccEnableArenas"))
+                if (message.ccEnableArenas != null && Object.hasOwnProperty.call(message, "ccEnableArenas"))
                     object.ccEnableArenas = message.ccEnableArenas;
-                if (message.objcClassPrefix != null && message.hasOwnProperty("objcClassPrefix"))
+                if (message.objcClassPrefix != null && Object.hasOwnProperty.call(message, "objcClassPrefix"))
                     object.objcClassPrefix = message.objcClassPrefix;
-                if (message.csharpNamespace != null && message.hasOwnProperty("csharpNamespace"))
+                if (message.csharpNamespace != null && Object.hasOwnProperty.call(message, "csharpNamespace"))
                     object.csharpNamespace = message.csharpNamespace;
-                if (message.swiftPrefix != null && message.hasOwnProperty("swiftPrefix"))
+                if (message.swiftPrefix != null && Object.hasOwnProperty.call(message, "swiftPrefix"))
                     object.swiftPrefix = message.swiftPrefix;
-                if (message.phpClassPrefix != null && message.hasOwnProperty("phpClassPrefix"))
+                if (message.phpClassPrefix != null && Object.hasOwnProperty.call(message, "phpClassPrefix"))
                     object.phpClassPrefix = message.phpClassPrefix;
-                if (message.phpNamespace != null && message.hasOwnProperty("phpNamespace"))
+                if (message.phpNamespace != null && Object.hasOwnProperty.call(message, "phpNamespace"))
                     object.phpNamespace = message.phpNamespace;
-                if (message.phpMetadataNamespace != null && message.hasOwnProperty("phpMetadataNamespace"))
+                if (message.phpMetadataNamespace != null && Object.hasOwnProperty.call(message, "phpMetadataNamespace"))
                     object.phpMetadataNamespace = message.phpMetadataNamespace;
-                if (message.rubyPackage != null && message.hasOwnProperty("rubyPackage"))
+                if (message.rubyPackage != null && Object.hasOwnProperty.call(message, "rubyPackage"))
                     object.rubyPackage = message.rubyPackage;
-                if (message.features != null && message.hasOwnProperty("features"))
+                if (message.features != null && Object.hasOwnProperty.call(message, "features"))
                     object.features = $root.google.protobuf.FeatureSet.toObject(message.features, options, q + 1);
                 if (message.uninterpretedOption && message.uninterpretedOption.length) {
                     object.uninterpretedOption = [];
@@ -16974,27 +16974,27 @@ $root.google = (function() {
                     long = 0;
                 if (long > $util.recursionLimit)
                     return "maximum nesting depth exceeded";
-                if (message.messageSetWireFormat != null && message.hasOwnProperty("messageSetWireFormat"))
+                if (message.messageSetWireFormat != null && Object.hasOwnProperty.call(message, "messageSetWireFormat"))
                     if (typeof message.messageSetWireFormat !== "boolean")
                         return "messageSetWireFormat: boolean expected";
-                if (message.noStandardDescriptorAccessor != null && message.hasOwnProperty("noStandardDescriptorAccessor"))
+                if (message.noStandardDescriptorAccessor != null && Object.hasOwnProperty.call(message, "noStandardDescriptorAccessor"))
                     if (typeof message.noStandardDescriptorAccessor !== "boolean")
                         return "noStandardDescriptorAccessor: boolean expected";
-                if (message.deprecated != null && message.hasOwnProperty("deprecated"))
+                if (message.deprecated != null && Object.hasOwnProperty.call(message, "deprecated"))
                     if (typeof message.deprecated !== "boolean")
                         return "deprecated: boolean expected";
-                if (message.mapEntry != null && message.hasOwnProperty("mapEntry"))
+                if (message.mapEntry != null && Object.hasOwnProperty.call(message, "mapEntry"))
                     if (typeof message.mapEntry !== "boolean")
                         return "mapEntry: boolean expected";
-                if (message.deprecatedLegacyJsonFieldConflicts != null && message.hasOwnProperty("deprecatedLegacyJsonFieldConflicts"))
+                if (message.deprecatedLegacyJsonFieldConflicts != null && Object.hasOwnProperty.call(message, "deprecatedLegacyJsonFieldConflicts"))
                     if (typeof message.deprecatedLegacyJsonFieldConflicts !== "boolean")
                         return "deprecatedLegacyJsonFieldConflicts: boolean expected";
-                if (message.features != null && message.hasOwnProperty("features")) {
+                if (message.features != null && Object.hasOwnProperty.call(message, "features")) {
                     var error = $root.google.protobuf.FeatureSet.verify(message.features, long + 1);
                     if (error)
                         return "features." + error;
                 }
-                if (message.uninterpretedOption != null && message.hasOwnProperty("uninterpretedOption")) {
+                if (message.uninterpretedOption != null && Object.hasOwnProperty.call(message, "uninterpretedOption")) {
                     if (!Array.isArray(message.uninterpretedOption))
                         return "uninterpretedOption: array expected";
                     for (var i = 0; i < message.uninterpretedOption.length; ++i) {
@@ -17079,17 +17079,17 @@ $root.google = (function() {
                     object.deprecatedLegacyJsonFieldConflicts = false;
                     object.features = null;
                 }
-                if (message.messageSetWireFormat != null && message.hasOwnProperty("messageSetWireFormat"))
+                if (message.messageSetWireFormat != null && Object.hasOwnProperty.call(message, "messageSetWireFormat"))
                     object.messageSetWireFormat = message.messageSetWireFormat;
-                if (message.noStandardDescriptorAccessor != null && message.hasOwnProperty("noStandardDescriptorAccessor"))
+                if (message.noStandardDescriptorAccessor != null && Object.hasOwnProperty.call(message, "noStandardDescriptorAccessor"))
                     object.noStandardDescriptorAccessor = message.noStandardDescriptorAccessor;
-                if (message.deprecated != null && message.hasOwnProperty("deprecated"))
+                if (message.deprecated != null && Object.hasOwnProperty.call(message, "deprecated"))
                     object.deprecated = message.deprecated;
-                if (message.mapEntry != null && message.hasOwnProperty("mapEntry"))
+                if (message.mapEntry != null && Object.hasOwnProperty.call(message, "mapEntry"))
                     object.mapEntry = message.mapEntry;
-                if (message.deprecatedLegacyJsonFieldConflicts != null && message.hasOwnProperty("deprecatedLegacyJsonFieldConflicts"))
+                if (message.deprecatedLegacyJsonFieldConflicts != null && Object.hasOwnProperty.call(message, "deprecatedLegacyJsonFieldConflicts"))
                     object.deprecatedLegacyJsonFieldConflicts = message.deprecatedLegacyJsonFieldConflicts;
-                if (message.features != null && message.hasOwnProperty("features"))
+                if (message.features != null && Object.hasOwnProperty.call(message, "features"))
                     object.features = $root.google.protobuf.FeatureSet.toObject(message.features, options, q + 1);
                 if (message.uninterpretedOption && message.uninterpretedOption.length) {
                     object.uninterpretedOption = [];
@@ -17485,7 +17485,7 @@ $root.google = (function() {
                     long = 0;
                 if (long > $util.recursionLimit)
                     return "maximum nesting depth exceeded";
-                if (message.ctype != null && message.hasOwnProperty("ctype"))
+                if (message.ctype != null && Object.hasOwnProperty.call(message, "ctype"))
                     switch (message.ctype) {
                     default:
                         return "ctype: enum value expected";
@@ -17494,10 +17494,10 @@ $root.google = (function() {
                     case 2:
                         break;
                     }
-                if (message.packed != null && message.hasOwnProperty("packed"))
+                if (message.packed != null && Object.hasOwnProperty.call(message, "packed"))
                     if (typeof message.packed !== "boolean")
                         return "packed: boolean expected";
-                if (message.jstype != null && message.hasOwnProperty("jstype"))
+                if (message.jstype != null && Object.hasOwnProperty.call(message, "jstype"))
                     switch (message.jstype) {
                     default:
                         return "jstype: enum value expected";
@@ -17506,22 +17506,22 @@ $root.google = (function() {
                     case 2:
                         break;
                     }
-                if (message.lazy != null && message.hasOwnProperty("lazy"))
+                if (message.lazy != null && Object.hasOwnProperty.call(message, "lazy"))
                     if (typeof message.lazy !== "boolean")
                         return "lazy: boolean expected";
-                if (message.unverifiedLazy != null && message.hasOwnProperty("unverifiedLazy"))
+                if (message.unverifiedLazy != null && Object.hasOwnProperty.call(message, "unverifiedLazy"))
                     if (typeof message.unverifiedLazy !== "boolean")
                         return "unverifiedLazy: boolean expected";
-                if (message.deprecated != null && message.hasOwnProperty("deprecated"))
+                if (message.deprecated != null && Object.hasOwnProperty.call(message, "deprecated"))
                     if (typeof message.deprecated !== "boolean")
                         return "deprecated: boolean expected";
-                if (message.weak != null && message.hasOwnProperty("weak"))
+                if (message.weak != null && Object.hasOwnProperty.call(message, "weak"))
                     if (typeof message.weak !== "boolean")
                         return "weak: boolean expected";
-                if (message.debugRedact != null && message.hasOwnProperty("debugRedact"))
+                if (message.debugRedact != null && Object.hasOwnProperty.call(message, "debugRedact"))
                     if (typeof message.debugRedact !== "boolean")
                         return "debugRedact: boolean expected";
-                if (message.retention != null && message.hasOwnProperty("retention"))
+                if (message.retention != null && Object.hasOwnProperty.call(message, "retention"))
                     switch (message.retention) {
                     default:
                         return "retention: enum value expected";
@@ -17530,7 +17530,7 @@ $root.google = (function() {
                     case 2:
                         break;
                     }
-                if (message.targets != null && message.hasOwnProperty("targets")) {
+                if (message.targets != null && Object.hasOwnProperty.call(message, "targets")) {
                     if (!Array.isArray(message.targets))
                         return "targets: array expected";
                     for (var i = 0; i < message.targets.length; ++i)
@@ -17550,7 +17550,7 @@ $root.google = (function() {
                             break;
                         }
                 }
-                if (message.editionDefaults != null && message.hasOwnProperty("editionDefaults")) {
+                if (message.editionDefaults != null && Object.hasOwnProperty.call(message, "editionDefaults")) {
                     if (!Array.isArray(message.editionDefaults))
                         return "editionDefaults: array expected";
                     for (var i = 0; i < message.editionDefaults.length; ++i) {
@@ -17559,17 +17559,17 @@ $root.google = (function() {
                             return "editionDefaults." + error;
                     }
                 }
-                if (message.features != null && message.hasOwnProperty("features")) {
+                if (message.features != null && Object.hasOwnProperty.call(message, "features")) {
                     var error = $root.google.protobuf.FeatureSet.verify(message.features, long + 1);
                     if (error)
                         return "features." + error;
                 }
-                if (message.featureSupport != null && message.hasOwnProperty("featureSupport")) {
+                if (message.featureSupport != null && Object.hasOwnProperty.call(message, "featureSupport")) {
                     var error = $root.google.protobuf.FieldOptions.FeatureSupport.verify(message.featureSupport, long + 1);
                     if (error)
                         return "featureSupport." + error;
                 }
-                if (message.uninterpretedOption != null && message.hasOwnProperty("uninterpretedOption")) {
+                if (message.uninterpretedOption != null && Object.hasOwnProperty.call(message, "uninterpretedOption")) {
                     if (!Array.isArray(message.uninterpretedOption))
                         return "uninterpretedOption: array expected";
                     for (var i = 0; i < message.uninterpretedOption.length; ++i) {
@@ -17792,23 +17792,23 @@ $root.google = (function() {
                     object.features = null;
                     object.featureSupport = null;
                 }
-                if (message.ctype != null && message.hasOwnProperty("ctype"))
+                if (message.ctype != null && Object.hasOwnProperty.call(message, "ctype"))
                     object.ctype = options.enums === String ? $root.google.protobuf.FieldOptions.CType[message.ctype] === undefined ? message.ctype : $root.google.protobuf.FieldOptions.CType[message.ctype] : message.ctype;
-                if (message.packed != null && message.hasOwnProperty("packed"))
+                if (message.packed != null && Object.hasOwnProperty.call(message, "packed"))
                     object.packed = message.packed;
-                if (message.deprecated != null && message.hasOwnProperty("deprecated"))
+                if (message.deprecated != null && Object.hasOwnProperty.call(message, "deprecated"))
                     object.deprecated = message.deprecated;
-                if (message.lazy != null && message.hasOwnProperty("lazy"))
+                if (message.lazy != null && Object.hasOwnProperty.call(message, "lazy"))
                     object.lazy = message.lazy;
-                if (message.jstype != null && message.hasOwnProperty("jstype"))
+                if (message.jstype != null && Object.hasOwnProperty.call(message, "jstype"))
                     object.jstype = options.enums === String ? $root.google.protobuf.FieldOptions.JSType[message.jstype] === undefined ? message.jstype : $root.google.protobuf.FieldOptions.JSType[message.jstype] : message.jstype;
-                if (message.weak != null && message.hasOwnProperty("weak"))
+                if (message.weak != null && Object.hasOwnProperty.call(message, "weak"))
                     object.weak = message.weak;
-                if (message.unverifiedLazy != null && message.hasOwnProperty("unverifiedLazy"))
+                if (message.unverifiedLazy != null && Object.hasOwnProperty.call(message, "unverifiedLazy"))
                     object.unverifiedLazy = message.unverifiedLazy;
-                if (message.debugRedact != null && message.hasOwnProperty("debugRedact"))
+                if (message.debugRedact != null && Object.hasOwnProperty.call(message, "debugRedact"))
                     object.debugRedact = message.debugRedact;
-                if (message.retention != null && message.hasOwnProperty("retention"))
+                if (message.retention != null && Object.hasOwnProperty.call(message, "retention"))
                     object.retention = options.enums === String ? $root.google.protobuf.FieldOptions.OptionRetention[message.retention] === undefined ? message.retention : $root.google.protobuf.FieldOptions.OptionRetention[message.retention] : message.retention;
                 if (message.targets && message.targets.length) {
                     object.targets = [];
@@ -17820,9 +17820,9 @@ $root.google = (function() {
                     for (var j = 0; j < message.editionDefaults.length; ++j)
                         object.editionDefaults[j] = $root.google.protobuf.FieldOptions.EditionDefault.toObject(message.editionDefaults[j], options, q + 1);
                 }
-                if (message.features != null && message.hasOwnProperty("features"))
+                if (message.features != null && Object.hasOwnProperty.call(message, "features"))
                     object.features = $root.google.protobuf.FeatureSet.toObject(message.features, options, q + 1);
-                if (message.featureSupport != null && message.hasOwnProperty("featureSupport"))
+                if (message.featureSupport != null && Object.hasOwnProperty.call(message, "featureSupport"))
                     object.featureSupport = $root.google.protobuf.FieldOptions.FeatureSupport.toObject(message.featureSupport, options, q + 1);
                 if (message.uninterpretedOption && message.uninterpretedOption.length) {
                     object.uninterpretedOption = [];
@@ -18096,7 +18096,7 @@ $root.google = (function() {
                         long = 0;
                     if (long > $util.recursionLimit)
                         return "maximum nesting depth exceeded";
-                    if (message.edition != null && message.hasOwnProperty("edition"))
+                    if (message.edition != null && Object.hasOwnProperty.call(message, "edition"))
                         switch (message.edition) {
                         default:
                             return "edition: enum value expected";
@@ -18114,7 +18114,7 @@ $root.google = (function() {
                         case 2147483647:
                             break;
                         }
-                    if (message.value != null && message.hasOwnProperty("value"))
+                    if (message.value != null && Object.hasOwnProperty.call(message, "value"))
                         if (!$util.isString(message.value))
                             return "value: string expected";
                     return null;
@@ -18220,9 +18220,9 @@ $root.google = (function() {
                         object.value = "";
                         object.edition = options.enums === String ? "EDITION_UNKNOWN" : 0;
                     }
-                    if (message.value != null && message.hasOwnProperty("value"))
+                    if (message.value != null && Object.hasOwnProperty.call(message, "value"))
                         object.value = message.value;
-                    if (message.edition != null && message.hasOwnProperty("edition"))
+                    if (message.edition != null && Object.hasOwnProperty.call(message, "edition"))
                         object.edition = options.enums === String ? $root.google.protobuf.Edition[message.edition] === undefined ? message.edition : $root.google.protobuf.Edition[message.edition] : message.edition;
                     return object;
                 };
@@ -18446,7 +18446,7 @@ $root.google = (function() {
                         long = 0;
                     if (long > $util.recursionLimit)
                         return "maximum nesting depth exceeded";
-                    if (message.editionIntroduced != null && message.hasOwnProperty("editionIntroduced"))
+                    if (message.editionIntroduced != null && Object.hasOwnProperty.call(message, "editionIntroduced"))
                         switch (message.editionIntroduced) {
                         default:
                             return "editionIntroduced: enum value expected";
@@ -18464,7 +18464,7 @@ $root.google = (function() {
                         case 2147483647:
                             break;
                         }
-                    if (message.editionDeprecated != null && message.hasOwnProperty("editionDeprecated"))
+                    if (message.editionDeprecated != null && Object.hasOwnProperty.call(message, "editionDeprecated"))
                         switch (message.editionDeprecated) {
                         default:
                             return "editionDeprecated: enum value expected";
@@ -18482,10 +18482,10 @@ $root.google = (function() {
                         case 2147483647:
                             break;
                         }
-                    if (message.deprecationWarning != null && message.hasOwnProperty("deprecationWarning"))
+                    if (message.deprecationWarning != null && Object.hasOwnProperty.call(message, "deprecationWarning"))
                         if (!$util.isString(message.deprecationWarning))
                             return "deprecationWarning: string expected";
-                    if (message.editionRemoved != null && message.hasOwnProperty("editionRemoved"))
+                    if (message.editionRemoved != null && Object.hasOwnProperty.call(message, "editionRemoved"))
                         switch (message.editionRemoved) {
                         default:
                             return "editionRemoved: enum value expected";
@@ -18720,13 +18720,13 @@ $root.google = (function() {
                         object.deprecationWarning = "";
                         object.editionRemoved = options.enums === String ? "EDITION_UNKNOWN" : 0;
                     }
-                    if (message.editionIntroduced != null && message.hasOwnProperty("editionIntroduced"))
+                    if (message.editionIntroduced != null && Object.hasOwnProperty.call(message, "editionIntroduced"))
                         object.editionIntroduced = options.enums === String ? $root.google.protobuf.Edition[message.editionIntroduced] === undefined ? message.editionIntroduced : $root.google.protobuf.Edition[message.editionIntroduced] : message.editionIntroduced;
-                    if (message.editionDeprecated != null && message.hasOwnProperty("editionDeprecated"))
+                    if (message.editionDeprecated != null && Object.hasOwnProperty.call(message, "editionDeprecated"))
                         object.editionDeprecated = options.enums === String ? $root.google.protobuf.Edition[message.editionDeprecated] === undefined ? message.editionDeprecated : $root.google.protobuf.Edition[message.editionDeprecated] : message.editionDeprecated;
-                    if (message.deprecationWarning != null && message.hasOwnProperty("deprecationWarning"))
+                    if (message.deprecationWarning != null && Object.hasOwnProperty.call(message, "deprecationWarning"))
                         object.deprecationWarning = message.deprecationWarning;
-                    if (message.editionRemoved != null && message.hasOwnProperty("editionRemoved"))
+                    if (message.editionRemoved != null && Object.hasOwnProperty.call(message, "editionRemoved"))
                         object.editionRemoved = options.enums === String ? $root.google.protobuf.Edition[message.editionRemoved] === undefined ? message.editionRemoved : $root.google.protobuf.Edition[message.editionRemoved] : message.editionRemoved;
                     return object;
                 };
@@ -18927,12 +18927,12 @@ $root.google = (function() {
                     long = 0;
                 if (long > $util.recursionLimit)
                     return "maximum nesting depth exceeded";
-                if (message.features != null && message.hasOwnProperty("features")) {
+                if (message.features != null && Object.hasOwnProperty.call(message, "features")) {
                     var error = $root.google.protobuf.FeatureSet.verify(message.features, long + 1);
                     if (error)
                         return "features." + error;
                 }
-                if (message.uninterpretedOption != null && message.hasOwnProperty("uninterpretedOption")) {
+                if (message.uninterpretedOption != null && Object.hasOwnProperty.call(message, "uninterpretedOption")) {
                     if (!Array.isArray(message.uninterpretedOption))
                         return "uninterpretedOption: array expected";
                     for (var i = 0; i < message.uninterpretedOption.length; ++i) {
@@ -19001,7 +19001,7 @@ $root.google = (function() {
                     object.uninterpretedOption = [];
                 if (options.defaults)
                     object.features = null;
-                if (message.features != null && message.hasOwnProperty("features"))
+                if (message.features != null && Object.hasOwnProperty.call(message, "features"))
                     object.features = $root.google.protobuf.FeatureSet.toObject(message.features, options, q + 1);
                 if (message.uninterpretedOption && message.uninterpretedOption.length) {
                     object.uninterpretedOption = [];
@@ -19264,21 +19264,21 @@ $root.google = (function() {
                     long = 0;
                 if (long > $util.recursionLimit)
                     return "maximum nesting depth exceeded";
-                if (message.allowAlias != null && message.hasOwnProperty("allowAlias"))
+                if (message.allowAlias != null && Object.hasOwnProperty.call(message, "allowAlias"))
                     if (typeof message.allowAlias !== "boolean")
                         return "allowAlias: boolean expected";
-                if (message.deprecated != null && message.hasOwnProperty("deprecated"))
+                if (message.deprecated != null && Object.hasOwnProperty.call(message, "deprecated"))
                     if (typeof message.deprecated !== "boolean")
                         return "deprecated: boolean expected";
-                if (message.deprecatedLegacyJsonFieldConflicts != null && message.hasOwnProperty("deprecatedLegacyJsonFieldConflicts"))
+                if (message.deprecatedLegacyJsonFieldConflicts != null && Object.hasOwnProperty.call(message, "deprecatedLegacyJsonFieldConflicts"))
                     if (typeof message.deprecatedLegacyJsonFieldConflicts !== "boolean")
                         return "deprecatedLegacyJsonFieldConflicts: boolean expected";
-                if (message.features != null && message.hasOwnProperty("features")) {
+                if (message.features != null && Object.hasOwnProperty.call(message, "features")) {
                     var error = $root.google.protobuf.FeatureSet.verify(message.features, long + 1);
                     if (error)
                         return "features." + error;
                 }
-                if (message.uninterpretedOption != null && message.hasOwnProperty("uninterpretedOption")) {
+                if (message.uninterpretedOption != null && Object.hasOwnProperty.call(message, "uninterpretedOption")) {
                     if (!Array.isArray(message.uninterpretedOption))
                         return "uninterpretedOption: array expected";
                     for (var i = 0; i < message.uninterpretedOption.length; ++i) {
@@ -19287,7 +19287,7 @@ $root.google = (function() {
                             return "uninterpretedOption." + error;
                     }
                 }
-                if (message[".jspb.test.IsExtension.simpleOption"] != null && message.hasOwnProperty(".jspb.test.IsExtension.simpleOption"))
+                if (message[".jspb.test.IsExtension.simpleOption"] != null && Object.hasOwnProperty.call(message, ".jspb.test.IsExtension.simpleOption"))
                     if (!$util.isString(message[".jspb.test.IsExtension.simpleOption"]))
                         return ".jspb.test.IsExtension.simpleOption: string expected";
                 return null;
@@ -19363,20 +19363,20 @@ $root.google = (function() {
                     object.features = null;
                     object[".jspb.test.IsExtension.simpleOption"] = "";
                 }
-                if (message.allowAlias != null && message.hasOwnProperty("allowAlias"))
+                if (message.allowAlias != null && Object.hasOwnProperty.call(message, "allowAlias"))
                     object.allowAlias = message.allowAlias;
-                if (message.deprecated != null && message.hasOwnProperty("deprecated"))
+                if (message.deprecated != null && Object.hasOwnProperty.call(message, "deprecated"))
                     object.deprecated = message.deprecated;
-                if (message.deprecatedLegacyJsonFieldConflicts != null && message.hasOwnProperty("deprecatedLegacyJsonFieldConflicts"))
+                if (message.deprecatedLegacyJsonFieldConflicts != null && Object.hasOwnProperty.call(message, "deprecatedLegacyJsonFieldConflicts"))
                     object.deprecatedLegacyJsonFieldConflicts = message.deprecatedLegacyJsonFieldConflicts;
-                if (message.features != null && message.hasOwnProperty("features"))
+                if (message.features != null && Object.hasOwnProperty.call(message, "features"))
                     object.features = $root.google.protobuf.FeatureSet.toObject(message.features, options, q + 1);
                 if (message.uninterpretedOption && message.uninterpretedOption.length) {
                     object.uninterpretedOption = [];
                     for (var j = 0; j < message.uninterpretedOption.length; ++j)
                         object.uninterpretedOption[j] = $root.google.protobuf.UninterpretedOption.toObject(message.uninterpretedOption[j], options, q + 1);
                 }
-                if (message[".jspb.test.IsExtension.simpleOption"] != null && message.hasOwnProperty(".jspb.test.IsExtension.simpleOption"))
+                if (message[".jspb.test.IsExtension.simpleOption"] != null && Object.hasOwnProperty.call(message, ".jspb.test.IsExtension.simpleOption"))
                     object[".jspb.test.IsExtension.simpleOption"] = message[".jspb.test.IsExtension.simpleOption"];
                 return object;
             };
@@ -19619,23 +19619,23 @@ $root.google = (function() {
                     long = 0;
                 if (long > $util.recursionLimit)
                     return "maximum nesting depth exceeded";
-                if (message.deprecated != null && message.hasOwnProperty("deprecated"))
+                if (message.deprecated != null && Object.hasOwnProperty.call(message, "deprecated"))
                     if (typeof message.deprecated !== "boolean")
                         return "deprecated: boolean expected";
-                if (message.features != null && message.hasOwnProperty("features")) {
+                if (message.features != null && Object.hasOwnProperty.call(message, "features")) {
                     var error = $root.google.protobuf.FeatureSet.verify(message.features, long + 1);
                     if (error)
                         return "features." + error;
                 }
-                if (message.debugRedact != null && message.hasOwnProperty("debugRedact"))
+                if (message.debugRedact != null && Object.hasOwnProperty.call(message, "debugRedact"))
                     if (typeof message.debugRedact !== "boolean")
                         return "debugRedact: boolean expected";
-                if (message.featureSupport != null && message.hasOwnProperty("featureSupport")) {
+                if (message.featureSupport != null && Object.hasOwnProperty.call(message, "featureSupport")) {
                     var error = $root.google.protobuf.FieldOptions.FeatureSupport.verify(message.featureSupport, long + 1);
                     if (error)
                         return "featureSupport." + error;
                 }
-                if (message.uninterpretedOption != null && message.hasOwnProperty("uninterpretedOption")) {
+                if (message.uninterpretedOption != null && Object.hasOwnProperty.call(message, "uninterpretedOption")) {
                     if (!Array.isArray(message.uninterpretedOption))
                         return "uninterpretedOption: array expected";
                     for (var i = 0; i < message.uninterpretedOption.length; ++i) {
@@ -19717,13 +19717,13 @@ $root.google = (function() {
                     object.debugRedact = false;
                     object.featureSupport = null;
                 }
-                if (message.deprecated != null && message.hasOwnProperty("deprecated"))
+                if (message.deprecated != null && Object.hasOwnProperty.call(message, "deprecated"))
                     object.deprecated = message.deprecated;
-                if (message.features != null && message.hasOwnProperty("features"))
+                if (message.features != null && Object.hasOwnProperty.call(message, "features"))
                     object.features = $root.google.protobuf.FeatureSet.toObject(message.features, options, q + 1);
-                if (message.debugRedact != null && message.hasOwnProperty("debugRedact"))
+                if (message.debugRedact != null && Object.hasOwnProperty.call(message, "debugRedact"))
                     object.debugRedact = message.debugRedact;
-                if (message.featureSupport != null && message.hasOwnProperty("featureSupport"))
+                if (message.featureSupport != null && Object.hasOwnProperty.call(message, "featureSupport"))
                     object.featureSupport = $root.google.protobuf.FieldOptions.FeatureSupport.toObject(message.featureSupport, options, q + 1);
                 if (message.uninterpretedOption && message.uninterpretedOption.length) {
                     object.uninterpretedOption = [];
@@ -19941,15 +19941,15 @@ $root.google = (function() {
                     long = 0;
                 if (long > $util.recursionLimit)
                     return "maximum nesting depth exceeded";
-                if (message.features != null && message.hasOwnProperty("features")) {
+                if (message.features != null && Object.hasOwnProperty.call(message, "features")) {
                     var error = $root.google.protobuf.FeatureSet.verify(message.features, long + 1);
                     if (error)
                         return "features." + error;
                 }
-                if (message.deprecated != null && message.hasOwnProperty("deprecated"))
+                if (message.deprecated != null && Object.hasOwnProperty.call(message, "deprecated"))
                     if (typeof message.deprecated !== "boolean")
                         return "deprecated: boolean expected";
-                if (message.uninterpretedOption != null && message.hasOwnProperty("uninterpretedOption")) {
+                if (message.uninterpretedOption != null && Object.hasOwnProperty.call(message, "uninterpretedOption")) {
                     if (!Array.isArray(message.uninterpretedOption))
                         return "uninterpretedOption: array expected";
                     for (var i = 0; i < message.uninterpretedOption.length; ++i) {
@@ -20022,9 +20022,9 @@ $root.google = (function() {
                     object.deprecated = false;
                     object.features = null;
                 }
-                if (message.deprecated != null && message.hasOwnProperty("deprecated"))
+                if (message.deprecated != null && Object.hasOwnProperty.call(message, "deprecated"))
                     object.deprecated = message.deprecated;
-                if (message.features != null && message.hasOwnProperty("features"))
+                if (message.features != null && Object.hasOwnProperty.call(message, "features"))
                     object.features = $root.google.protobuf.FeatureSet.toObject(message.features, options, q + 1);
                 if (message.uninterpretedOption && message.uninterpretedOption.length) {
                     object.uninterpretedOption = [];
@@ -20257,10 +20257,10 @@ $root.google = (function() {
                     long = 0;
                 if (long > $util.recursionLimit)
                     return "maximum nesting depth exceeded";
-                if (message.deprecated != null && message.hasOwnProperty("deprecated"))
+                if (message.deprecated != null && Object.hasOwnProperty.call(message, "deprecated"))
                     if (typeof message.deprecated !== "boolean")
                         return "deprecated: boolean expected";
-                if (message.idempotencyLevel != null && message.hasOwnProperty("idempotencyLevel"))
+                if (message.idempotencyLevel != null && Object.hasOwnProperty.call(message, "idempotencyLevel"))
                     switch (message.idempotencyLevel) {
                     default:
                         return "idempotencyLevel: enum value expected";
@@ -20269,12 +20269,12 @@ $root.google = (function() {
                     case 2:
                         break;
                     }
-                if (message.features != null && message.hasOwnProperty("features")) {
+                if (message.features != null && Object.hasOwnProperty.call(message, "features")) {
                     var error = $root.google.protobuf.FeatureSet.verify(message.features, long + 1);
                     if (error)
                         return "features." + error;
                 }
-                if (message.uninterpretedOption != null && message.hasOwnProperty("uninterpretedOption")) {
+                if (message.uninterpretedOption != null && Object.hasOwnProperty.call(message, "uninterpretedOption")) {
                     if (!Array.isArray(message.uninterpretedOption))
                         return "uninterpretedOption: array expected";
                     for (var i = 0; i < message.uninterpretedOption.length; ++i) {
@@ -20368,11 +20368,11 @@ $root.google = (function() {
                     object.idempotencyLevel = options.enums === String ? "IDEMPOTENCY_UNKNOWN" : 0;
                     object.features = null;
                 }
-                if (message.deprecated != null && message.hasOwnProperty("deprecated"))
+                if (message.deprecated != null && Object.hasOwnProperty.call(message, "deprecated"))
                     object.deprecated = message.deprecated;
-                if (message.idempotencyLevel != null && message.hasOwnProperty("idempotencyLevel"))
+                if (message.idempotencyLevel != null && Object.hasOwnProperty.call(message, "idempotencyLevel"))
                     object.idempotencyLevel = options.enums === String ? $root.google.protobuf.MethodOptions.IdempotencyLevel[message.idempotencyLevel] === undefined ? message.idempotencyLevel : $root.google.protobuf.MethodOptions.IdempotencyLevel[message.idempotencyLevel] : message.idempotencyLevel;
-                if (message.features != null && message.hasOwnProperty("features"))
+                if (message.features != null && Object.hasOwnProperty.call(message, "features"))
                     object.features = $root.google.protobuf.FeatureSet.toObject(message.features, options, q + 1);
                 if (message.uninterpretedOption && message.uninterpretedOption.length) {
                     object.uninterpretedOption = [];
@@ -20666,7 +20666,7 @@ $root.google = (function() {
                     long = 0;
                 if (long > $util.recursionLimit)
                     return "maximum nesting depth exceeded";
-                if (message.name != null && message.hasOwnProperty("name")) {
+                if (message.name != null && Object.hasOwnProperty.call(message, "name")) {
                     if (!Array.isArray(message.name))
                         return "name: array expected";
                     for (var i = 0; i < message.name.length; ++i) {
@@ -20675,22 +20675,22 @@ $root.google = (function() {
                             return "name." + error;
                     }
                 }
-                if (message.identifierValue != null && message.hasOwnProperty("identifierValue"))
+                if (message.identifierValue != null && Object.hasOwnProperty.call(message, "identifierValue"))
                     if (!$util.isString(message.identifierValue))
                         return "identifierValue: string expected";
-                if (message.positiveIntValue != null && message.hasOwnProperty("positiveIntValue"))
+                if (message.positiveIntValue != null && Object.hasOwnProperty.call(message, "positiveIntValue"))
                     if (!$util.isInteger(message.positiveIntValue) && !(message.positiveIntValue && $util.isInteger(message.positiveIntValue.low) && $util.isInteger(message.positiveIntValue.high)))
                         return "positiveIntValue: integer|Long expected";
-                if (message.negativeIntValue != null && message.hasOwnProperty("negativeIntValue"))
+                if (message.negativeIntValue != null && Object.hasOwnProperty.call(message, "negativeIntValue"))
                     if (!$util.isInteger(message.negativeIntValue) && !(message.negativeIntValue && $util.isInteger(message.negativeIntValue.low) && $util.isInteger(message.negativeIntValue.high)))
                         return "negativeIntValue: integer|Long expected";
-                if (message.doubleValue != null && message.hasOwnProperty("doubleValue"))
+                if (message.doubleValue != null && Object.hasOwnProperty.call(message, "doubleValue"))
                     if (typeof message.doubleValue !== "number")
                         return "doubleValue: number expected";
-                if (message.stringValue != null && message.hasOwnProperty("stringValue"))
+                if (message.stringValue != null && Object.hasOwnProperty.call(message, "stringValue"))
                     if (!(message.stringValue && typeof message.stringValue.length === "number" || $util.isString(message.stringValue)))
                         return "stringValue: buffer expected";
-                if (message.aggregateValue != null && message.hasOwnProperty("aggregateValue"))
+                if (message.aggregateValue != null && Object.hasOwnProperty.call(message, "aggregateValue"))
                     if (!$util.isString(message.aggregateValue))
                         return "aggregateValue: string expected";
                 return null;
@@ -20802,27 +20802,27 @@ $root.google = (function() {
                     for (var j = 0; j < message.name.length; ++j)
                         object.name[j] = $root.google.protobuf.UninterpretedOption.NamePart.toObject(message.name[j], options, q + 1);
                 }
-                if (message.identifierValue != null && message.hasOwnProperty("identifierValue"))
+                if (message.identifierValue != null && Object.hasOwnProperty.call(message, "identifierValue"))
                     object.identifierValue = message.identifierValue;
-                if (message.positiveIntValue != null && message.hasOwnProperty("positiveIntValue"))
+                if (message.positiveIntValue != null && Object.hasOwnProperty.call(message, "positiveIntValue"))
                     if (typeof BigInt !== "undefined" && options.longs === BigInt)
                         object.positiveIntValue = typeof message.positiveIntValue === "number" ? BigInt(message.positiveIntValue) : $util.Long.fromBits(message.positiveIntValue.low >>> 0, message.positiveIntValue.high >>> 0, true).toBigInt();
                     else if (typeof message.positiveIntValue === "number")
                         object.positiveIntValue = options.longs === String ? String(message.positiveIntValue) : message.positiveIntValue;
                     else
                         object.positiveIntValue = options.longs === String ? $util.Long.prototype.toString.call(message.positiveIntValue) : options.longs === Number ? new $util.LongBits(message.positiveIntValue.low >>> 0, message.positiveIntValue.high >>> 0).toNumber(true) : message.positiveIntValue;
-                if (message.negativeIntValue != null && message.hasOwnProperty("negativeIntValue"))
+                if (message.negativeIntValue != null && Object.hasOwnProperty.call(message, "negativeIntValue"))
                     if (typeof BigInt !== "undefined" && options.longs === BigInt)
                         object.negativeIntValue = typeof message.negativeIntValue === "number" ? BigInt(message.negativeIntValue) : $util.Long.fromBits(message.negativeIntValue.low >>> 0, message.negativeIntValue.high >>> 0, false).toBigInt();
                     else if (typeof message.negativeIntValue === "number")
                         object.negativeIntValue = options.longs === String ? String(message.negativeIntValue) : message.negativeIntValue;
                     else
                         object.negativeIntValue = options.longs === String ? $util.Long.prototype.toString.call(message.negativeIntValue) : options.longs === Number ? new $util.LongBits(message.negativeIntValue.low >>> 0, message.negativeIntValue.high >>> 0).toNumber() : message.negativeIntValue;
-                if (message.doubleValue != null && message.hasOwnProperty("doubleValue"))
+                if (message.doubleValue != null && Object.hasOwnProperty.call(message, "doubleValue"))
                     object.doubleValue = options.json && !isFinite(message.doubleValue) ? String(message.doubleValue) : message.doubleValue;
-                if (message.stringValue != null && message.hasOwnProperty("stringValue"))
+                if (message.stringValue != null && Object.hasOwnProperty.call(message, "stringValue"))
                     object.stringValue = options.bytes === String ? $util.base64.encode(message.stringValue, 0, message.stringValue.length) : options.bytes === Array ? Array.prototype.slice.call(message.stringValue) : message.stringValue;
-                if (message.aggregateValue != null && message.hasOwnProperty("aggregateValue"))
+                if (message.aggregateValue != null && Object.hasOwnProperty.call(message, "aggregateValue"))
                     object.aggregateValue = message.aggregateValue;
                 return object;
             };
@@ -20977,9 +20977,9 @@ $root.google = (function() {
                             break;
                         }
                     }
-                    if (!message.hasOwnProperty("namePart"))
+                    if (!Object.hasOwnProperty.call(message, "namePart"))
                         throw $util.ProtocolError("missing required 'namePart'", { instance: message });
-                    if (!message.hasOwnProperty("isExtension"))
+                    if (!Object.hasOwnProperty.call(message, "isExtension"))
                         throw $util.ProtocolError("missing required 'isExtension'", { instance: message });
                     return message;
                 };
@@ -21068,9 +21068,9 @@ $root.google = (function() {
                         object.namePart = "";
                         object.isExtension = false;
                     }
-                    if (message.namePart != null && message.hasOwnProperty("namePart"))
+                    if (message.namePart != null && Object.hasOwnProperty.call(message, "namePart"))
                         object.namePart = message.namePart;
-                    if (message.isExtension != null && message.hasOwnProperty("isExtension"))
+                    if (message.isExtension != null && Object.hasOwnProperty.call(message, "isExtension"))
                         object.isExtension = message.isExtension;
                     return object;
                 };
@@ -21357,7 +21357,7 @@ $root.google = (function() {
                     long = 0;
                 if (long > $util.recursionLimit)
                     return "maximum nesting depth exceeded";
-                if (message.fieldPresence != null && message.hasOwnProperty("fieldPresence"))
+                if (message.fieldPresence != null && Object.hasOwnProperty.call(message, "fieldPresence"))
                     switch (message.fieldPresence) {
                     default:
                         return "fieldPresence: enum value expected";
@@ -21367,7 +21367,7 @@ $root.google = (function() {
                     case 3:
                         break;
                     }
-                if (message.enumType != null && message.hasOwnProperty("enumType"))
+                if (message.enumType != null && Object.hasOwnProperty.call(message, "enumType"))
                     switch (message.enumType) {
                     default:
                         return "enumType: enum value expected";
@@ -21376,7 +21376,7 @@ $root.google = (function() {
                     case 2:
                         break;
                     }
-                if (message.repeatedFieldEncoding != null && message.hasOwnProperty("repeatedFieldEncoding"))
+                if (message.repeatedFieldEncoding != null && Object.hasOwnProperty.call(message, "repeatedFieldEncoding"))
                     switch (message.repeatedFieldEncoding) {
                     default:
                         return "repeatedFieldEncoding: enum value expected";
@@ -21385,7 +21385,7 @@ $root.google = (function() {
                     case 2:
                         break;
                     }
-                if (message.utf8Validation != null && message.hasOwnProperty("utf8Validation"))
+                if (message.utf8Validation != null && Object.hasOwnProperty.call(message, "utf8Validation"))
                     switch (message.utf8Validation) {
                     default:
                         return "utf8Validation: enum value expected";
@@ -21394,7 +21394,7 @@ $root.google = (function() {
                     case 3:
                         break;
                     }
-                if (message.messageEncoding != null && message.hasOwnProperty("messageEncoding"))
+                if (message.messageEncoding != null && Object.hasOwnProperty.call(message, "messageEncoding"))
                     switch (message.messageEncoding) {
                     default:
                         return "messageEncoding: enum value expected";
@@ -21403,7 +21403,7 @@ $root.google = (function() {
                     case 2:
                         break;
                     }
-                if (message.jsonFormat != null && message.hasOwnProperty("jsonFormat"))
+                if (message.jsonFormat != null && Object.hasOwnProperty.call(message, "jsonFormat"))
                     switch (message.jsonFormat) {
                     default:
                         return "jsonFormat: enum value expected";
@@ -21412,7 +21412,7 @@ $root.google = (function() {
                     case 2:
                         break;
                     }
-                if (message.enforceNamingStyle != null && message.hasOwnProperty("enforceNamingStyle"))
+                if (message.enforceNamingStyle != null && Object.hasOwnProperty.call(message, "enforceNamingStyle"))
                     switch (message.enforceNamingStyle) {
                     default:
                         return "enforceNamingStyle: enum value expected";
@@ -21421,7 +21421,7 @@ $root.google = (function() {
                     case 2:
                         break;
                     }
-                if (message.defaultSymbolVisibility != null && message.hasOwnProperty("defaultSymbolVisibility"))
+                if (message.defaultSymbolVisibility != null && Object.hasOwnProperty.call(message, "defaultSymbolVisibility"))
                     switch (message.defaultSymbolVisibility) {
                     default:
                         return "defaultSymbolVisibility: enum value expected";
@@ -21655,21 +21655,21 @@ $root.google = (function() {
                     object.enforceNamingStyle = options.enums === String ? "ENFORCE_NAMING_STYLE_UNKNOWN" : 0;
                     object.defaultSymbolVisibility = options.enums === String ? "DEFAULT_SYMBOL_VISIBILITY_UNKNOWN" : 0;
                 }
-                if (message.fieldPresence != null && message.hasOwnProperty("fieldPresence"))
+                if (message.fieldPresence != null && Object.hasOwnProperty.call(message, "fieldPresence"))
                     object.fieldPresence = options.enums === String ? $root.google.protobuf.FeatureSet.FieldPresence[message.fieldPresence] === undefined ? message.fieldPresence : $root.google.protobuf.FeatureSet.FieldPresence[message.fieldPresence] : message.fieldPresence;
-                if (message.enumType != null && message.hasOwnProperty("enumType"))
+                if (message.enumType != null && Object.hasOwnProperty.call(message, "enumType"))
                     object.enumType = options.enums === String ? $root.google.protobuf.FeatureSet.EnumType[message.enumType] === undefined ? message.enumType : $root.google.protobuf.FeatureSet.EnumType[message.enumType] : message.enumType;
-                if (message.repeatedFieldEncoding != null && message.hasOwnProperty("repeatedFieldEncoding"))
+                if (message.repeatedFieldEncoding != null && Object.hasOwnProperty.call(message, "repeatedFieldEncoding"))
                     object.repeatedFieldEncoding = options.enums === String ? $root.google.protobuf.FeatureSet.RepeatedFieldEncoding[message.repeatedFieldEncoding] === undefined ? message.repeatedFieldEncoding : $root.google.protobuf.FeatureSet.RepeatedFieldEncoding[message.repeatedFieldEncoding] : message.repeatedFieldEncoding;
-                if (message.utf8Validation != null && message.hasOwnProperty("utf8Validation"))
+                if (message.utf8Validation != null && Object.hasOwnProperty.call(message, "utf8Validation"))
                     object.utf8Validation = options.enums === String ? $root.google.protobuf.FeatureSet.Utf8Validation[message.utf8Validation] === undefined ? message.utf8Validation : $root.google.protobuf.FeatureSet.Utf8Validation[message.utf8Validation] : message.utf8Validation;
-                if (message.messageEncoding != null && message.hasOwnProperty("messageEncoding"))
+                if (message.messageEncoding != null && Object.hasOwnProperty.call(message, "messageEncoding"))
                     object.messageEncoding = options.enums === String ? $root.google.protobuf.FeatureSet.MessageEncoding[message.messageEncoding] === undefined ? message.messageEncoding : $root.google.protobuf.FeatureSet.MessageEncoding[message.messageEncoding] : message.messageEncoding;
-                if (message.jsonFormat != null && message.hasOwnProperty("jsonFormat"))
+                if (message.jsonFormat != null && Object.hasOwnProperty.call(message, "jsonFormat"))
                     object.jsonFormat = options.enums === String ? $root.google.protobuf.FeatureSet.JsonFormat[message.jsonFormat] === undefined ? message.jsonFormat : $root.google.protobuf.FeatureSet.JsonFormat[message.jsonFormat] : message.jsonFormat;
-                if (message.enforceNamingStyle != null && message.hasOwnProperty("enforceNamingStyle"))
+                if (message.enforceNamingStyle != null && Object.hasOwnProperty.call(message, "enforceNamingStyle"))
                     object.enforceNamingStyle = options.enums === String ? $root.google.protobuf.FeatureSet.EnforceNamingStyle[message.enforceNamingStyle] === undefined ? message.enforceNamingStyle : $root.google.protobuf.FeatureSet.EnforceNamingStyle[message.enforceNamingStyle] : message.enforceNamingStyle;
-                if (message.defaultSymbolVisibility != null && message.hasOwnProperty("defaultSymbolVisibility"))
+                if (message.defaultSymbolVisibility != null && Object.hasOwnProperty.call(message, "defaultSymbolVisibility"))
                     object.defaultSymbolVisibility = options.enums === String ? $root.google.protobuf.FeatureSet.VisibilityFeature.DefaultSymbolVisibility[message.defaultSymbolVisibility] === undefined ? message.defaultSymbolVisibility : $root.google.protobuf.FeatureSet.VisibilityFeature.DefaultSymbolVisibility[message.defaultSymbolVisibility] : message.defaultSymbolVisibility;
                 return object;
             };
@@ -22211,7 +22211,7 @@ $root.google = (function() {
                     long = 0;
                 if (long > $util.recursionLimit)
                     return "maximum nesting depth exceeded";
-                if (message.defaults != null && message.hasOwnProperty("defaults")) {
+                if (message.defaults != null && Object.hasOwnProperty.call(message, "defaults")) {
                     if (!Array.isArray(message.defaults))
                         return "defaults: array expected";
                     for (var i = 0; i < message.defaults.length; ++i) {
@@ -22220,7 +22220,7 @@ $root.google = (function() {
                             return "defaults." + error;
                     }
                 }
-                if (message.minimumEdition != null && message.hasOwnProperty("minimumEdition"))
+                if (message.minimumEdition != null && Object.hasOwnProperty.call(message, "minimumEdition"))
                     switch (message.minimumEdition) {
                     default:
                         return "minimumEdition: enum value expected";
@@ -22238,7 +22238,7 @@ $root.google = (function() {
                     case 2147483647:
                         break;
                     }
-                if (message.maximumEdition != null && message.hasOwnProperty("maximumEdition"))
+                if (message.maximumEdition != null && Object.hasOwnProperty.call(message, "maximumEdition"))
                     switch (message.maximumEdition) {
                     default:
                         return "maximumEdition: enum value expected";
@@ -22430,9 +22430,9 @@ $root.google = (function() {
                     for (var j = 0; j < message.defaults.length; ++j)
                         object.defaults[j] = $root.google.protobuf.FeatureSetDefaults.FeatureSetEditionDefault.toObject(message.defaults[j], options, q + 1);
                 }
-                if (message.minimumEdition != null && message.hasOwnProperty("minimumEdition"))
+                if (message.minimumEdition != null && Object.hasOwnProperty.call(message, "minimumEdition"))
                     object.minimumEdition = options.enums === String ? $root.google.protobuf.Edition[message.minimumEdition] === undefined ? message.minimumEdition : $root.google.protobuf.Edition[message.minimumEdition] : message.minimumEdition;
-                if (message.maximumEdition != null && message.hasOwnProperty("maximumEdition"))
+                if (message.maximumEdition != null && Object.hasOwnProperty.call(message, "maximumEdition"))
                     object.maximumEdition = options.enums === String ? $root.google.protobuf.Edition[message.maximumEdition] === undefined ? message.maximumEdition : $root.google.protobuf.Edition[message.maximumEdition] : message.maximumEdition;
                 return object;
             };
@@ -22638,7 +22638,7 @@ $root.google = (function() {
                         long = 0;
                     if (long > $util.recursionLimit)
                         return "maximum nesting depth exceeded";
-                    if (message.edition != null && message.hasOwnProperty("edition"))
+                    if (message.edition != null && Object.hasOwnProperty.call(message, "edition"))
                         switch (message.edition) {
                         default:
                             return "edition: enum value expected";
@@ -22656,12 +22656,12 @@ $root.google = (function() {
                         case 2147483647:
                             break;
                         }
-                    if (message.overridableFeatures != null && message.hasOwnProperty("overridableFeatures")) {
+                    if (message.overridableFeatures != null && Object.hasOwnProperty.call(message, "overridableFeatures")) {
                         var error = $root.google.protobuf.FeatureSet.verify(message.overridableFeatures, long + 1);
                         if (error)
                             return "overridableFeatures." + error;
                     }
-                    if (message.fixedFeatures != null && message.hasOwnProperty("fixedFeatures")) {
+                    if (message.fixedFeatures != null && Object.hasOwnProperty.call(message, "fixedFeatures")) {
                         var error = $root.google.protobuf.FeatureSet.verify(message.fixedFeatures, long + 1);
                         if (error)
                             return "fixedFeatures." + error;
@@ -22778,11 +22778,11 @@ $root.google = (function() {
                         object.overridableFeatures = null;
                         object.fixedFeatures = null;
                     }
-                    if (message.edition != null && message.hasOwnProperty("edition"))
+                    if (message.edition != null && Object.hasOwnProperty.call(message, "edition"))
                         object.edition = options.enums === String ? $root.google.protobuf.Edition[message.edition] === undefined ? message.edition : $root.google.protobuf.Edition[message.edition] : message.edition;
-                    if (message.overridableFeatures != null && message.hasOwnProperty("overridableFeatures"))
+                    if (message.overridableFeatures != null && Object.hasOwnProperty.call(message, "overridableFeatures"))
                         object.overridableFeatures = $root.google.protobuf.FeatureSet.toObject(message.overridableFeatures, options, q + 1);
-                    if (message.fixedFeatures != null && message.hasOwnProperty("fixedFeatures"))
+                    if (message.fixedFeatures != null && Object.hasOwnProperty.call(message, "fixedFeatures"))
                         object.fixedFeatures = $root.google.protobuf.FeatureSet.toObject(message.fixedFeatures, options, q + 1);
                     return object;
                 };
@@ -22968,7 +22968,7 @@ $root.google = (function() {
                     long = 0;
                 if (long > $util.recursionLimit)
                     return "maximum nesting depth exceeded";
-                if (message.location != null && message.hasOwnProperty("location")) {
+                if (message.location != null && Object.hasOwnProperty.call(message, "location")) {
                     if (!Array.isArray(message.location))
                         return "location: array expected";
                     for (var i = 0; i < message.location.length; ++i) {
@@ -23297,27 +23297,27 @@ $root.google = (function() {
                         long = 0;
                     if (long > $util.recursionLimit)
                         return "maximum nesting depth exceeded";
-                    if (message.path != null && message.hasOwnProperty("path")) {
+                    if (message.path != null && Object.hasOwnProperty.call(message, "path")) {
                         if (!Array.isArray(message.path))
                             return "path: array expected";
                         for (var i = 0; i < message.path.length; ++i)
                             if (!$util.isInteger(message.path[i]))
                                 return "path: integer[] expected";
                     }
-                    if (message.span != null && message.hasOwnProperty("span")) {
+                    if (message.span != null && Object.hasOwnProperty.call(message, "span")) {
                         if (!Array.isArray(message.span))
                             return "span: array expected";
                         for (var i = 0; i < message.span.length; ++i)
                             if (!$util.isInteger(message.span[i]))
                                 return "span: integer[] expected";
                     }
-                    if (message.leadingComments != null && message.hasOwnProperty("leadingComments"))
+                    if (message.leadingComments != null && Object.hasOwnProperty.call(message, "leadingComments"))
                         if (!$util.isString(message.leadingComments))
                             return "leadingComments: string expected";
-                    if (message.trailingComments != null && message.hasOwnProperty("trailingComments"))
+                    if (message.trailingComments != null && Object.hasOwnProperty.call(message, "trailingComments"))
                         if (!$util.isString(message.trailingComments))
                             return "trailingComments: string expected";
-                    if (message.leadingDetachedComments != null && message.hasOwnProperty("leadingDetachedComments")) {
+                    if (message.leadingDetachedComments != null && Object.hasOwnProperty.call(message, "leadingDetachedComments")) {
                         if (!Array.isArray(message.leadingDetachedComments))
                             return "leadingDetachedComments: array expected";
                         for (var i = 0; i < message.leadingDetachedComments.length; ++i)
@@ -23409,9 +23409,9 @@ $root.google = (function() {
                         for (var j = 0; j < message.span.length; ++j)
                             object.span[j] = message.span[j];
                     }
-                    if (message.leadingComments != null && message.hasOwnProperty("leadingComments"))
+                    if (message.leadingComments != null && Object.hasOwnProperty.call(message, "leadingComments"))
                         object.leadingComments = message.leadingComments;
-                    if (message.trailingComments != null && message.hasOwnProperty("trailingComments"))
+                    if (message.trailingComments != null && Object.hasOwnProperty.call(message, "trailingComments"))
                         object.trailingComments = message.trailingComments;
                     if (message.leadingDetachedComments && message.leadingDetachedComments.length) {
                         object.leadingDetachedComments = [];
@@ -23602,7 +23602,7 @@ $root.google = (function() {
                     long = 0;
                 if (long > $util.recursionLimit)
                     return "maximum nesting depth exceeded";
-                if (message.annotation != null && message.hasOwnProperty("annotation")) {
+                if (message.annotation != null && Object.hasOwnProperty.call(message, "annotation")) {
                     if (!Array.isArray(message.annotation))
                         return "annotation: array expected";
                     for (var i = 0; i < message.annotation.length; ++i) {
@@ -23915,23 +23915,23 @@ $root.google = (function() {
                         long = 0;
                     if (long > $util.recursionLimit)
                         return "maximum nesting depth exceeded";
-                    if (message.path != null && message.hasOwnProperty("path")) {
+                    if (message.path != null && Object.hasOwnProperty.call(message, "path")) {
                         if (!Array.isArray(message.path))
                             return "path: array expected";
                         for (var i = 0; i < message.path.length; ++i)
                             if (!$util.isInteger(message.path[i]))
                                 return "path: integer[] expected";
                     }
-                    if (message.sourceFile != null && message.hasOwnProperty("sourceFile"))
+                    if (message.sourceFile != null && Object.hasOwnProperty.call(message, "sourceFile"))
                         if (!$util.isString(message.sourceFile))
                             return "sourceFile: string expected";
-                    if (message.begin != null && message.hasOwnProperty("begin"))
+                    if (message.begin != null && Object.hasOwnProperty.call(message, "begin"))
                         if (!$util.isInteger(message.begin))
                             return "begin: integer expected";
-                    if (message.end != null && message.hasOwnProperty("end"))
+                    if (message.end != null && Object.hasOwnProperty.call(message, "end"))
                         if (!$util.isInteger(message.end))
                             return "end: integer expected";
-                    if (message.semantic != null && message.hasOwnProperty("semantic"))
+                    if (message.semantic != null && Object.hasOwnProperty.call(message, "semantic"))
                         switch (message.semantic) {
                         default:
                             return "semantic: enum value expected";
@@ -24027,13 +24027,13 @@ $root.google = (function() {
                         for (var j = 0; j < message.path.length; ++j)
                             object.path[j] = message.path[j];
                     }
-                    if (message.sourceFile != null && message.hasOwnProperty("sourceFile"))
+                    if (message.sourceFile != null && Object.hasOwnProperty.call(message, "sourceFile"))
                         object.sourceFile = message.sourceFile;
-                    if (message.begin != null && message.hasOwnProperty("begin"))
+                    if (message.begin != null && Object.hasOwnProperty.call(message, "begin"))
                         object.begin = message.begin;
-                    if (message.end != null && message.hasOwnProperty("end"))
+                    if (message.end != null && Object.hasOwnProperty.call(message, "end"))
                         object.end = message.end;
-                    if (message.semantic != null && message.hasOwnProperty("semantic"))
+                    if (message.semantic != null && Object.hasOwnProperty.call(message, "semantic"))
                         object.semantic = options.enums === String ? $root.google.protobuf.GeneratedCodeInfo.Annotation.Semantic[message.semantic] === undefined ? message.semantic : $root.google.protobuf.GeneratedCodeInfo.Annotation.Semantic[message.semantic] : message.semantic;
                     return object;
                 };

--- a/tests/data/type_url.js
+++ b/tests/data/type_url.js
@@ -154,7 +154,7 @@ $root.TypeUrlTest = (function() {
             long = 0;
         if (long > $util.recursionLimit)
             return "maximum nesting depth exceeded";
-        if (message.nested != null && message.hasOwnProperty("nested")) {
+        if (message.nested != null && Object.hasOwnProperty.call(message, "nested")) {
             var error = $root.TypeUrlTest.Nested.verify(message.nested, long + 1);
             if (error)
                 return "nested." + error;
@@ -207,7 +207,7 @@ $root.TypeUrlTest = (function() {
         var object = {};
         if (options.defaults)
             object.nested = null;
-        if (message.nested != null && message.hasOwnProperty("nested"))
+        if (message.nested != null && Object.hasOwnProperty.call(message, "nested"))
             object.nested = $root.TypeUrlTest.Nested.toObject(message.nested, options, q + 1);
         return object;
     };
@@ -383,7 +383,7 @@ $root.TypeUrlTest = (function() {
                 long = 0;
             if (long > $util.recursionLimit)
                 return "maximum nesting depth exceeded";
-            if (message.a != null && message.hasOwnProperty("a"))
+            if (message.a != null && Object.hasOwnProperty.call(message, "a"))
                 if (!$util.isString(message.a))
                     return "a: string expected";
             return null;
@@ -431,7 +431,7 @@ $root.TypeUrlTest = (function() {
             var object = {};
             if (options.defaults)
                 object.a = "";
-            if (message.a != null && message.hasOwnProperty("a"))
+            if (message.a != null && Object.hasOwnProperty.call(message, "a"))
                 object.a = message.a;
             return object;
         };


### PR DESCRIPTION
Backports the relevant parts of #2300 and #2302 to 7.x: prototype-independent own-property checks, `$`-prefixed field/oneof name rejection, and the `rpcCall` service wrapper change.

The substantially more invasive static-codegen naming-collision rewrite in #2302 is not backported.