### PR TITLE
fix: Reconfigure and speed up CI (7.x)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -80,11 +80,6 @@ jobs:
         working-directory: lib/float
         run: npm publish --ignore-scripts --access public
 
-      - name: Publish @protobufjs/inquire
-        if: ${{ steps.release.outputs['lib/inquire--release_created'] == 'true' }}
-        working-directory: lib/inquire
-        run: npm publish --ignore-scripts --access public
-
       - name: Publish @protobufjs/path
         if: ${{ steps.release.outputs['lib/path--release_created'] == 'true' }}
         working-directory: lib/path

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,6 @@
 name: "Test"
 env:
+  MIN_NODE_VERSION: &min_node_version "12"
   NPM_CONFIG_AUDIT: "false"
 on:
   push:
@@ -11,10 +12,10 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
-    - uses: actions/setup-node@v1
+    - uses: actions/checkout@v6
+    - uses: actions/setup-node@v6
       with:
-        node-version: "12"
+        node-version: "lts/*"
     - name: "Install dependencies"
       run: npm install
     - name: "Lint sources"
@@ -25,12 +26,15 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node_version: ["12", "14", "16", "18"]
+        node_version: [*min_node_version, "lts/*"]
     steps:
-    - uses: actions/checkout@v1
-    - uses: actions/setup-node@v1
+    - uses: actions/checkout@v6
+    - uses: actions/setup-node@v6
       with:
         node-version: ${{ matrix.node_version }}
+    - name: "Use npm 8 on Node 12"
+      if: ${{ matrix.node_version == '12' }}
+      run: npm install -g npm@8
     - name: "Install dependencies"
       run: npm install
     - name: "Test sources"
@@ -40,10 +44,10 @@ jobs:
   bench:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
-    - uses: actions/setup-node@v1
+    - uses: actions/checkout@v6
+    - uses: actions/setup-node@v6
       with:
-        node-version: "12"
+        node-version: "lts/*"
     - name: "Install dependencies"
       run: npm install
     - name: "Run benchmark"

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -7,7 +7,6 @@
   "lib/eventemitter": "1.1.1",
   "lib/fetch": "1.1.1",
   "lib/float": "1.0.2",
-  "lib/inquire": "1.1.2",
   "lib/path": "1.1.2",
   "lib/pool": "1.1.0",
   "lib/utf8": "1.1.1"

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -11,7 +11,6 @@
         "lib/eventemitter",
         "lib/fetch",
         "lib/float",
-        "lib/inquire",
         "lib/path",
         "lib/pool",
         "lib/utf8"
@@ -23,7 +22,6 @@
     "lib/eventemitter": {},
     "lib/fetch": {},
     "lib/float": {},
-    "lib/inquire": {},
     "lib/path": {},
     "lib/pool": {},
     "lib/utf8": {}


### PR DESCRIPTION
Removes stale `lib/inquire` release metadata after the 7.x inquire removal backport, and backports the 8.x test workflow speedups.