### PR TITLE
fix: Omit implicit scalar defaults during encode

### DIFF
--- a/src/converter.js
+++ b/src/converter.js
@@ -162,6 +162,8 @@ converter.fromObject = function fromObject(mtype) {
     ("if(d%s.length){", prop);
                 else if (field.type === "bool") gen
     ("if(d%s){", prop);
+                else if (field.type === "double" || field.type === "float") gen
+    ("if(!Object.is(Number(d%s),0)){", prop);
                 else if (types.long[field.type] !== undefined) gen
     ("if(typeof d%s===\"object\"?d%s.low||d%s.high:Number(d%s)!==0){", prop, prop, prop, prop);
                 else gen

--- a/src/decoder.js
+++ b/src/decoder.js
@@ -173,7 +173,7 @@ function decoder(mtype) {
             else if (types.long[type] !== undefined) gen
                 ("if(typeof(v=r.%s())===\"object\"?v.low||v.high:v!==0)", type);
             else if (type === "double" || type === "float") gen
-                ("if((v=r.%s())!==0)", type);
+                ("if(!Object.is(v=r.%s(),0))", type);
             else gen
                 ("if(v=r.%s())", type);
             gen

--- a/src/encoder.js
+++ b/src/encoder.js
@@ -91,8 +91,23 @@ function encoder(mtype) {
 
         // Non-repeated
         } else {
-            if (!field.required) gen
+            if (!field.required)
+                if (field.hasPresence || !(field.resolvedType instanceof Enum || types.basic[type] !== undefined)) gen
     ("if(%s!=null&&Object.hasOwnProperty.call(m,%j))", ref, field.name); // !== undefined && !== null
+                else if (field.resolvedType instanceof Enum) gen
+    ("if(%s!=null&&Object.hasOwnProperty.call(m,%j)&&%s!==%j)", ref, field.name, ref, field.typeDefault);
+                else if (type === "bool") gen
+    ("if(%s!=null&&Object.hasOwnProperty.call(m,%j)&&%s!==false)", ref, field.name, ref);
+                else if (type === "string") gen
+    ("if(%s!=null&&Object.hasOwnProperty.call(m,%j)&&%s!==\"\")", ref, field.name, ref);
+                else if (type === "bytes") gen
+    ("if(%s!=null&&Object.hasOwnProperty.call(m,%j)&&%s.length)", ref, field.name, ref);
+                else if (type === "double" || type === "float") gen
+    ("if(%s!=null&&Object.hasOwnProperty.call(m,%j)&&!Object.is(%s,0))", ref, field.name, ref);
+                else if (types.long[type] !== undefined) gen
+    ("if(%s!=null&&Object.hasOwnProperty.call(m,%j)&&(typeof %s===\"object\"?%s.low||%s.high:%s!==0))", ref, field.name, ref, ref, ref, ref);
+                else gen
+    ("if(%s!=null&&Object.hasOwnProperty.call(m,%j)&&%s!==0)", ref, field.name, ref);
 
             if (wireType === undefined)
         genTypePartial(gen, field, index, ref);

--- a/src/object.js
+++ b/src/object.js
@@ -353,6 +353,8 @@ ReflectionObject.prototype.setOptions = function setOptions(options, ifNotSet) {
 
 /**
  * Converts this instance to its string representation.
+ * @name ReflectionObject#toString
+ * @function
  * @returns {string} Class name[, space, full name]
  */
 Object.defineProperty(ReflectionObject.prototype, "toString", {

--- a/tests/api_type.js
+++ b/tests/api_type.js
@@ -517,6 +517,127 @@ tape.test("decode implicit enum zero with non-zero default", function(test) {
     test.notOk(Message.fields.op.hasPresence, "enum field should have implicit presence");
     test.equal(Message.fields.op.typeDefault, -1, "enum field should use the first value as default");
     test.equal(Message.decode(protobuf.util.newBuffer([0x20, 0x00])).op, 0, "should preserve explicit enum zero");
+    test.equal(Buffer.from(Message.encode({ op: -1 }).finish()).toString("hex"), "", "should omit implicit enum default");
+    test.equal(Buffer.from(Message.encode({ op: 0 }).finish()).toString("hex"), "2000", "should encode non-default enum zero");
+
+    test.end();
+});
+
+tape.test("encode omits implicit default values", function(test) {
+    var Message = protobuf.parse("syntax=\"proto3\";\
+        message Message {\
+            int32 int32_value = 1;\
+            bool bool_value = 2;\
+            string string_value = 3;\
+            bytes bytes_value = 4;\
+            double double_value = 5;\
+            float float_value = 6;\
+            Enum enum_value = 7;\
+            optional int32 optional_int32_value = 8;\
+            optional double optional_double_value = 9;\
+            oneof kind { int32 oneof_int32_value = 10; }\
+            enum Enum { A = 0; B = 1; }\
+        }").root.resolveAll().lookupType("Message");
+
+    function hex(buf) {
+        return Buffer.from(buf).toString("hex");
+    }
+
+    test.equal(hex(Message.encode({
+        int32Value: 0,
+        boolValue: false,
+        stringValue: "",
+        bytesValue: [],
+        doubleValue: 0,
+        floatValue: 0,
+        enumValue: 0
+    }).finish()), "", "should omit implicit scalar defaults");
+
+    test.equal(hex(Message.encode({
+        doubleValue: -0,
+        floatValue: -0
+    }).finish()), "2900000000000000803500000080", "should preserve implicit negative zero");
+
+    test.equal(hex(Message.encode({
+        optionalInt32Value: 0,
+        optionalDoubleValue: -0,
+        oneofInt32Value: 0
+    }).finish()), "40004900000000000000805000", "should encode explicit defaults");
+
+    test.end();
+});
+
+tape.test("decode preserves implicit negative zero", function(test) {
+    var Message = protobuf.parse("syntax=\"proto3\";\
+        message Message {\
+            double double_value = 1;\
+            float float_value = 2;\
+            optional double optional_double_value = 3;\
+            optional float optional_float_value = 4;\
+        }").root.resolveAll().lookupType("Message");
+
+    function bytes(hex) {
+        return protobuf.util.newBuffer(Buffer.from(hex, "hex"));
+    }
+
+    function hex(buf) {
+        return Buffer.from(buf).toString("hex");
+    }
+
+    var implicit = Message.decode(bytes("0900000000000000801500000080"));
+    test.ok(Object.is(implicit.doubleValue, -0), "should decode implicit double negative zero");
+    test.ok(Object.is(implicit.floatValue, -0), "should decode implicit float negative zero");
+    test.equal(hex(Message.encode(implicit).finish()), "0900000000000000801500000080", "should re-encode implicit negative zero");
+
+    var positive = Message.decode(bytes("0900000000000000001500000000"));
+    test.notOk(Object.prototype.hasOwnProperty.call(positive, "doubleValue"), "should drop implicit double positive zero");
+    test.notOk(Object.prototype.hasOwnProperty.call(positive, "floatValue"), "should drop implicit float positive zero");
+    test.equal(hex(Message.encode(positive).finish()), "", "should not re-encode implicit positive zero");
+
+    var explicit = Message.decode(bytes("1900000000000000802500000080"));
+    test.ok(Object.is(explicit.optionalDoubleValue, -0), "should decode explicit double negative zero");
+    test.ok(Object.is(explicit.optionalFloatValue, -0), "should decode explicit float negative zero");
+    test.equal(hex(Message.encode(explicit).finish()), "1900000000000000802500000080", "should re-encode explicit negative zero");
+
+    test.end();
+});
+
+tape.test("fromObject preserves implicit negative zero", function(test) {
+    var Message = protobuf.parse("syntax=\"proto3\";\
+        message Message {\
+            double double_value = 1;\
+            float float_value = 2;\
+            optional double optional_double_value = 3;\
+            optional float optional_float_value = 4;\
+        }").root.resolveAll().lookupType("Message");
+
+    function hex(buf) {
+        return Buffer.from(buf).toString("hex");
+    }
+
+    var implicit = Message.fromObject({
+        doubleValue: -0,
+        floatValue: -0
+    });
+    test.ok(Object.is(implicit.doubleValue, -0), "should convert implicit double negative zero");
+    test.ok(Object.is(implicit.floatValue, -0), "should convert implicit float negative zero");
+    test.equal(hex(Message.encode(implicit).finish()), "0900000000000000801500000080", "should encode converted implicit negative zero");
+
+    var positive = Message.fromObject({
+        doubleValue: 0,
+        floatValue: 0
+    });
+    test.notOk(Object.prototype.hasOwnProperty.call(positive, "doubleValue"), "should drop implicit double positive zero");
+    test.notOk(Object.prototype.hasOwnProperty.call(positive, "floatValue"), "should drop implicit float positive zero");
+    test.equal(hex(Message.encode(positive).finish()), "", "should not encode converted implicit positive zero");
+
+    var explicit = Message.fromObject({
+        optionalDoubleValue: -0,
+        optionalFloatValue: -0
+    });
+    test.ok(Object.is(explicit.optionalDoubleValue, -0), "should convert explicit double negative zero");
+    test.ok(Object.is(explicit.optionalFloatValue, -0), "should convert explicit float negative zero");
+    test.equal(hex(Message.encode(explicit).finish()), "1900000000000000802500000080", "should encode converted explicit negative zero");
 
     test.end();
 });

--- a/tests/comp_optional.js
+++ b/tests/comp_optional.js
@@ -99,11 +99,11 @@ tape.test("proto3 implicit scalar conversion defaults", function(test) {
         return Array.prototype.slice.call(Message.encode(message).finish());
     }
 
-    test.same(encode({ regularInt32: 0 }), [8, 0], "should preserve direct int32 default values");
-    test.same(encode({ regularString: "" }), [34, 0], "should preserve direct string default values");
-    test.same(encode({ regularBytes: "" }), [42, 0], "should preserve direct bytes default values");
-    test.same(encode({ regularBool: false }), [56, 0], "should preserve direct bool default values");
-    test.same(encode({ regularEnum: 0 }), [72, 0], "should preserve direct enum default values");
+    test.same(encode({ regularInt32: 0 }), [], "should omit direct int32 default values");
+    test.same(encode({ regularString: "" }), [], "should omit direct string default values");
+    test.same(encode({ regularBytes: "" }), [], "should omit direct bytes default values");
+    test.same(encode({ regularBool: false }), [], "should omit direct bool default values");
+    test.same(encode({ regularEnum: 0 }), [], "should omit direct enum default values");
 
     test.same(encode(Message.fromObject({ regularInt32: "0" })), [], "should omit converted int32 defaults");
     test.same(encode(Message.fromObject({ regularString: "" })), [], "should omit converted string defaults");

--- a/tests/data/comments.js
+++ b/tests/data/comments.js
@@ -108,11 +108,11 @@ $root.Test1 = (function() {
             _depth = 0;
         if (_depth > $util.recursionLimit)
             throw $Error("max depth exceeded");
-        if (message.field1 != null && $Object.hasOwnProperty.call(message, "field1"))
+        if (message.field1 != null && $Object.hasOwnProperty.call(message, "field1") && message.field1 !== "")
             writer.uint32(/* id 1, wireType 2 =*/10).string(message.field1);
-        if (message.field2 != null && $Object.hasOwnProperty.call(message, "field2"))
+        if (message.field2 != null && $Object.hasOwnProperty.call(message, "field2") && message.field2 !== 0)
             writer.uint32(/* id 2, wireType 0 =*/16).uint32(message.field2);
-        if (message.field3 != null && $Object.hasOwnProperty.call(message, "field3"))
+        if (message.field3 != null && $Object.hasOwnProperty.call(message, "field3") && message.field3 !== false)
             writer.uint32(/* id 3, wireType 0 =*/24).bool(message.field3);
         if (message.$unknowns != null && $Object.hasOwnProperty.call(message, "$unknowns"))
             for (var i = 0; i < message.$unknowns.length; ++i)

--- a/tests/data/convert.d.ts
+++ b/tests/data/convert.d.ts
@@ -16,6 +16,8 @@ export class Message {
     enumVal: Message.SomeEnum;
     enumRepeated: Message.SomeEnum[];
     int64Map: { [k: string]: (number|Long) };
+    doubleVal: number;
+    floatVal: number;
     static create(properties: Message.$Shape): Message & Message.$Shape;
     static create(properties?: Message.$Properties): Message;
     static encode(message: Message.$Properties, writer?: $protobuf.Writer): $protobuf.Writer;
@@ -40,6 +42,8 @@ export namespace Message {
         enumVal?: (Message.SomeEnum|null);
         enumRepeated?: (Message.SomeEnum[]|null);
         int64Map?: ({ [k: string]: (number|Long) }|null);
+        doubleVal?: (number|null);
+        floatVal?: (number|null);
         $unknowns?: Uint8Array[];
     }
     type $Shape = Message.$Properties;

--- a/tests/data/convert.js
+++ b/tests/data/convert.js
@@ -5,7 +5,7 @@ var $protobuf = require("../../minimal");
 
 // Common aliases
 var $Reader = $protobuf.Reader, $Writer = $protobuf.Writer, $util = $protobuf.util;
-var $Object = $util.global.Object, $undefined = $util.global.undefined, $Error = $util.global.Error, $Array = $util.global.Array, $TypeError = $util.global.TypeError, $String = $util.global.String, $Number = $util.global.Number, $parseInt = $util.global.parseInt, $BigInt = $util.global.BigInt;
+var $Object = $util.global.Object, $undefined = $util.global.undefined, $Error = $util.global.Error, $Array = $util.global.Array, $TypeError = $util.global.TypeError, $String = $util.global.String, $Number = $util.global.Number, $parseInt = $util.global.parseInt, $BigInt = $util.global.BigInt, $isFinite = $util.global.isFinite;
 
 // Exported root namespace
 var $root = $protobuf.roots["test_convert"] || ($protobuf.roots["test_convert"] = {});
@@ -24,6 +24,8 @@ $root.Message = (function() {
      * @property {Message.SomeEnum|null} [enumVal] Message enumVal
      * @property {Array.<Message.SomeEnum>|null} [enumRepeated] Message enumRepeated
      * @property {Object.<string,number|Long>|null} [int64Map] Message int64Map
+     * @property {number|null} [doubleVal] Message doubleVal
+     * @property {number|null} [floatVal] Message floatVal
      * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding when enabled
      */
 
@@ -133,6 +135,22 @@ $root.Message = (function() {
     Message.prototype.int64Map = $util.emptyObject;
 
     /**
+     * Message doubleVal.
+     * @member {number} doubleVal
+     * @memberof Message
+     * @instance
+     */
+    Message.prototype.doubleVal = 0;
+
+    /**
+     * Message floatVal.
+     * @member {number} floatVal
+     * @memberof Message
+     * @instance
+     */
+    Message.prototype.floatVal = 0;
+
+    /**
      * Creates a new Message instance using the specified properties.
      * @function create
      * @memberof Message
@@ -164,12 +182,12 @@ $root.Message = (function() {
             _depth = 0;
         if (_depth > $util.recursionLimit)
             throw $Error("max depth exceeded");
-        if (message.stringVal != null && $Object.hasOwnProperty.call(message, "stringVal"))
+        if (message.stringVal != null && $Object.hasOwnProperty.call(message, "stringVal") && message.stringVal !== "")
             writer.uint32(/* id 1, wireType 2 =*/10).string(message.stringVal);
         if (message.stringRepeated != null && message.stringRepeated.length)
             for (var i = 0; i < message.stringRepeated.length; ++i)
                 writer.uint32(/* id 2, wireType 2 =*/18).string(message.stringRepeated[i]);
-        if (message.uint64Val != null && $Object.hasOwnProperty.call(message, "uint64Val"))
+        if (message.uint64Val != null && $Object.hasOwnProperty.call(message, "uint64Val") && (typeof message.uint64Val === "object" ? message.uint64Val.low || message.uint64Val.high : message.uint64Val !== 0))
             writer.uint32(/* id 3, wireType 0 =*/24).uint64(message.uint64Val);
         if (message.uint64Repeated != null && message.uint64Repeated.length) {
             writer.uint32(/* id 4, wireType 2 =*/34).fork();
@@ -177,12 +195,12 @@ $root.Message = (function() {
                 writer.uint64(message.uint64Repeated[i]);
             writer.ldelim();
         }
-        if (message.bytesVal != null && $Object.hasOwnProperty.call(message, "bytesVal"))
+        if (message.bytesVal != null && $Object.hasOwnProperty.call(message, "bytesVal") && message.bytesVal.length)
             writer.uint32(/* id 5, wireType 2 =*/42).bytes(message.bytesVal);
         if (message.bytesRepeated != null && message.bytesRepeated.length)
             for (var i = 0; i < message.bytesRepeated.length; ++i)
                 writer.uint32(/* id 6, wireType 2 =*/50).bytes(message.bytesRepeated[i]);
-        if (message.enumVal != null && $Object.hasOwnProperty.call(message, "enumVal"))
+        if (message.enumVal != null && $Object.hasOwnProperty.call(message, "enumVal") && message.enumVal !== 1)
             writer.uint32(/* id 7, wireType 0 =*/56).int32(message.enumVal);
         if (message.enumRepeated != null && message.enumRepeated.length) {
             writer.uint32(/* id 8, wireType 2 =*/66).fork();
@@ -193,6 +211,10 @@ $root.Message = (function() {
         if (message.int64Map != null && $Object.hasOwnProperty.call(message, "int64Map"))
             for (var keys = $Object.keys(message.int64Map), i = 0; i < keys.length; ++i)
                 writer.uint32(/* id 9, wireType 2 =*/74).fork().uint32(/* id 1, wireType 2 =*/10).string(keys[i]).uint32(/* id 2, wireType 0 =*/16).int64(message.int64Map[keys[i]]).ldelim();
+        if (message.doubleVal != null && $Object.hasOwnProperty.call(message, "doubleVal") && !$Object.is(message.doubleVal, 0))
+            writer.uint32(/* id 10, wireType 1 =*/81).double(message.doubleVal);
+        if (message.floatVal != null && $Object.hasOwnProperty.call(message, "floatVal") && !$Object.is(message.floatVal, 0))
+            writer.uint32(/* id 11, wireType 5 =*/93).float(message.floatVal);
         if (message.$unknowns != null && $Object.hasOwnProperty.call(message, "$unknowns"))
             for (var i = 0; i < message.$unknowns.length; ++i)
                 writer.raw(message.$unknowns[i]);
@@ -354,6 +376,24 @@ $root.Message = (function() {
                     message.int64Map[key] = value;
                     continue;
                 }
+            case 10: {
+                    if (wireType !== 1)
+                        break;
+                    if (!$Object.is(value = reader.double(), 0))
+                        message.doubleVal = value;
+                    else
+                        delete message.doubleVal;
+                    continue;
+                }
+            case 11: {
+                    if (wireType !== 5)
+                        break;
+                    if (!$Object.is(value = reader.float(), 0))
+                        message.floatVal = value;
+                    else
+                        delete message.floatVal;
+                    continue;
+                }
             }
             reader.skipType(wireType, _depth, tag);
             if (!reader.discardUnknown) {
@@ -455,6 +495,12 @@ $root.Message = (function() {
                 if (!$util.isInteger(message.int64Map[key[i]]) && !(message.int64Map[key[i]] && $util.isInteger(message.int64Map[key[i]].low) && $util.isInteger(message.int64Map[key[i]].high)))
                     return "int64Map: integer|Long{k:string} expected";
         }
+        if (message.doubleVal != null && $Object.hasOwnProperty.call(message, "doubleVal"))
+            if (typeof message.doubleVal !== "number")
+                return "doubleVal: number expected";
+        if (message.floatVal != null && $Object.hasOwnProperty.call(message, "floatVal"))
+            if (typeof message.floatVal !== "number")
+                return "floatVal: number expected";
         return null;
     };
 
@@ -581,6 +627,12 @@ $root.Message = (function() {
                     message.int64Map[keys[i]] = new $util.LongBits(object.int64Map[keys[i]].low >>> 0, object.int64Map[keys[i]].high >>> 0).toNumber();
             }
         }
+        if (object.doubleVal != null)
+            if (!$Object.is($Number(object.doubleVal), 0))
+                message.doubleVal = $Number(object.doubleVal);
+        if (object.floatVal != null)
+            if (!$Object.is($Number(object.floatVal), 0))
+                message.floatVal = $Number(object.floatVal);
         return message;
     };
 
@@ -624,6 +676,8 @@ $root.Message = (function() {
                     object.bytesVal = $util.newBuffer(object.bytesVal);
             }
             object.enumVal = options.enums === $String ? "ONE" : 1;
+            object.doubleVal = 0;
+            object.floatVal = 0;
         }
         if (message.stringVal != null && $Object.hasOwnProperty.call(message, "stringVal"))
             object.stringVal = message.stringVal;
@@ -677,6 +731,10 @@ $root.Message = (function() {
                     object.int64Map[keys2[j]] = options.longs === $String ? $util.Long.prototype.toString.call(message.int64Map[keys2[j]]) : options.longs === $Number ? new $util.LongBits(message.int64Map[keys2[j]].low >>> 0, message.int64Map[keys2[j]].high >>> 0).toNumber() : message.int64Map[keys2[j]];
             }
         }
+        if (message.doubleVal != null && $Object.hasOwnProperty.call(message, "doubleVal"))
+            object.doubleVal = options.json && !$isFinite(message.doubleVal) ? $String(message.doubleVal) : message.doubleVal;
+        if (message.floatVal != null && $Object.hasOwnProperty.call(message, "floatVal"))
+            object.floatVal = options.json && !$isFinite(message.floatVal) ? $String(message.floatVal) : message.floatVal;
         return object;
     };
 

--- a/tests/data/convert.proto
+++ b/tests/data/convert.proto
@@ -20,4 +20,7 @@ message Message {
     }
 
     map<string,int64> int64_map = 9;
+
+    double double_val = 10;
+    float float_val = 11;
 }

--- a/tests/data/package.js
+++ b/tests/data/package.js
@@ -237,26 +237,26 @@ $root.Package = (function() {
             _depth = 0;
         if (_depth > $util.recursionLimit)
             throw $Error("max depth exceeded");
-        if (message.name != null && $Object.hasOwnProperty.call(message, "name"))
+        if (message.name != null && $Object.hasOwnProperty.call(message, "name") && message.name !== "")
             writer.uint32(/* id 1, wireType 2 =*/10).string(message.name);
-        if (message.version != null && $Object.hasOwnProperty.call(message, "version"))
+        if (message.version != null && $Object.hasOwnProperty.call(message, "version") && message.version !== "")
             writer.uint32(/* id 2, wireType 2 =*/18).string(message.version);
-        if (message.description != null && $Object.hasOwnProperty.call(message, "description"))
+        if (message.description != null && $Object.hasOwnProperty.call(message, "description") && message.description !== "")
             writer.uint32(/* id 3, wireType 2 =*/26).string(message.description);
-        if (message.author != null && $Object.hasOwnProperty.call(message, "author"))
+        if (message.author != null && $Object.hasOwnProperty.call(message, "author") && message.author !== "")
             writer.uint32(/* id 4, wireType 2 =*/34).string(message.author);
-        if (message.license != null && $Object.hasOwnProperty.call(message, "license"))
+        if (message.license != null && $Object.hasOwnProperty.call(message, "license") && message.license !== "")
             writer.uint32(/* id 5, wireType 2 =*/42).string(message.license);
         if (message.repository != null && $Object.hasOwnProperty.call(message, "repository"))
             $root.Package.Repository.encode(message.repository, writer.uint32(/* id 6, wireType 2 =*/50).fork(), _depth + 1).ldelim();
-        if (message.bugs != null && $Object.hasOwnProperty.call(message, "bugs"))
+        if (message.bugs != null && $Object.hasOwnProperty.call(message, "bugs") && message.bugs !== "")
             writer.uint32(/* id 7, wireType 2 =*/58).string(message.bugs);
-        if (message.homepage != null && $Object.hasOwnProperty.call(message, "homepage"))
+        if (message.homepage != null && $Object.hasOwnProperty.call(message, "homepage") && message.homepage !== "")
             writer.uint32(/* id 8, wireType 2 =*/66).string(message.homepage);
         if (message.keywords != null && message.keywords.length)
             for (var i = 0; i < message.keywords.length; ++i)
                 writer.uint32(/* id 9, wireType 2 =*/74).string(message.keywords[i]);
-        if (message.main != null && $Object.hasOwnProperty.call(message, "main"))
+        if (message.main != null && $Object.hasOwnProperty.call(message, "main") && message.main !== "")
             writer.uint32(/* id 10, wireType 2 =*/82).string(message.main);
         if (message.bin != null && $Object.hasOwnProperty.call(message, "bin"))
             for (var keys = $Object.keys(message.bin), i = 0; i < keys.length; ++i)
@@ -270,12 +270,12 @@ $root.Package = (function() {
         if (message.devDependencies != null && $Object.hasOwnProperty.call(message, "devDependencies"))
             for (var keys = $Object.keys(message.devDependencies), i = 0; i < keys.length; ++i)
                 writer.uint32(/* id 15, wireType 2 =*/122).fork().uint32(/* id 1, wireType 2 =*/10).string(keys[i]).uint32(/* id 2, wireType 2 =*/18).string(message.devDependencies[keys[i]]).ldelim();
-        if (message.types != null && $Object.hasOwnProperty.call(message, "types"))
+        if (message.types != null && $Object.hasOwnProperty.call(message, "types") && message.types !== "")
             writer.uint32(/* id 17, wireType 2 =*/138).string(message.types);
         if (message.cliDependencies != null && message.cliDependencies.length)
             for (var i = 0; i < message.cliDependencies.length; ++i)
                 writer.uint32(/* id 18, wireType 2 =*/146).string(message.cliDependencies[i]);
-        if (message.versionScheme != null && $Object.hasOwnProperty.call(message, "versionScheme"))
+        if (message.versionScheme != null && $Object.hasOwnProperty.call(message, "versionScheme") && message.versionScheme !== "")
             writer.uint32(/* id 19, wireType 2 =*/154).string(message.versionScheme);
         if (message.$unknowns != null && $Object.hasOwnProperty.call(message, "$unknowns"))
             for (var i = 0; i < message.$unknowns.length; ++i)
@@ -1012,9 +1012,9 @@ $root.Package = (function() {
                 _depth = 0;
             if (_depth > $util.recursionLimit)
                 throw $Error("max depth exceeded");
-            if (message.type != null && $Object.hasOwnProperty.call(message, "type"))
+            if (message.type != null && $Object.hasOwnProperty.call(message, "type") && message.type !== "")
                 writer.uint32(/* id 1, wireType 2 =*/10).string(message.type);
-            if (message.url != null && $Object.hasOwnProperty.call(message, "url"))
+            if (message.url != null && $Object.hasOwnProperty.call(message, "url") && message.url !== "")
                 writer.uint32(/* id 2, wireType 2 =*/18).string(message.url);
             if (message.$unknowns != null && $Object.hasOwnProperty.call(message, "$unknowns"))
                 for (var i = 0; i < message.$unknowns.length; ++i)

--- a/tests/data/rpc-es6.js
+++ b/tests/data/rpc-es6.js
@@ -161,7 +161,7 @@ export const MyRequest = $root.MyRequest = (() => {
             _depth = 0;
         if (_depth > $util.recursionLimit)
             throw $Error("max depth exceeded");
-        if (message.path != null && $Object.hasOwnProperty.call(message, "path"))
+        if (message.path != null && $Object.hasOwnProperty.call(message, "path") && message.path !== "")
             writer.uint32(/* id 1, wireType 2 =*/10).string(message.path);
         if (message.$unknowns != null && $Object.hasOwnProperty.call(message, "$unknowns"))
             for (let i = 0; i < message.$unknowns.length; ++i)
@@ -421,7 +421,7 @@ export const MyResponse = $root.MyResponse = (() => {
             _depth = 0;
         if (_depth > $util.recursionLimit)
             throw $Error("max depth exceeded");
-        if (message.status != null && $Object.hasOwnProperty.call(message, "status"))
+        if (message.status != null && $Object.hasOwnProperty.call(message, "status") && message.status !== 0)
             writer.uint32(/* id 2, wireType 0 =*/16).int32(message.status);
         if (message.$unknowns != null && $Object.hasOwnProperty.call(message, "$unknowns"))
             for (let i = 0; i < message.$unknowns.length; ++i)

--- a/tests/data/rpc-reserved.js
+++ b/tests/data/rpc-reserved.js
@@ -163,7 +163,7 @@ $root.MyRequest = (function() {
             _depth = 0;
         if (_depth > $util.recursionLimit)
             throw $Error("max depth exceeded");
-        if (message.path != null && $Object.hasOwnProperty.call(message, "path"))
+        if (message.path != null && $Object.hasOwnProperty.call(message, "path") && message.path !== "")
             writer.uint32(/* id 1, wireType 2 =*/10).string(message.path);
         if (message.$unknowns != null && $Object.hasOwnProperty.call(message, "$unknowns"))
             for (var i = 0; i < message.$unknowns.length; ++i)
@@ -423,7 +423,7 @@ $root.MyResponse = (function() {
             _depth = 0;
         if (_depth > $util.recursionLimit)
             throw $Error("max depth exceeded");
-        if (message.status != null && $Object.hasOwnProperty.call(message, "status"))
+        if (message.status != null && $Object.hasOwnProperty.call(message, "status") && message.status !== 0)
             writer.uint32(/* id 2, wireType 0 =*/16).int32(message.status);
         if (message.$unknowns != null && $Object.hasOwnProperty.call(message, "$unknowns"))
             for (var i = 0; i < message.$unknowns.length; ++i)

--- a/tests/data/rpc.js
+++ b/tests/data/rpc.js
@@ -163,7 +163,7 @@ $root.MyRequest = (function() {
             _depth = 0;
         if (_depth > $util.recursionLimit)
             throw $Error("max depth exceeded");
-        if (message.path != null && $Object.hasOwnProperty.call(message, "path"))
+        if (message.path != null && $Object.hasOwnProperty.call(message, "path") && message.path !== "")
             writer.uint32(/* id 1, wireType 2 =*/10).string(message.path);
         if (message.$unknowns != null && $Object.hasOwnProperty.call(message, "$unknowns"))
             for (var i = 0; i < message.$unknowns.length; ++i)
@@ -423,7 +423,7 @@ $root.MyResponse = (function() {
             _depth = 0;
         if (_depth > $util.recursionLimit)
             throw $Error("max depth exceeded");
-        if (message.status != null && $Object.hasOwnProperty.call(message, "status"))
+        if (message.status != null && $Object.hasOwnProperty.call(message, "status") && message.status !== 0)
             writer.uint32(/* id 2, wireType 0 =*/16).int32(message.status);
         if (message.$unknowns != null && $Object.hasOwnProperty.call(message, "$unknowns"))
             for (var i = 0; i < message.$unknowns.length; ++i)

--- a/tests/data/type_url.js
+++ b/tests/data/type_url.js
@@ -345,7 +345,7 @@ $root.TypeUrlTest = (function() {
                 _depth = 0;
             if (_depth > $util.recursionLimit)
                 throw $Error("max depth exceeded");
-            if (message.a != null && $Object.hasOwnProperty.call(message, "a"))
+            if (message.a != null && $Object.hasOwnProperty.call(message, "a") && message.a !== "")
                 writer.uint32(/* id 1, wireType 2 =*/10).string(message.a);
             if (message.$unknowns != null && $Object.hasOwnProperty.call(message, "$unknowns"))
                 for (var i = 0; i < message.$unknowns.length; ++i)


### PR DESCRIPTION
Updates generated encoders to omit implicit scalar fields set to their default value, as per protobuf presence semantics. This aligns encoding with the normalization already performed during decode, so both encode and decode consistently avoid materializing semantically absent implicit-presence fields. Should be safe to do now because decode already normalizes these fields, so the previous encode-only wire-format distinction is no longer semantically observable.