### PR TITLE
fix: Support utf8_validation during decode

### DIFF
--- a/.github/actions/conformance/action.yml
+++ b/.github/actions/conformance/action.yml
@@ -190,3 +190,24 @@ runs:
             echo "No conformance log found."
           fi
         } | tee -a "$GITHUB_STEP_SUMMARY"
+
+    - name: "Summarize conformance runner"
+      if: always()
+      shell: bash
+      run: |
+        {
+          echo ""
+          echo "---"
+          echo ""
+          if [ -d "${{ inputs.upstream-dir }}/.git" ]; then
+            echo "Conformance runner: protocolbuffers/protobuf \`${{ inputs.upstream-version }}\` (\`$(git -C "${{ inputs.upstream-dir }}" rev-parse --short HEAD)\`)"
+          else
+            echo "Conformance runner: protocolbuffers/protobuf \`${{ inputs.upstream-version }}\`"
+          fi
+          if [ -x "${{ inputs.runner-cache }}/build/protoc" ]; then
+            echo "Protoc: \`$("${{ inputs.runner-cache }}/build/protoc" --version)\`"
+          else
+            echo "Protoc: unavailable"
+          fi
+          echo "Options: \`--maximum_edition ${{ inputs.maximum-edition }} --enforce_recommended\`"
+        } | tee -a "$GITHUB_STEP_SUMMARY"

--- a/.github/actions/conformance/action.yml
+++ b/.github/actions/conformance/action.yml
@@ -3,7 +3,7 @@ description: "Build and run the upstream Protocol Buffers conformance suite for 
 inputs:
   upstream-version:
     description: "Upstream protocolbuffers/protobuf tag or branch to test against."
-    default: "v33.0"
+    default: "v35.0"
   upstream-dir:
     description: "Directory where upstream protobuf is checked out."
     default: "tests/conformance/upstream"

