### PR TITLE
fix: support runtimes without ICU

### DIFF
--- a/src/util/utf8.js
+++ b/src/util/utf8.js
@@ -11,7 +11,7 @@ var utf8 = exports,
 
 try {
     strictDecoder = new TextDecoder("utf-8", { fatal: true, ignoreBOM: true });
-} catch (error) {
+} catch {
     // "fatal" option is not supported on Node.js compiled without ICU
     strictDecoder = new TextDecoder("utf-8", { ignoreBOM: true });
 }

--- a/src/util/utf8.js
+++ b/src/util/utf8.js
@@ -11,7 +11,7 @@ var utf8 = exports,
 
 try {
     strictDecoder = new TextDecoder("utf-8", { fatal: true, ignoreBOM: true });
-} catch {
+} catch (err) {
     // "fatal" option is not supported on Node.js compiled without ICU
     strictDecoder = new TextDecoder("utf-8", { ignoreBOM: true });
 }

--- a/src/util/utf8.js
+++ b/src/util/utf8.js
@@ -7,7 +7,13 @@
  */
 var utf8 = exports,
     replacementChar = "\ufffd",
+    strictDecoder
+
+try {
     strictDecoder = new TextDecoder("utf-8", { fatal: true, ignoreBOM: true });
+} catch (error) {
+    strictDecoder = new TextDecoder("utf-8", { ignoreBOM: true });
+}
 
 /**
  * Calculates the UTF8 byte length of a string.

--- a/src/util/utf8.js
+++ b/src/util/utf8.js
@@ -7,11 +7,12 @@
  */
 var utf8 = exports,
     replacementChar = "\ufffd",
-    strictDecoder
+    strictDecoder;
 
 try {
     strictDecoder = new TextDecoder("utf-8", { fatal: true, ignoreBOM: true });
 } catch (error) {
+    // "fatal" option is not supported on Node.js compiled without ICU
     strictDecoder = new TextDecoder("utf-8", { ignoreBOM: true });
 }
 


### PR DESCRIPTION
https://github.com/protobufjs/protobuf.js/commit/4dff8e46bf1c35351c15065349446774605d6c51 introduced a regression which causes NodeJS running on any OS without ICU to crash instantly the moment protobuf.js is imported with `TypeError [ERR_NO_ICU]: "fatal" option is not supported on Node.js compiled without ICU`, even when strings are not used

this "works around" this problem by disabling fatal, this might not be a great solution, but at the very least it doesn't cause a top-level error