### PR TITLE
fix: Preserve null conversion behavior for fieldless messages (7.x)

### DIFF
--- a/src/converter.js
+++ b/src/converter.js
@@ -107,14 +107,15 @@ converter.fromObject = function fromObject(mtype) {
     var fields = mtype.fieldsArray;
     var gen = util.codegen(["d", "n"], mtype.name + "$fromObject")
     ("if(d instanceof this.ctor)")
-        ("return d")
+        ("return d");
+    if (!fields.length) return gen
+    ("return new this.ctor");
+    gen
     ("if(!util.isObject(d))")
         ("throw TypeError(%j)", mtype.fullName + ": object expected")
     ("if(n===undefined)n=0")
     ("if(n>util.recursionLimit)")
         ("throw Error(\"maximum nesting depth exceeded\")");
-    if (!fields.length) return gen
-    ("return new this.ctor");
     gen
     ("var m=new this.ctor");
     for (var i = 0; i < fields.length; ++i) {

--- a/tests/api_type.js
+++ b/tests/api_type.js
@@ -320,11 +320,17 @@ tape.test("object conversion rejects null message values", function(test) {
                     key: { type: "string", id: 1 },
                     value: { type: "string", id: 2 }
                 }
+            },
+            Empty: {
+                fields: {}
             }
         }
     });
     var Document = root.lookupType("Document");
     var Metadata = root.lookupType("Metadata");
+    var Empty = root.lookupType("Empty");
+
+    test.ok(Empty.fromObject(null) instanceof Empty.ctor, "should allow null top-level fieldless messages");
 
     test.throws(function() {
         Metadata.fromObject(null);

--- a/tests/data/comments.js
+++ b/tests/data/comments.js
@@ -430,12 +430,6 @@ $root.Test2 = (function() {
     Test2.fromObject = function fromObject(object, long) {
         if (object instanceof $root.Test2)
             return object;
-        if (!$util.isObject(object))
-            throw TypeError(".Test2: object expected");
-        if (long === undefined)
-            long = 0;
-        if (long > $util.recursionLimit)
-            throw Error("maximum nesting depth exceeded");
         return new $root.Test2();
     };
 

--- a/tests/data/test.js
+++ b/tests/data/test.js
@@ -171,12 +171,6 @@ $root.jspb = (function() {
             Empty.fromObject = function fromObject(object, long) {
                 if (object instanceof $root.jspb.test.Empty)
                     return object;
-                if (!$util.isObject(object))
-                    throw TypeError(".jspb.test.Empty: object expected");
-                if (long === undefined)
-                    long = 0;
-                if (long > $util.recursionLimit)
-                    throw Error("maximum nesting depth exceeded");
                 return new $root.jspb.test.Empty();
             };
 
@@ -3129,12 +3123,6 @@ $root.jspb = (function() {
             OuterMessage.fromObject = function fromObject(object, long) {
                 if (object instanceof $root.jspb.test.OuterMessage)
                     return object;
-                if (!$util.isObject(object))
-                    throw TypeError(".jspb.test.OuterMessage: object expected");
-                if (long === undefined)
-                    long = 0;
-                if (long > $util.recursionLimit)
-                    throw Error("maximum nesting depth exceeded");
                 return new $root.jspb.test.OuterMessage();
             };
 
@@ -3778,12 +3766,6 @@ $root.jspb = (function() {
             IndirectExtension.fromObject = function fromObject(object, long) {
                 if (object instanceof $root.jspb.test.IndirectExtension)
                     return object;
-                if (!$util.isObject(object))
-                    throw TypeError(".jspb.test.IndirectExtension: object expected");
-                if (long === undefined)
-                    long = 0;
-                if (long > $util.recursionLimit)
-                    throw Error("maximum nesting depth exceeded");
                 return new $root.jspb.test.IndirectExtension();
             };
 
@@ -7794,12 +7776,6 @@ $root.jspb = (function() {
             TestReservedNamesExtension.fromObject = function fromObject(object, long) {
                 if (object instanceof $root.jspb.test.TestReservedNamesExtension)
                     return object;
-                if (!$util.isObject(object))
-                    throw TypeError(".jspb.test.TestReservedNamesExtension: object expected");
-                if (long === undefined)
-                    long = 0;
-                if (long > $util.recursionLimit)
-                    throw Error("maximum nesting depth exceeded");
                 return new $root.jspb.test.TestReservedNamesExtension();
             };
 
@@ -10039,12 +10015,6 @@ $root.jspb = (function() {
             Deeply.fromObject = function fromObject(object, long) {
                 if (object instanceof $root.jspb.test.Deeply)
                     return object;
-                if (!$util.isObject(object))
-                    throw TypeError(".jspb.test.Deeply: object expected");
-                if (long === undefined)
-                    long = 0;
-                if (long > $util.recursionLimit)
-                    throw Error("maximum nesting depth exceeded");
                 return new $root.jspb.test.Deeply();
             };
 
@@ -10231,12 +10201,6 @@ $root.jspb = (function() {
                 Nested.fromObject = function fromObject(object, long) {
                     if (object instanceof $root.jspb.test.Deeply.Nested)
                         return object;
-                    if (!$util.isObject(object))
-                        throw TypeError(".jspb.test.Deeply.Nested: object expected");
-                    if (long === undefined)
-                        long = 0;
-                    if (long > $util.recursionLimit)
-                        throw Error("maximum nesting depth exceeded");
                     return new $root.jspb.test.Deeply.Nested();
                 };
 
@@ -21958,12 +21922,6 @@ $root.google = (function() {
                 VisibilityFeature.fromObject = function fromObject(object, long) {
                     if (object instanceof $root.google.protobuf.FeatureSet.VisibilityFeature)
                         return object;
-                    if (!$util.isObject(object))
-                        throw TypeError(".google.protobuf.FeatureSet.VisibilityFeature: object expected");
-                    if (long === undefined)
-                        long = 0;
-                    if (long > $util.recursionLimit)
-                        throw Error("maximum nesting depth exceeded");
                     return new $root.google.protobuf.FeatureSet.VisibilityFeature();
                 };
 


### PR DESCRIPTION
Restores the pre-7.6.2 behavior where `fromObject(null)` returns a new message for fieldless message types like `google.protobuf.Empty`, instead of throwing on `null`.

See https://github.com/protobufjs/protobuf.js/pull/2294#issuecomment-4659616265