--- a/index.d.ts
+++ b/index.d.ts
@@ -1341,6 +1341,12 @@ export class Reader {
     string(): string;
 
     /**
+     * Reads a string preceeded by its byte length as a varint, rejecting invalid UTF8.
+     * @returns Value read
+     */
+    stringVerify(): string;
+
+    /**
      * Skips the specified number of bytes if specified, otherwise skips a varint.
      * @param [length] Length if known, otherwise a varint is assumed
      * @returns `this`
@@ -2632,6 +2638,15 @@ export namespace util {
          * @returns String read
          */
         function read(buffer: Uint8Array, start: number, end: number): string;
+
+        /**
+         * Reads UTF8 bytes as a string, rejecting invalid UTF8.
+         * @param buffer Source buffer
+         * @param start Source start
+         * @param end Source end
+         * @returns String read
+         */
+        function readStrict(buffer: Uint8Array, start: number, end: number): string;
 
         /**
          * Writes a string as UTF8 bytes.

--- a/src/decoder.js
+++ b/src/decoder.js
@@ -9,6 +9,10 @@ function missing(field) {
     return "missing required '" + field.name + "'";
 }
 
+function stringMethod(field) {
+    return field._features.utf8_validation === "VERIFY" ? "stringVerify" : "string";
+}
+
 /**
  * Generates a decoder specific to the specified message type.
  * @param {Type} mtype Message type
@@ -78,7 +82,7 @@ function decoder(mtype) {
                         ("case 1:")
                             ("if(u!==%i)", types.mapKey[field.keyType])
                                 ("break")
-                            ("k=r.%s()", field.keyType)
+                            ("k=r.%s()", field.keyType === "string" ? stringMethod(field) : field.keyType)
                             ("continue")
                         ("case 2:")
                             ("if(u!==%i)", types.basic[type] === undefined ? 2 : types.basic[type])
@@ -87,7 +91,7 @@ function decoder(mtype) {
             if (types.basic[type] === undefined) gen
                             ("v=types[%i].decode(r,r.uint32(),undefined,q+1)", i); // can't be groups
             else gen
-                            ("v=r.%s()", type);
+                            ("v=r.%s()", type === "string" ? stringMethod(field) : type);
 
             gen
                             ("continue")
@@ -134,7 +138,7 @@ function decoder(mtype) {
                 else gen
                     ("%s.push(types[%i].decode(r,r.uint32(),undefined,q+1))", ref, i);
             } else gen
-                    ("%s.push(r.%s())", ref, type);
+                    ("%s.push(r.%s())", ref, type === "string" ? stringMethod(field) : type);
 
         // Non-repeated
         } else if (types.basic[type] === undefined) {
@@ -152,7 +156,7 @@ function decoder(mtype) {
             ("case %i:{", field.id)
                 ("if(u!==%i)", types.basic[type])
                     ("break")
-                ("%s=r.%s()", ref, type);
+                ("%s=r.%s()", ref, type === "string" ? stringMethod(field) : type);
         } else {
             gen
             ("case %i:{", field.id)
@@ -162,7 +166,9 @@ function decoder(mtype) {
                 // TODO: Protoc rejects open enums whose first value is not zero.
                 // We should do the same, but for v8 this would be a regression.
                 ("if((v=r.%s())!==%j)", type, field.typeDefault);
-            else if (type === "string" || type === "bytes") gen
+            else if (type === "string") gen
+                ("if((v=r.%s()).length)", stringMethod(field));
+            else if (type === "bytes") gen
                 ("if((v=r.%s()).length)", type);
             else if (types.long[type] !== undefined) gen
                 ("if(typeof(v=r.%s())===\"object\"?v.low||v.high:v!==0)", type);

--- a/src/reader.js
+++ b/src/reader.js
@@ -430,6 +430,23 @@ Reader.prototype.string = function read_string() {
 };
 
 /**
+ * Reads a string preceeded by its byte length as a varint, rejecting invalid UTF8.
+ * @returns {string} Value read
+ */
+Reader.prototype.stringVerify = function read_string_verify() {
+    var length = this.uint32(),
+        start  = this.pos,
+        end    = this.pos + length;
+
+    /* istanbul ignore if */
+    if (end > this.len)
+        throw indexOutOfRange(this, length);
+
+    this.pos = end;
+    return utf8.readStrict(this.buf, start, end);
+};
+
+/**
  * Skips the specified number of bytes if specified, otherwise skips a varint.
  * @param {number} [length] Length if known, otherwise a varint is assumed
  * @returns {Reader} `this`

--- a/src/util/utf8.js
+++ b/src/util/utf8.js
@@ -6,7 +6,8 @@
  * @namespace
  */
 var utf8 = exports,
-    replacementChar = "\ufffd";
+    replacementChar = "\ufffd",
+    strictDecoder = new TextDecoder("utf-8", { fatal: true, ignoreBOM: true });
 
 /**
  * Calculates the UTF8 byte length of a string.
@@ -89,6 +90,56 @@ utf8.read = function utf8_read_ascii(buffer, start, end) {
         c1 = buffer[i];
         if (c1 & 0x80)
             return utf8_read_js(buffer, i, end, str);
+        str += String.fromCharCode(c1);
+    }
+
+    return str;
+};
+
+function utf8_read_strict(buffer, start, end) {
+    var source = start === 0 && end === buffer.length
+        ? buffer
+        : buffer.subarray
+            ? buffer.subarray(start, end)
+            : buffer.slice(start, end);
+    if (Array.isArray(source))
+        source = Uint8Array.from(source);
+    return strictDecoder.decode(source);
+}
+
+/**
+ * Reads UTF8 bytes as a string, rejecting invalid UTF8.
+ * @param {Uint8Array} buffer Source buffer
+ * @param {number} start Source start
+ * @param {number} end Source end
+ * @returns {string} String read
+ */
+utf8.readStrict = function utf8_read_strict_ascii(buffer, start, end) {
+    if (end - start < 1)
+        return "";
+
+    var str = "",
+        i = start,
+        c1, c2, c3, c4, c5, c6, c7, c8;
+
+    for (; i + 7 < end; i += 8) {
+        c1 = buffer[i];
+        c2 = buffer[i + 1];
+        c3 = buffer[i + 2];
+        c4 = buffer[i + 3];
+        c5 = buffer[i + 4];
+        c6 = buffer[i + 5];
+        c7 = buffer[i + 6];
+        c8 = buffer[i + 7];
+        if ((c1 | c2 | c3 | c4 | c5 | c6 | c7 | c8) & 0x80)
+            return str + utf8_read_strict(buffer, i, end);
+        str += String.fromCharCode(c1, c2, c3, c4, c5, c6, c7, c8);
+    }
+
+    for (; i < end; ++i) {
+        c1 = buffer[i];
+        if (c1 & 0x80)
+            return str + utf8_read_strict(buffer, i, end);
         str += String.fromCharCode(c1);
     }
 

--- a/tests/api_type.js
+++ b/tests/api_type.js
@@ -382,6 +382,110 @@ tape.test("decode known fields by wire type", function(test) {
     test.end();
 });
 
+tape.test("decode string fields by utf8_validation feature", function(test) {
+    var root = protobuf.Root.fromJSON({
+        nested: {
+            Verify: {
+                fields: {
+                    singular: { type: "string", id: 1 },
+                    repeated: { rule: "repeated", type: "string", id: 2 },
+                    map: { keyType: "string", type: "string", id: 3 },
+                    choice: { type: "string", id: 4 }
+                },
+                oneofs: {
+                    kind: { oneof: [ "choice" ] }
+                }
+            },
+            Proto2: {
+                edition: "proto2",
+                fields: {
+                    value: { type: "string", id: 1 }
+                }
+            },
+            EditionNone: {
+                edition: "2023",
+                options: { features: { utf8_validation: "NONE" } },
+                fields: {
+                    value: { type: "string", id: 1 }
+                }
+            }
+        }
+    });
+    var Verify = root.lookupType("Verify");
+    var Proto2 = root.lookupType("Proto2");
+    var EditionNone = root.lookupType("EditionNone");
+    var invalid = [ 0xA0, 0xB0, 0xC0, 0xD0 ];
+    var surrogate = [ 0xED, 0xA0, 0x80 ];
+    var valid = [ 0x66, 0x6F, 0x6F ];
+    var invalidReplacement = protobuf.util.newBuffer(invalid).toString("utf8");
+    var surrogateReplacement = protobuf.util.newBuffer(surrogate).toString("utf8");
+
+    function stringField(id, value) {
+        return [ id << 3 | 2, value.length ].concat(value);
+    }
+
+    function mapField(key, value) {
+        var entry = stringField(1, key).concat(stringField(2, value));
+        return [ 3 << 3 | 2, entry.length ].concat(entry);
+    }
+
+    test.throws(function() {
+        Verify.decode(protobuf.util.newBuffer(stringField(1, invalid)));
+    }, /utf-?8|encoded data/i, "should reject invalid singular strings when verification is enabled");
+
+    test.throws(function() {
+        Verify.decode(protobuf.util.newBuffer(stringField(2, invalid)));
+    }, /utf-?8|encoded data/i, "should reject invalid repeated strings when verification is enabled");
+
+    test.throws(function() {
+        Verify.decode(protobuf.util.newBuffer(stringField(4, invalid)));
+    }, /utf-?8|encoded data/i, "should reject invalid oneof strings when verification is enabled");
+
+    test.throws(function() {
+        Verify.decode(protobuf.util.newBuffer(mapField(invalid, valid)));
+    }, /utf-?8|encoded data/i, "should reject invalid map string keys when verification is enabled");
+
+    test.throws(function() {
+        Verify.decode(protobuf.util.newBuffer(mapField(valid, invalid)));
+    }, /utf-?8|encoded data/i, "should reject invalid map string values when verification is enabled");
+
+    test.throws(function() {
+        Verify.decode(protobuf.util.newBuffer(stringField(1, surrogate)));
+    }, /utf-?8|encoded data/i, "should reject UTF8-encoded lone surrogates when verification is enabled");
+
+    test.equal(
+        Verify.decode(stringField(1, [ 0xC3, 0xBC ])).singular,
+        "\u00fc",
+        "should decode valid non-ASCII strings from array buffers when verification is enabled"
+    );
+
+    test.equal(
+        Proto2.decode(protobuf.util.newBuffer(stringField(1, invalid))).value,
+        invalidReplacement,
+        "should replace malformed strings when verification is disabled by proto2 defaults"
+    );
+
+    test.equal(
+        EditionNone.decode(protobuf.util.newBuffer(stringField(1, invalid))).value,
+        invalidReplacement,
+        "should replace malformed strings when verification is disabled by editions features"
+    );
+
+    test.equal(
+        Proto2.decode(protobuf.util.newBuffer(stringField(1, surrogate))).value,
+        surrogateReplacement,
+        "should replace UTF8-encoded lone surrogates when verification is disabled by proto2 defaults"
+    );
+
+    test.equal(
+        EditionNone.decode(protobuf.util.newBuffer(stringField(1, surrogate))).value,
+        surrogateReplacement,
+        "should replace UTF8-encoded lone surrogates when verification is disabled by editions features"
+    );
+
+    test.end();
+});
+
 // TODO: Protoc rejects open enums whose first value is not zero.
 // We should do the same, but for v8 this would be a regression.
 // Remove this test once we enforce this restriction.

--- a/tests/data/comments.js
+++ b/tests/data/comments.js
@@ -164,7 +164,7 @@ $root.Test1 = (function() {
             case 1: {
                     if (wireType !== 2)
                         break;
-                    if ((value = reader.string()).length)
+                    if ((value = reader.stringVerify()).length)
                         message.field1 = value;
                     else
                         delete message.field1;

--- a/tests/data/convert.js
+++ b/tests/data/convert.js
@@ -243,7 +243,7 @@ $root.Message = (function() {
             case 1: {
                     if (wireType !== 2)
                         break;
-                    if ((value = reader.string()).length)
+                    if ((value = reader.stringVerify()).length)
                         message.stringVal = value;
                     else
                         delete message.stringVal;
@@ -254,7 +254,7 @@ $root.Message = (function() {
                         break;
                     if (!(message.stringRepeated && message.stringRepeated.length))
                         message.stringRepeated = [];
-                    message.stringRepeated.push(reader.string());
+                    message.stringRepeated.push(reader.stringVerify());
                     continue;
                 }
             case 3: {
@@ -339,7 +339,7 @@ $root.Message = (function() {
                         case 1:
                             if (wireType !== 2)
                                 break;
-                            key = reader.string();
+                            key = reader.stringVerify();
                             continue;
                         case 2:
                             if (wireType !== 0)

--- a/tests/data/package.js
+++ b/tests/data/package.js
@@ -327,7 +327,7 @@ $root.Package = (function() {
             case 1: {
                     if (wireType !== 2)
                         break;
-                    if ((value = reader.string()).length)
+                    if ((value = reader.stringVerify()).length)
                         message.name = value;
                     else
                         delete message.name;
@@ -336,7 +336,7 @@ $root.Package = (function() {
             case 2: {
                     if (wireType !== 2)
                         break;
-                    if ((value = reader.string()).length)
+                    if ((value = reader.stringVerify()).length)
                         message.version = value;
                     else
                         delete message.version;
@@ -345,7 +345,7 @@ $root.Package = (function() {
             case 19: {
                     if (wireType !== 2)
                         break;
-                    if ((value = reader.string()).length)
+                    if ((value = reader.stringVerify()).length)
                         message.versionScheme = value;
                     else
                         delete message.versionScheme;
@@ -354,7 +354,7 @@ $root.Package = (function() {
             case 3: {
                     if (wireType !== 2)
                         break;
-                    if ((value = reader.string()).length)
+                    if ((value = reader.stringVerify()).length)
                         message.description = value;
                     else
                         delete message.description;
@@ -363,7 +363,7 @@ $root.Package = (function() {
             case 4: {
                     if (wireType !== 2)
                         break;
-                    if ((value = reader.string()).length)
+                    if ((value = reader.stringVerify()).length)
                         message.author = value;
                     else
                         delete message.author;
@@ -372,7 +372,7 @@ $root.Package = (function() {
             case 5: {
                     if (wireType !== 2)
                         break;
-                    if ((value = reader.string()).length)
+                    if ((value = reader.stringVerify()).length)
                         message.license = value;
                     else
                         delete message.license;
@@ -387,7 +387,7 @@ $root.Package = (function() {
             case 7: {
                     if (wireType !== 2)
                         break;
-                    if ((value = reader.string()).length)
+                    if ((value = reader.stringVerify()).length)
                         message.bugs = value;
                     else
                         delete message.bugs;
@@ -396,7 +396,7 @@ $root.Package = (function() {
             case 8: {
                     if (wireType !== 2)
                         break;
-                    if ((value = reader.string()).length)
+                    if ((value = reader.stringVerify()).length)
                         message.homepage = value;
                     else
                         delete message.homepage;
@@ -407,13 +407,13 @@ $root.Package = (function() {
                         break;
                     if (!(message.keywords && message.keywords.length))
                         message.keywords = [];
-                    message.keywords.push(reader.string());
+                    message.keywords.push(reader.stringVerify());
                     continue;
                 }
             case 10: {
                     if (wireType !== 2)
                         break;
-                    if ((value = reader.string()).length)
+                    if ((value = reader.stringVerify()).length)
                         message.main = value;
                     else
                         delete message.main;
@@ -434,12 +434,12 @@ $root.Package = (function() {
                         case 1:
                             if (wireType !== 2)
                                 break;
-                            key = reader.string();
+                            key = reader.stringVerify();
                             continue;
                         case 2:
                             if (wireType !== 2)
                                 break;
-                            value = reader.string();
+                            value = reader.stringVerify();
                             continue;
                         }
                         reader.skipType(wireType, _depth, tag2);
@@ -464,12 +464,12 @@ $root.Package = (function() {
                         case 1:
                             if (wireType !== 2)
                                 break;
-                            key = reader.string();
+                            key = reader.stringVerify();
                             continue;
                         case 2:
                             if (wireType !== 2)
                                 break;
-                            value = reader.string();
+                            value = reader.stringVerify();
                             continue;
                         }
                         reader.skipType(wireType, _depth, tag2);
@@ -494,12 +494,12 @@ $root.Package = (function() {
                         case 1:
                             if (wireType !== 2)
                                 break;
-                            key = reader.string();
+                            key = reader.stringVerify();
                             continue;
                         case 2:
                             if (wireType !== 2)
                                 break;
-                            value = reader.string();
+                            value = reader.stringVerify();
                             continue;
                         }
                         reader.skipType(wireType, _depth, tag2);
@@ -524,12 +524,12 @@ $root.Package = (function() {
                         case 1:
                             if (wireType !== 2)
                                 break;
-                            key = reader.string();
+                            key = reader.stringVerify();
                             continue;
                         case 2:
                             if (wireType !== 2)
                                 break;
-                            value = reader.string();
+                            value = reader.stringVerify();
                             continue;
                         }
                         reader.skipType(wireType, _depth, tag2);
@@ -542,7 +542,7 @@ $root.Package = (function() {
             case 17: {
                     if (wireType !== 2)
                         break;
-                    if ((value = reader.string()).length)
+                    if ((value = reader.stringVerify()).length)
                         message.types = value;
                     else
                         delete message.types;
@@ -553,7 +553,7 @@ $root.Package = (function() {
                         break;
                     if (!(message.cliDependencies && message.cliDependencies.length))
                         message.cliDependencies = [];
-                    message.cliDependencies.push(reader.string());
+                    message.cliDependencies.push(reader.stringVerify());
                     continue;
                 }
             }
@@ -1066,7 +1066,7 @@ $root.Package = (function() {
                 case 1: {
                         if (wireType !== 2)
                             break;
-                        if ((value = reader.string()).length)
+                        if ((value = reader.stringVerify()).length)
                             message.type = value;
                         else
                             delete message.type;
@@ -1075,7 +1075,7 @@ $root.Package = (function() {
                 case 2: {
                         if (wireType !== 2)
                             break;
-                        if ((value = reader.string()).length)
+                        if ((value = reader.stringVerify()).length)
                             message.url = value;
                         else
                             delete message.url;

--- a/tests/data/rpc-es6.js
+++ b/tests/data/rpc-es6.js
@@ -213,7 +213,7 @@ export const MyRequest = $root.MyRequest = (() => {
             case 1: {
                     if (wireType !== 2)
                         break;
-                    if ((value = reader.string()).length)
+                    if ((value = reader.stringVerify()).length)
                         message.path = value;
                     else
                         delete message.path;

--- a/tests/data/rpc-reserved.js
+++ b/tests/data/rpc-reserved.js
@@ -215,7 +215,7 @@ $root.MyRequest = (function() {
             case 1: {
                     if (wireType !== 2)
                         break;
-                    if ((value = reader.string()).length)
+                    if ((value = reader.stringVerify()).length)
                         message.path = value;
                     else
                         delete message.path;

--- a/tests/data/rpc.js
+++ b/tests/data/rpc.js
@@ -215,7 +215,7 @@ $root.MyRequest = (function() {
             case 1: {
                     if (wireType !== 2)
                         break;
-                    if ((value = reader.string()).length)
+                    if ((value = reader.stringVerify()).length)
                         message.path = value;
                     else
                         delete message.path;

--- a/tests/data/type_url.js
+++ b/tests/data/type_url.js
@@ -397,7 +397,7 @@ $root.TypeUrlTest = (function() {
                 case 1: {
                         if (wireType !== 2)
                             break;
-                        if ((value = reader.string()).length)
+                        if ((value = reader.stringVerify()).length)
                             message.a = value;
                         else
                             delete message.a;

--- a/tests/node/comp_loaders.js
+++ b/tests/node/comp_loaders.js
@@ -33,7 +33,8 @@ var distPath = path.join(__dirname, "..", "..", "dist");
                 window: {
                     dcodeIO: dcodeIO
                 },
-                dcodeIO: dcodeIO
+                dcodeIO: dcodeIO,
+                TextDecoder: TextDecoder
             });
 
             test.ok(sandbox.window.protobuf, "should load the library as a global");
@@ -50,7 +51,8 @@ var distPath = path.join(__dirname, "..", "..", "dist");
                 self: {
                     dcodeIO: dcodeIO
                 },
-                dcodeIO: dcodeIO
+                dcodeIO: dcodeIO,
+                TextDecoder: TextDecoder
             });
 
             test.ok(sandbox.self.protobuf, "should load the library as a global");
@@ -73,7 +75,8 @@ var distPath = path.join(__dirname, "..", "..", "dist");
                 define: fakeDefine,
                 window: {},
                 require: undefined,
-                console: console
+                console: console,
+                TextDecoder: TextDecoder
             });
 
             test.ok(sandbox.window.protobuf, "should load the library as a global");


### PR DESCRIPTION
Implements UTF-8 validation for decoded string fields when field features indicate `utf8_validation = VERIFY`, using a fatal `TextDecoder`. In Node.js, the `TextDecoder` global is present since v11.0.0, meeting our support floor.

Also updates the conformance job to use the upstream v35.0 harness, which includes the corresponding recommended tests.