### PR TITLE
fix: Include interfaces in API docs and fix FieldMask doc comment

### DIFF
--- a/config/jsdoc.json
+++ b/config/jsdoc.json
@@ -22,6 +22,9 @@
         },
         "applicationName": "protobuf.js",
         "applicationSubtitle": "API documentation",
+        "meta": {
+            "title": "protobuf.js API documentation"
+        },
         "linenums"      : true
     },
     "markdown"  : {

--- a/index.d.ts
+++ b/index.d.ts
@@ -100,6 +100,11 @@ export namespace common {
         value?: Uint8Array;
     }
 
+    /** Properties of a google.protobuf.FieldMask message. */
+    interface IFieldMask {
+        paths?: string[];
+    }
+
     /**
      * Gets the root definition of the specified common proto file.
      *

--- a/src/common.js
+++ b/src/common.js
@@ -363,9 +363,9 @@ common("field_mask", {
 
     /**
      * Properties of a google.protobuf.FieldMask message.
-     * @interface IDoubleValue
+     * @interface IFieldMask
      * @type {Object}
-     * @property {number} [value]
+     * @property {string[]} [paths]
      * @memberof common
      */
     FieldMask: {


### PR DESCRIPTION
Updates the JSDoc template submodule so API docs generate pages and navigation for interfaces.

Also uncovered and fixes an issue with the `FieldMask` doc comment.

Fixes #830