### PR TITLE
fix: Consistently reject truncated 64-bit varints

### DIFF
--- a/src/reader.js
+++ b/src/reader.js
@@ -224,18 +224,16 @@ function readLongVarint() {
             return bits;
         i = 0;
     } else {
-        for (; i < 3; ++i) {
+        for (; i < 4; ++i) {
             /* istanbul ignore if */
             if (this.pos >= this.len)
                 throw indexOutOfRange(this);
-            // 1st..3th
+            // 1st..4th
             bits.lo = (bits.lo | (this.buf[this.pos] & 127) << i * 7) >>> 0;
             if (this.buf[this.pos++] < 128)
                 return bits;
         }
-        // 4th
-        bits.lo = (bits.lo | (this.buf[this.pos++] & 127) << i * 7) >>> 0;
-        return bits;
+        throw indexOutOfRange(this);
     }
     if (this.len - this.pos > 4) { // fast route (hi)
         for (; i < 5; ++i) {

--- a/tests/api_writer-reader.js
+++ b/tests/api_writer-reader.js
@@ -84,6 +84,12 @@ tape.test("writer & reader", function(test) {
         var zzBaseVal = longVal.shru(1).xor(longVal.and(1).negate());
         test.ok(expect("sint64", zzBaseVal, val[1]), "should write " + zzBaseVal + " as a signed zig-zag encoded varint of length " + val[1].length + " and read it back equally");
     });
+    test.throws(function() {
+        Reader.create([ 128, 128, 128 ]).uint64();
+    }, /index out of range/, "should throw on truncated 64 bit varints with 3 bytes");
+    test.throws(function() {
+        Reader.create([ 128, 128, 128, 128 ]).uint64();
+    }, /index out of range/, "should throw on truncated 64 bit varints with 4 bytes");
 
     // fixed64, sfixed64 -> see also see comp_fixed/sfixed64 (grpc)
 


### PR DESCRIPTION
Fixes `readLongVarint` so truncated varints with 3 or 4 continuation bytes throw `RangeError` instead of being accepted as zero.

Fixes #2321