### PR TITLE
docs: Document custom constructor registration order

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ const decoded = AwesomeMessage.decode(bytes);
 decoded.customInstanceMethod(); // string
 ```
 
-protobuf.js will populate the constructor with the usual static runtime methods and use it for decoded messages. In TypeScript, custom members are visible when using the custom class type in consuming code.
+protobuf.js will populate the constructor with the usual static runtime methods and use it for decoded messages. When assigning constructors manually, add the type to its parent namespace/root first if fields reference other reflected types. In TypeScript, custom members are visible when using the custom class type in consuming code.
 
 ### Services
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1711,6 +1711,7 @@ export class Type extends NamespaceBase {
     /**
      * The registered constructor, if any registered, otherwise a generic constructor.
      * Assigning a function replaces the internal constructor. If the function does not extend {@link Message} yet, its prototype will be setup accordingly and static methods will be populated. If it already extends {@link Message}, it will just replace the internal constructor.
+     * When assigning manually, add the type to its parent namespace/root first if fields reference other reflected types, because constructor setup resolves field defaults.
      */
     ctor: Constructor<{}>;
 

--- a/src/type.js
+++ b/src/type.js
@@ -155,6 +155,7 @@ Object.defineProperties(Type.prototype, {
     /**
      * The registered constructor, if any registered, otherwise a generic constructor.
      * Assigning a function replaces the internal constructor. If the function does not extend {@link Message} yet, its prototype will be setup accordingly and static methods will be populated. If it already extends {@link Message}, it will just replace the internal constructor.
+     * When assigning manually, add the type to its parent namespace/root first if fields reference other reflected types, because constructor setup resolves field defaults.
      * @name Type#ctor
      * @type {Constructor<{}>}
      */


### PR DESCRIPTION
Documents that custom constructors should be assigned after the reflected type has been added to its parent namespace/root when fields reference other reflected types. This order is necessary because constructor setup resolves field defaults.

Fixes #2027