### PR TITLE
fix: Implement open/closed enum semantics

### DIFF
--- a/cli/targets/static.js
+++ b/cli/targets/static.js
@@ -444,6 +444,15 @@ function buildFunction(type, functionName, gen, scope) {
              && node.property.type === "Identifier" && node.property.name === "values"
             )
                 return rootMemberRef(type.fieldsArray[node.object.property.value].resolvedType);
+            // replace types[N].valuesById with the field's actual enum object
+            if (
+                node.type === "MemberExpression"
+             && node.object.type === "MemberExpression"
+             && node.object.object.type === "Identifier" && node.object.object.name === "types"
+             && node.object.property.type === "Literal"
+             && node.property.type === "Identifier" && node.property.name === "valuesById"
+            )
+                return rootMemberRef(type.fieldsArray[node.object.property.value].resolvedType);
             // replace types[N] with the field's actual type
             if (
                 node.type === "MemberExpression"

--- a/ext/protojson.js
+++ b/ext/protojson.js
@@ -241,8 +241,10 @@ function readEnum(enm, value, name, options) {
         throw invalid(name, value, "unknown enum value");
     }
     if (typeof value === "number") {
-        if (!isFinite(value) || Math.floor(value) !== value)
+        if ((value | 0) !== value)
             throw invalid(name, value, "invalid enum number");
+        if (enm._features.enum_type === "CLOSED" && enm.valuesById[value] === undefined)
+            throw invalid(name, value, "unknown enum value");
         return value;
     }
     if (value === null && enm.fullName === ".google.protobuf.NullValue")

--- a/ext/textformat.js
+++ b/ext/textformat.js
@@ -846,6 +846,12 @@ function parseInteger(token, sign, unsigned, bits) {
         return parseIntegerBigInt(digits, radix, sign, unsigned, bits);
 
     var value = parseInt(digits, radix) * sign;
+    if (bits === 32) {
+        var min = unsigned ? 0 : -2147483648,
+            max = unsigned ? 4294967295 : 2147483647;
+        if (value < min || value > max)
+            throw Error((unsigned ? "unsigned " : "") + "integer value out of range");
+    }
     if (bits === 64 && util.Long)
         return util.Long.fromString(String(value), unsigned);
     return value;

--- a/scripts/gentests.js
+++ b/scripts/gentests.js
@@ -7,6 +7,7 @@ var fs   = require("fs"),
 [
     { file: "tests/data/comments.proto", flags: [] },
     { file: "tests/data/convert.proto", flags: [] },
+    { file: "tests/data/enum-semantics.proto", flags: [] },
     { file: "tests/data/mapbox/vector_tile.proto", flags: [] },
     { file: "tests/data/package.proto", flags: [] },
     { file: "tests/data/rpc.proto", flags: [ "es6" ] },
@@ -47,6 +48,7 @@ process.stdout.write("\n");
 [
     { file: "tests/data/comments.js" },
     { file: "tests/data/convert.js" },
+    { file: "tests/data/enum-semantics.js" },
     { file: "tests/data/mapbox/vector_tile.js" },
     { file: "tests/data/package.js" },
     { file: "tests/data/rpc.js" },

--- a/src/converter.js
+++ b/src/converter.js
@@ -15,31 +15,33 @@ var Enum  = require("./enum"),
  * @param {Field} field Reflected field
  * @param {number} fieldIndex Field index
  * @param {string} prop Property reference
+ * @param {string} [dstProp] Repeated destination property reference
  * @returns {Codegen} Codegen instance
  * @ignore
  */
-function genValuePartial_fromObject(gen, field, fieldIndex, prop) {
-    var defaultAlreadyEmitted = false;
+function genValuePartial_fromObject(gen, field, fieldIndex, prop, dstProp) {
     /* eslint-disable no-unexpected-multiline, block-scoped-var, no-redeclare */
     if (field.resolvedType) {
-        if (field.resolvedType instanceof Enum) { gen
+        if (field.resolvedType instanceof Enum) {
+            var dst = dstProp
+                ? "m" + dstProp + "[m" + dstProp + ".length]"
+                : "m" + prop;
+            gen
             ("switch(d%s){", prop);
-            for (var values = field.resolvedType.values, keys = Object.keys(values), i = 0; i < keys.length; ++i) {
-                // enum unknown values passthrough
-                if (values[keys[i]] === field.typeDefault && !defaultAlreadyEmitted) { gen
-                    ("default:")
-                        ("if(typeof d%s===\"number\"){m%s=d%s;break}", prop, prop, prop);
-                    if (!field.repeated) gen // fallback to default value only for
-                                             // arrays, to avoid leaving holes.
-                        ("break");           // for non-repeated fields, just ignore
-                    defaultAlreadyEmitted = true;
-                }
-                gen
+            for (var values = field.resolvedType.values, keys = Object.keys(values), i = 0; i < keys.length; ++i) { gen
                 ("case%j:", keys[i])
                 ("case %i:", values[keys[i]])
-                    ("m%s=%j", prop, values[keys[i]])
+                    ("%s=%j", dst, values[keys[i]])
                     ("break");
-            } gen
+            }
+            gen
+                ("default:");
+            if (field.resolvedType._features.enum_type !== "CLOSED") {
+                gen
+                    ("if(typeof d%s===\"number\"&&(d%s|0)===d%s)", prop, prop, prop)
+                        ("%s=d%s", dst, prop);
+            }
+            gen
             ("}");
         } else gen
             ("if(!util.isObject(d%s))", prop)
@@ -142,10 +144,14 @@ converter.fromObject = function fromObject(mtype) {
         } else if (field.repeated) { gen
     ("if(d%s){", prop)
         ("if(!Array.isArray(d%s))", prop)
-            ("throw TypeError(%j)", field.fullName + ": array expected")
-        ("m%s=Array(d%s.length)", prop, prop)
+            ("throw TypeError(%j)", field.fullName + ": array expected");
+            if (field.resolvedType instanceof Enum) gen
+        ("m%s=[]", prop);
+            else gen
+        ("m%s=Array(d%s.length)", prop, prop);
+            gen
         ("for(var i=0;i<d%s.length;++i){", prop);
-            genValuePartial_fromObject(gen, field, /* not sorted */ i, prop + "[i]")
+            genValuePartial_fromObject(gen, field, /* not sorted */ i, prop + "[i]", field.resolvedType instanceof Enum ? prop : undefined)
         ("}")
     ("}");
 

--- a/src/decoder.js
+++ b/src/decoder.js
@@ -13,6 +13,16 @@ function stringMethod(field) {
     return field._features.utf8_validation === "VERIFY" ? "stringVerify" : "string";
 }
 
+function genPreserveUnknown(gen, ref) {
+    /* eslint-disable no-unexpected-multiline */
+    return gen
+        ("if(!r.discardUnknown){")
+            ("util.makeProp(m,\"$unknowns\",false);")
+            ("(m.$unknowns||(m.$unknowns=[])).push(%s)", ref)
+        ("}");
+    /* eslint-enable no-unexpected-multiline */
+}
+
 /**
  * Generates a decoder specific to the specified message type.
  * @param {Type} mtype Message type
@@ -21,14 +31,14 @@ function stringMethod(field) {
 function decoder(mtype) {
     /* eslint-disable no-unexpected-multiline */
     var hasMapField = false,
-        hasImplicitPresenceField = false,
+        needsValueVar = false,
         i = 0;
     for (; i < mtype.fieldsArray.length; ++i) {
         var pfield = mtype._fieldsArray[i];
         if (pfield.map)
             hasMapField = true;
-        if (!pfield.repeated && !pfield.map && !pfield.hasPresence)
-            hasImplicitPresenceField = true;
+        if (pfield.resolvedType instanceof Enum || !pfield.repeated && !pfield.map && !pfield.hasPresence)
+            needsValueVar = true;
     }
     var gen = util.codegen(["r", "l", "z", "q", "g"])
     ("if(!(r instanceof Reader))")
@@ -36,7 +46,7 @@ function decoder(mtype) {
     ("if(q===undefined)q=0")
     ("if(q>Reader.recursionLimit)")
         ("throw Error(\"max depth exceeded\")")
-    ("var c=l===undefined?r.len:r.pos+l,m=g||new C" + (hasMapField ? ",k,v" : hasImplicitPresenceField ? ",v" : ""))
+    ("var c=l===undefined?r.len:r.pos+l,m=g||new C" + (hasMapField ? ",k,v" : needsValueVar ? ",v" : ""))
     ("while(r.pos<c){")
         ("var s=r.pos")
         ("var t=r.tag()")
@@ -48,18 +58,21 @@ function decoder(mtype) {
         ("var u=t&7")
         ("switch(t>>>=3){");
     for (i = 0; i < /* initializes */ mtype.fieldsArray.length; ++i) {
-        var field = mtype._fieldsArray[i].resolve(),
-            type  = field.resolvedType instanceof Enum ? "int32" : field.type,
-            ref   = "m" + util.safeProp(field.name);
+        var field  = mtype._fieldsArray[i].resolve(),
+            type   = field.resolvedType instanceof Enum ? "int32" : field.type,
+            ref    = "m" + util.safeProp(field.name),
+            closed = field.resolvedType instanceof Enum && field.resolvedType._features.enum_type === "CLOSED";
 
         // Map fields
         if (field.map) {
             gen
             ("case %i:{", field.id)
                 ("if(u!==2)")
-                    ("break")
+                    ("break");
+            if (!closed) gen
                 ("if(%s===util.emptyObject)", ref)
-                    ("%s={}", ref)
+                    ("%s={}", ref);
+            gen
                 ("var c2=r.uint32()+r.pos");
 
             if (types.defaults[field.keyType] !== undefined) gen
@@ -99,6 +112,15 @@ function decoder(mtype) {
                     ("r.skipType(u,q,t2)")
                 ("}");
 
+            if (closed) { gen
+                ("if(types[%i].valuesById[v]===undefined){", i);
+                    genPreserveUnknown(gen, "r.raw(s,r.pos)")
+                    ("continue")
+                ("}")
+                ("if(%s===util.emptyObject)", ref)
+                    ("%s={}", ref);
+            }
+
             var val = types.basic[type] === undefined ? "v||new types[" + i + "].ctor" : "v";
             if (types.long[field.keyType] !== undefined) gen
                 ("%s[typeof k===\"object\"?util.longToHash(k):k]=%s", ref, val);
@@ -116,20 +138,39 @@ function decoder(mtype) {
             ("{");
 
             // Packable (always check for forward and backward compatiblity)
-            if (types.packed[type] !== undefined) gen
-                ("if(u===2){")
+            if (types.packed[type] !== undefined) {
+                gen
+                ("if(u===2){");
+                if (!closed) gen
                     ("if(!(%s&&%s.length))", ref, ref)
-                        ("%s=[]", ref)
-                    ("var c2=r.uint32()+r.pos")
+                        ("%s=[]", ref);
+                gen
+                    ("var c2=r.uint32()+r.pos");
+                if (closed) {
+                    gen
+                    ("while(r.pos<c2){")
+                        ("s=r.pos")
+                        ("v=r.%s()", type)
+                        ("if(types[%i].valuesById[v]!==undefined){", i)
+                            ("if(!(%s&&%s.length))", ref, ref)
+                                ("%s=[]", ref)
+                            ("%s.push(v)", ref)
+                        ("}else");
+                            genPreserveUnknown(gen, "util.rawField(" + field.id + ",0,r.raw(s,r.pos))")
+                    ("}");
+                } else gen
                     ("while(r.pos<c2)")
-                        ("%s.push(r.%s())", ref, type)
+                        ("%s.push(r.%s())", ref, type);
+                gen
                     ("continue")
                 ("}");
+            }
 
             // Non-packed
             gen
                 ("if(u!==%i)", types.basic[type] === undefined ? field.delimited ? 3 : 2 : types.basic[type])
-                    ("break")
+                    ("break");
+            if (!closed) gen
                 ("if(!(%s&&%s.length))", ref, ref)
                     ("%s=[]", ref);
             if (types.basic[type] === undefined) {
@@ -137,6 +178,14 @@ function decoder(mtype) {
                     ("%s.push(types[%i].decode(r,undefined,%i,q+1))", ref, i, field.id * 8 + 4);
                 else gen
                     ("%s.push(types[%i].decode(r,r.uint32(),undefined,q+1))", ref, i);
+            } else if (closed) { gen
+                    ("v=r.%s()", type)
+                    ("if(types[%i].valuesById[v]!==undefined){", i)
+                        ("if(!(%s&&%s.length))", ref, ref)
+                            ("%s=[]", ref)
+                        ("%s.push(v)", ref)
+                    ("}else");
+                        genPreserveUnknown(gen, "r.raw(s,r.pos)");
             } else gen
                     ("%s.push(r.%s())", ref, type === "string" ? stringMethod(field) : type);
 
@@ -155,33 +204,55 @@ function decoder(mtype) {
             gen
             ("case %i:{", field.id)
                 ("if(u!==%i)", types.basic[type])
-                    ("break")
+                    ("break");
+            if (closed) { gen
+                ("v=r.%s()", type)
+                ("if(types[%i].valuesById[v]!==undefined){", i)
+                    ("%s=v", ref);
+                if (field.partOf) gen
+                    ("m%s=%j", util.safeProp(field.partOf.name), field.name);
+                gen
+                ("}else");
+                    genPreserveUnknown(gen, "r.raw(s,r.pos)");
+            } else gen
                 ("%s=r.%s()", ref, type === "string" ? stringMethod(field) : type);
         } else {
             gen
             ("case %i:{", field.id)
                 ("if(u!==%i)", types.basic[type])
                     ("break");
-            if (field.resolvedType instanceof Enum && field.typeDefault !== 0) gen
-                // TODO: Protoc rejects open enums whose first value is not zero.
-                // We should do the same, but for v8 this would be a regression.
-                ("if((v=r.%s())!==%j)", type, field.typeDefault);
-            else if (type === "string") gen
-                ("if((v=r.%s()).length)", stringMethod(field));
-            else if (type === "bytes") gen
-                ("if((v=r.%s()).length)", type);
-            else if (types.long[type] !== undefined) gen
-                ("if(typeof(v=r.%s())===\"object\"?v.low||v.high:v!==0)", type);
-            else if (type === "double" || type === "float") gen
-                ("if((v=r.%s())!==0)", type);
-            else gen
-                ("if(v=r.%s())", type);
-            gen
-                    ("%s=v", ref)
-                ("else")
-                    ("delete %s", ref); // rare/odd case: later default clears earlier non-default
+            if (closed) { gen
+                ("v=r.%s()", type)
+                ("if(types[%i].valuesById[v]!==undefined){", i)
+                    ("if(v!==%j)", field.typeDefault)
+                        ("%s=v", ref)
+                    ("else")
+                        ("delete %s", ref)
+                ("}else{");
+                    genPreserveUnknown(gen, "r.raw(s,r.pos)")
+                ("}");
+            } else {
+                if (field.resolvedType instanceof Enum && field.typeDefault !== 0) gen
+                    // TODO: Protoc rejects open enums whose first value is not zero.
+                    // We should do the same, but for v8 this would be a regression.
+                    ("if((v=r.%s())!==%j)", type, field.typeDefault);
+                else if (type === "string") gen
+                    ("if((v=r.%s()).length)", stringMethod(field));
+                else if (type === "bytes") gen
+                    ("if((v=r.%s()).length)", type);
+                else if (types.long[type] !== undefined) gen
+                    ("if(typeof(v=r.%s())===\"object\"?v.low||v.high:v!==0)", type);
+                else if (type === "double" || type === "float") gen
+                    ("if((v=r.%s())!==0)", type);
+                else gen
+                    ("if(v=r.%s())", type);
+                gen
+                        ("%s=v", ref)
+                    ("else")
+                        ("delete %s", ref); // rare/odd case: later default clears earlier non-default
+            }
         }
-        if (field.partOf) gen
+        if (field.partOf && !closed) gen
                 ("m%s=%j", util.safeProp(field.partOf.name), field.name);
         gen
                 ("continue")
@@ -191,11 +262,8 @@ function decoder(mtype) {
         ("}");
     // Unknown fields
     gen
-        ("r.skipType(%s,q,t)", i ? "u" : "t&7")
-        ("if(!r.discardUnknown){")
-            ("util.makeProp(m,\"$unknowns\",false);")
-            ("(m.$unknowns||(m.$unknowns=[])).push(r.raw(s,r.pos))")
-        ("}")
+        ("r.skipType(%s,q,t)", i ? "u" : "t&7");
+    genPreserveUnknown(gen, "r.raw(s,r.pos)")
     ("}")
     ("if(z!==undefined)")
         ("throw Error(\"missing end group\")");

--- a/src/util/minimal.js
+++ b/src/util/minimal.js
@@ -170,6 +170,28 @@ util.newBuffer = function newBuffer(sizeOrArray) {
 };
 
 /**
+ * Prepends a raw field tag to raw field data.
+ * @param {number} id Field id
+ * @param {number} wireType Wire type
+ * @param {Uint8Array} data Raw field data
+ * @returns {Uint8Array|Buffer} Raw field bytes
+ * @ignore
+ */
+util.rawField = function rawField(id, wireType, data) {
+    var out = [],
+        tag = id << 3 | wireType;
+    tag >>>= 0;
+    while (tag > 127) {
+        out.push(tag & 127 | 128);
+        tag >>>= 7;
+    }
+    out.push(tag);
+    for (var i = 0; i < data.length; ++i)
+        out.push(data[i]);
+    return util.newBuffer(out);
+};
+
+/**
  * Array implementation used in the browser. `Uint8Array` if supported, otherwise `Array`.
  * @type {Constructor<Uint8Array>}
  */

--- a/src/verifier.js
+++ b/src/verifier.js
@@ -19,16 +19,21 @@ function invalid(field, expected) {
  */
 function genVerifyValue(gen, field, fieldIndex, ref) {
     /* eslint-disable no-unexpected-multiline */
-    if (field.resolvedType) {
-        if (field.resolvedType instanceof Enum) { gen
-            ("switch(%s){", ref)
-                ("default:")
+    var resolvedType = field.resolvedType;
+    if (resolvedType) {
+        if (resolvedType instanceof Enum) {
+            if (resolvedType._features.enum_type === "CLOSED") { gen
+                ("switch(%s){", ref)
+                    ("default:")
+                        ("return%j", invalid(field, "enum value"));
+                for (var keys = Object.keys(resolvedType.values), j = 0; j < keys.length; ++j) gen
+                    ("case %i:", resolvedType.values[keys[j]]);
+                gen
+                        ("break")
+                ("}");
+            } else gen
+                ("if(typeof %s!==\"number\"||(%s|0)!==%s)", ref, ref, ref)
                     ("return%j", invalid(field, "enum value"));
-            for (var keys = Object.keys(field.resolvedType.values), j = 0; j < keys.length; ++j) gen
-                ("case %i:", field.resolvedType.values[keys[j]]);
-            gen
-                    ("break")
-            ("}");
         } else {
             gen
             ("{")

--- a/tests/comp_enum-semantics.js
+++ b/tests/comp_enum-semantics.js
@@ -1,0 +1,184 @@
+var tape = require("tape");
+
+var protobuf = require("..");
+var protojson = require("../ext/protojson");
+var textformat = require("../ext/textformat");
+var statik = require("./data/enum-semantics");
+
+var INT32_MIN = -2147483648;
+var INT32_MAX = 2147483647;
+
+function bytes(buffer) {
+    return Array.prototype.slice.call(buffer);
+}
+
+function object(value) {
+    return Object.assign({}, value);
+}
+
+function closedPayload() {
+    return protobuf.Writer.create()
+        .uint32(8).int32(2)
+        .uint32(16).int32(0)
+        .uint32(16).int32(2)
+        .uint32(16).int32(1)
+        .uint32(26).fork().int32(0).int32(2).int32(1).ldelim()
+        .uint32(34).fork().uint32(10).string("x").uint32(16).int32(2).ldelim()
+        .finish();
+}
+
+function decodePreserve(Type, payload) {
+    var reader = protobuf.Reader.create(payload);
+    reader.discardUnknown = false;
+    return Type.decode(reader);
+}
+
+function implicitClosedPayload(value) {
+    return protobuf.Writer.create()
+        .uint32(8).int32(value)
+        .finish();
+}
+
+function runImplicitTypeTests(test, label, ClosedImplicitMessage) {
+    var known = ClosedImplicitMessage.decode(implicitClosedPayload(1));
+    test.equal(known.singular, 1, label + " decodes implicit closed declared enum numbers");
+
+    var discard = ClosedImplicitMessage.decode(implicitClosedPayload(2));
+    test.equal(Object.prototype.hasOwnProperty.call(discard, "singular"), false, label + " drops implicit closed unknown enum numbers");
+    test.equal(discard.$unknowns, undefined, label + " discards implicit closed unknown enum numbers by default");
+
+    var preserve = decodePreserve(ClosedImplicitMessage, implicitClosedPayload(2));
+    test.equal(Object.prototype.hasOwnProperty.call(preserve, "singular"), false, label + " does not assign preserved implicit closed unknown enum numbers");
+    test.same(preserve.$unknowns.map(bytes), [
+        [ 8, 2 ]
+    ], label + " preserves implicit closed unknown enum numbers as unknown fields");
+}
+
+function runTypeTests(test, label, OpenMessage, ClosedMessage) {
+    var open = OpenMessage.decode(OpenMessage.encode({
+        singular: 2,
+        repeated: [ 0, 2, 1 ],
+        packed: [ 0, 2, 1 ],
+        values: { x: 2 }
+    }).finish());
+
+    test.equal(open.singular, 2, label + " preserves open singular unknown enum numbers");
+    test.same(open.repeated, [ 0, 2, 1 ], label + " preserves open unpacked repeated unknown enum numbers");
+    test.same(open.packed, [ 0, 2, 1 ], label + " preserves open packed repeated unknown enum numbers");
+    test.same(object(open.values), { x: 2 }, label + " preserves open map unknown enum numbers");
+
+    test.equal(OpenMessage.verify({ singular: 2 }), null, label + " verifies open unknown enum numbers");
+    test.equal(OpenMessage.verify({ singular: INT32_MIN }), null, label + " verifies open int32 minimum");
+    test.equal(OpenMessage.verify({ singular: INT32_MAX }), null, label + " verifies open int32 maximum");
+    test.equal(OpenMessage.verify({ singular: INT32_MAX + 1 }), "singular: enum value expected", label + " rejects open enum numbers above int32");
+    test.equal(OpenMessage.verify({ singular: 1.5 }), "singular: enum value expected", label + " rejects fractional open enum numbers");
+
+    var convertedOpen = OpenMessage.fromObject({
+        singular: 2,
+        repeated: [ 0, 2, INT32_MAX, INT32_MAX + 1, "ONE", "NOPE" ],
+        packed: [ INT32_MIN, INT32_MIN - 1 ],
+        values: { keep: 2, drop: INT32_MAX + 1 }
+    });
+    test.equal(convertedOpen.singular, 2, label + " converts open unknown enum numbers");
+    test.same(convertedOpen.repeated, [ 0, 2, INT32_MAX, 1 ], label + " drops invalid open repeated enum values");
+    test.same(convertedOpen.packed, [ INT32_MIN ], label + " drops invalid open packed enum values");
+    test.same(object(convertedOpen.values), { keep: 2 }, label + " drops invalid open map enum values");
+
+    var convertedClosed = ClosedMessage.fromObject({
+        singular: 2,
+        repeated: [ 0, 2, 1, "ONE", "NOPE" ],
+        packed: [ 0, 2, 1 ],
+        values: { keep: 1, drop: 2 }
+    });
+    test.equal(Object.prototype.hasOwnProperty.call(convertedClosed, "singular"), false, label + " drops closed singular unknown enum numbers");
+    test.same(convertedClosed.repeated, [ 0, 1, 1 ], label + " drops closed repeated unknown enum numbers");
+    test.same(convertedClosed.packed, [ 0, 1 ], label + " drops closed packed unknown enum numbers");
+    test.same(object(convertedClosed.values), { keep: 1 }, label + " drops closed map unknown enum numbers");
+
+    test.equal(ClosedMessage.verify({ singular: 1 }), null, label + " verifies closed declared enum numbers");
+    test.equal(ClosedMessage.verify({ singular: 2 }), "singular: enum value expected", label + " rejects closed unknown enum numbers");
+    test.equal(ClosedMessage.verify({ singular: INT32_MAX + 1 }), "singular: enum value expected", label + " rejects closed out-of-range enum numbers");
+
+    var closedDiscard = ClosedMessage.decode(closedPayload());
+    test.equal(Object.prototype.hasOwnProperty.call(closedDiscard, "singular"), false, label + " does not assign closed singular unknown enum numbers");
+    test.same(closedDiscard.repeated, [ 0, 1 ], label + " keeps only known unpacked repeated closed enum numbers");
+    test.same(closedDiscard.packed, [ 0, 1 ], label + " keeps only known packed repeated closed enum numbers");
+    test.same(object(closedDiscard.values), {}, label + " drops map entries with unknown closed enum values");
+    test.equal(closedDiscard.$unknowns, undefined, label + " discards unknown closed enum numbers by default");
+
+    var closedPreserve = decodePreserve(ClosedMessage, closedPayload());
+    test.same(closedPreserve.repeated, [ 0, 1 ], label + " preserves known closed repeated values with unknown preservation enabled");
+    test.same(closedPreserve.packed, [ 0, 1 ], label + " preserves known closed packed values with unknown preservation enabled");
+    test.same(closedPreserve.$unknowns.map(bytes), [
+        [ 8, 2 ],
+        [ 16, 2 ],
+        [ 24, 2 ],
+        [ 34, 5, 10, 1, 120, 16, 2 ]
+    ], label + " preserves unknown closed enum values as unknown fields");
+}
+
+tape.test("open and closed enum semantics", function(test) {
+    var root = protobuf.loadSync("tests/data/enum-semantics.proto").resolveAll();
+    var OpenMessage = root.lookupType("OpenMessage"),
+        ClosedMessage = root.lookupType("ClosedMessage"),
+        ClosedImplicitMessage = root.lookupType("ClosedImplicitMessage");
+
+    runTypeTests(test, "reflected", OpenMessage, ClosedMessage);
+    runImplicitTypeTests(test, "reflected", ClosedImplicitMessage);
+    runTypeTests(test, "static", statik.OpenMessage, statik.ClosedMessage);
+    runImplicitTypeTests(test, "static", statik.ClosedImplicitMessage);
+
+    var protoJsonOpen = protojson.fromJson(OpenMessage, {
+        singular: 2,
+        repeated: [ 2 ],
+        packed: [ 2 ],
+        values: { x: 2 }
+    });
+    test.equal(protoJsonOpen.singular, 2, "ProtoJSON preserves open singular unknown enum numbers");
+    test.same(protoJsonOpen.repeated, [ 2 ], "ProtoJSON preserves open repeated unknown enum numbers");
+    test.same(protoJsonOpen.packed, [ 2 ], "ProtoJSON preserves open packed unknown enum numbers");
+    test.same(object(protoJsonOpen.values), { x: 2 }, "ProtoJSON preserves open map unknown enum numbers");
+    test.throws(function() {
+        protojson.fromJson(OpenMessage, { singular: INT32_MAX + 1 });
+    }, /invalid enum number/, "ProtoJSON rejects open out-of-range enum numbers");
+    test.throws(function() {
+        protojson.fromJson(ClosedMessage, { singular: 2 });
+    }, /unknown enum value/, "ProtoJSON rejects closed unknown enum numbers");
+    test.throws(function() {
+        protojson.fromJson(ClosedMessage, { repeated: [ 2 ] });
+    }, /unknown enum value/, "ProtoJSON rejects closed repeated unknown enum numbers");
+    test.throws(function() {
+        protojson.fromJson(ClosedMessage, { packed: [ 2 ] });
+    }, /unknown enum value/, "ProtoJSON rejects closed packed unknown enum numbers");
+    test.throws(function() {
+        protojson.fromJson(ClosedMessage, { values: { x: 2 } });
+    }, /unknown enum value/, "ProtoJSON rejects closed map unknown enum numbers");
+
+    var textOpen = textformat.fromText(OpenMessage, [
+        "singular: 2",
+        "repeated: 2",
+        "packed: 2",
+        "values { key: \"x\" value: 2 }"
+    ].join("\n"));
+    test.equal(textOpen.singular, 2, "Text Format preserves open singular unknown enum numbers");
+    test.same(textOpen.repeated, [ 2 ], "Text Format preserves open repeated unknown enum numbers");
+    test.same(textOpen.packed, [ 2 ], "Text Format preserves open packed unknown enum numbers");
+    test.same(object(textOpen.values), { x: 2 }, "Text Format preserves open map unknown enum numbers");
+    test.throws(function() {
+        textformat.fromText(OpenMessage, "singular: 2147483648");
+    }, /integer value out of range/, "Text Format rejects open out-of-range enum numbers");
+    test.throws(function() {
+        textformat.fromText(ClosedMessage, "singular: 2");
+    }, /enum value expected/, "Text Format rejects closed unknown enum numbers");
+    test.throws(function() {
+        textformat.fromText(ClosedMessage, "repeated: 2");
+    }, /enum value expected/, "Text Format rejects closed repeated unknown enum numbers");
+    test.throws(function() {
+        textformat.fromText(ClosedMessage, "packed: 2");
+    }, /enum value expected/, "Text Format rejects closed packed unknown enum numbers");
+    test.throws(function() {
+        textformat.fromText(ClosedMessage, "values { key: \"x\" value: 2 }");
+    }, /enum value expected/, "Text Format rejects closed map unknown enum numbers");
+
+    test.end();
+});

--- a/tests/data/convert.js
+++ b/tests/data/convert.js
@@ -428,24 +428,14 @@ $root.Message = (function() {
                     return "bytesRepeated: buffer[] expected";
         }
         if (message.enumVal != null && $Object.hasOwnProperty.call(message, "enumVal"))
-            switch (message.enumVal) {
-            default:
+            if (typeof message.enumVal !== "number" || (message.enumVal | 0) !== message.enumVal)
                 return "enumVal: enum value expected";
-            case 1:
-            case 2:
-                break;
-            }
         if (message.enumRepeated != null && $Object.hasOwnProperty.call(message, "enumRepeated")) {
             if (!$Array.isArray(message.enumRepeated))
                 return "enumRepeated: array expected";
             for (var i = 0; i < message.enumRepeated.length; ++i)
-                switch (message.enumRepeated[i]) {
-                default:
+                if (typeof message.enumRepeated[i] !== "number" || (message.enumRepeated[i] | 0) !== message.enumRepeated[i])
                     return "enumRepeated: enum value[] expected";
-                case 1:
-                case 2:
-                    break;
-                }
         }
         if (message.int64Map != null && $Object.hasOwnProperty.call(message, "int64Map")) {
             if (!$util.isObject(message.int64Map))
@@ -528,12 +518,6 @@ $root.Message = (function() {
         }
         if (object.enumVal !== 1 && (typeof object.enumVal !== "string" || $root.Message.SomeEnum[object.enumVal] !== 1))
             switch (object.enumVal) {
-            default:
-                if (typeof object.enumVal === "number") {
-                    message.enumVal = object.enumVal;
-                    break;
-                }
-                break;
             case "ONE":
             case 1:
                 message.enumVal = 1;
@@ -542,26 +526,27 @@ $root.Message = (function() {
             case 2:
                 message.enumVal = 2;
                 break;
+            default:
+                if (typeof object.enumVal === "number" && (object.enumVal | 0) === object.enumVal)
+                    message.enumVal = object.enumVal;
             }
         if (object.enumRepeated) {
             if (!$Array.isArray(object.enumRepeated))
                 throw $TypeError(".Message.enumRepeated: array expected");
-            message.enumRepeated = $Array(object.enumRepeated.length);
+            message.enumRepeated = [];
             for (var i = 0; i < object.enumRepeated.length; ++i)
                 switch (object.enumRepeated[i]) {
-                default:
-                    if (typeof object.enumRepeated[i] === "number") {
-                        message.enumRepeated[i] = object.enumRepeated[i];
-                        break;
-                    }
                 case "ONE":
                 case 1:
-                    message.enumRepeated[i] = 1;
+                    message.enumRepeated[message.enumRepeated.length] = 1;
                     break;
                 case "TWO":
                 case 2:
-                    message.enumRepeated[i] = 2;
+                    message.enumRepeated[message.enumRepeated.length] = 2;
                     break;
+                default:
+                    if (typeof object.enumRepeated[i] === "number" && (object.enumRepeated[i] | 0) === object.enumRepeated[i])
+                        message.enumRepeated[message.enumRepeated.length] = object.enumRepeated[i];
                 }
         }
         if (object.int64Map) {

--- a/tests/data/enum-semantics.d.ts
+++ b/tests/data/enum-semantics.d.ts
@@ -1,0 +1,113 @@
+import * as $protobuf from "../..";
+import Long = require("long");
+
+export interface IOpenMessage extends OpenMessage.$Properties {
+}
+
+export class OpenMessage {
+    constructor(properties?: OpenMessage.$Properties);
+    $unknowns?: Uint8Array[];
+    singular: OpenMessage.OpenEnum;
+    repeated: OpenMessage.OpenEnum[];
+    packed: OpenMessage.OpenEnum[];
+    values: { [k: string]: OpenMessage.OpenEnum };
+    static create(properties: OpenMessage.$Shape): OpenMessage & OpenMessage.$Shape;
+    static create(properties?: OpenMessage.$Properties): OpenMessage;
+    static encode(message: OpenMessage.$Properties, writer?: $protobuf.Writer): $protobuf.Writer;
+    static encodeDelimited(message: OpenMessage.$Properties, writer?: $protobuf.Writer): $protobuf.Writer;
+    static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): OpenMessage & OpenMessage.$Shape;
+    static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): OpenMessage & OpenMessage.$Shape;
+    static verify(message: { [k: string]: any }): (string|null);
+    static fromObject(object: { [k: string]: any }): OpenMessage;
+    static toObject(message: OpenMessage, options?: $protobuf.IConversionOptions): { [k: string]: any };
+    toJSON(): { [k: string]: any };
+    static getTypeUrl(prefix?: string): string;
+}
+
+export namespace OpenMessage {
+    interface $Properties {
+        singular?: (OpenMessage.OpenEnum|null);
+        repeated?: (OpenMessage.OpenEnum[]|null);
+        packed?: (OpenMessage.OpenEnum[]|null);
+        values?: ({ [k: string]: OpenMessage.OpenEnum }|null);
+        $unknowns?: Uint8Array[];
+    }
+    type $Shape = OpenMessage.$Properties;
+
+    enum OpenEnum {
+        ZERO = 0,
+        ONE = 1
+    }
+}
+
+export interface IClosedMessage extends ClosedMessage.$Properties {
+}
+
+export class ClosedMessage {
+    constructor(properties?: ClosedMessage.$Properties);
+    $unknowns?: Uint8Array[];
+    singular: ClosedMessage.ClosedEnum;
+    repeated: ClosedMessage.ClosedEnum[];
+    packed: ClosedMessage.ClosedEnum[];
+    values: { [k: string]: ClosedMessage.ClosedEnum };
+    static create(properties: ClosedMessage.$Shape): ClosedMessage & ClosedMessage.$Shape;
+    static create(properties?: ClosedMessage.$Properties): ClosedMessage;
+    static encode(message: ClosedMessage.$Properties, writer?: $protobuf.Writer): $protobuf.Writer;
+    static encodeDelimited(message: ClosedMessage.$Properties, writer?: $protobuf.Writer): $protobuf.Writer;
+    static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): ClosedMessage & ClosedMessage.$Shape;
+    static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): ClosedMessage & ClosedMessage.$Shape;
+    static verify(message: { [k: string]: any }): (string|null);
+    static fromObject(object: { [k: string]: any }): ClosedMessage;
+    static toObject(message: ClosedMessage, options?: $protobuf.IConversionOptions): { [k: string]: any };
+    toJSON(): { [k: string]: any };
+    static getTypeUrl(prefix?: string): string;
+}
+
+export namespace ClosedMessage {
+    interface $Properties {
+        singular?: (ClosedMessage.ClosedEnum|null);
+        repeated?: (ClosedMessage.ClosedEnum[]|null);
+        packed?: (ClosedMessage.ClosedEnum[]|null);
+        values?: ({ [k: string]: ClosedMessage.ClosedEnum }|null);
+        $unknowns?: Uint8Array[];
+    }
+    type $Shape = ClosedMessage.$Properties;
+
+    enum ClosedEnum {
+        ZERO = 0,
+        ONE = 1
+    }
+}
+
+export interface IClosedImplicitMessage extends ClosedImplicitMessage.$Properties {
+}
+
+export class ClosedImplicitMessage {
+    constructor(properties?: ClosedImplicitMessage.$Properties);
+    $unknowns?: Uint8Array[];
+    singular: ClosedImplicitMessage.ClosedEnum;
+    static create(properties: ClosedImplicitMessage.$Shape): ClosedImplicitMessage & ClosedImplicitMessage.$Shape;
+    static create(properties?: ClosedImplicitMessage.$Properties): ClosedImplicitMessage;
+    static encode(message: ClosedImplicitMessage.$Properties, writer?: $protobuf.Writer): $protobuf.Writer;
+    static encodeDelimited(message: ClosedImplicitMessage.$Properties, writer?: $protobuf.Writer): $protobuf.Writer;
+    static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): ClosedImplicitMessage & ClosedImplicitMessage.$Shape;
+    static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): ClosedImplicitMessage & ClosedImplicitMessage.$Shape;
+    static verify(message: { [k: string]: any }): (string|null);
+    static fromObject(object: { [k: string]: any }): ClosedImplicitMessage;
+    static toObject(message: ClosedImplicitMessage, options?: $protobuf.IConversionOptions): { [k: string]: any };
+    toJSON(): { [k: string]: any };
+    static getTypeUrl(prefix?: string): string;
+}
+
+export namespace ClosedImplicitMessage {
+    interface $Properties {
+        singular?: (ClosedImplicitMessage.ClosedEnum|null);
+        $unknowns?: Uint8Array[];
+    }
+    type $Shape = ClosedImplicitMessage.$Properties;
+
+    enum ClosedEnum {
+        ZERO = 0,
+        ONE = 1
+    }
+}

--- a/tests/data/enum-semantics.js
+++ b/tests/data/enum-semantics.js
@@ -1124,7 +1124,7 @@ $root.ClosedImplicitMessage = (function() {
             _depth = 0;
         if (_depth > $util.recursionLimit)
             throw $Error("max depth exceeded");
-        if (message.singular != null && $Object.hasOwnProperty.call(message, "singular"))
+        if (message.singular != null && $Object.hasOwnProperty.call(message, "singular") && message.singular !== 0)
             writer.uint32(/* id 1, wireType 0 =*/8).int32(message.singular);
         if (message.$unknowns != null && $Object.hasOwnProperty.call(message, "$unknowns"))
             for (var i = 0; i < message.$unknowns.length; ++i)

--- a/tests/data/enum-semantics.js
+++ b/tests/data/enum-semantics.js
@@ -1,0 +1,1344 @@
+/*eslint-disable block-scoped-var, id-length, no-control-regex, no-magic-numbers, no-mixed-operators, no-prototype-builtins, no-redeclare, no-shadow, no-var, sort-vars, default-case, jsdoc/require-param*/
+"use strict";
+
+var $protobuf = require("../../minimal");
+
+// Common aliases
+var $Reader = $protobuf.Reader, $Writer = $protobuf.Writer, $util = $protobuf.util;
+var $Object = $util.global.Object, $undefined = $util.global.undefined, $Error = $util.global.Error, $Array = $util.global.Array, $TypeError = $util.global.TypeError, $String = $util.global.String;
+
+// Exported root namespace
+var $root = $protobuf.roots["test_enum-semantics"] || ($protobuf.roots["test_enum-semantics"] = {});
+
+$root.OpenMessage = (function() {
+
+    /**
+     * Properties of an OpenMessage.
+     * @typedef {Object} OpenMessage.$Properties
+     * @property {OpenMessage.OpenEnum|null} [singular] OpenMessage singular
+     * @property {Array.<OpenMessage.OpenEnum>|null} [repeated] OpenMessage repeated
+     * @property {Array.<OpenMessage.OpenEnum>|null} [packed] OpenMessage packed
+     * @property {Object.<string,OpenMessage.OpenEnum>|null} [values] OpenMessage values
+     * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding when enabled
+     */
+
+    /**
+     * Properties of an OpenMessage.
+     * @exports IOpenMessage
+     * @interface IOpenMessage
+     * @augments OpenMessage.$Properties
+     * @deprecated Use OpenMessage.$Properties instead.
+     */
+
+    /**
+     * Shape of an OpenMessage.
+     * @typedef {OpenMessage.$Properties} OpenMessage.$Shape
+     */
+
+    /**
+     * Constructs a new OpenMessage.
+     * @exports OpenMessage
+     * @classdesc Represents an OpenMessage.
+     * @constructor
+     * @param {OpenMessage.$Properties=} [properties] Properties to set
+     * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding when enabled
+     */
+    var OpenMessage = function (properties) {
+        this.repeated = [];
+        this.packed = [];
+        this.values = {};
+        if (properties)
+            for (var keys = $Object.keys(properties), i = 0; i < keys.length; ++i)
+                if (properties[keys[i]] != null && keys[i] !== "__proto__")
+                    this[keys[i]] = properties[keys[i]];
+    };
+
+    /**
+     * OpenMessage singular.
+     * @member {OpenMessage.OpenEnum} singular
+     * @memberof OpenMessage
+     * @instance
+     */
+    OpenMessage.prototype.singular = 0;
+
+    /**
+     * OpenMessage repeated.
+     * @member {Array.<OpenMessage.OpenEnum>} repeated
+     * @memberof OpenMessage
+     * @instance
+     */
+    OpenMessage.prototype.repeated = $util.emptyArray;
+
+    /**
+     * OpenMessage packed.
+     * @member {Array.<OpenMessage.OpenEnum>} packed
+     * @memberof OpenMessage
+     * @instance
+     */
+    OpenMessage.prototype.packed = $util.emptyArray;
+
+    /**
+     * OpenMessage values.
+     * @member {Object.<string,OpenMessage.OpenEnum>} values
+     * @memberof OpenMessage
+     * @instance
+     */
+    OpenMessage.prototype.values = $util.emptyObject;
+
+    /**
+     * Creates a new OpenMessage instance using the specified properties.
+     * @function create
+     * @memberof OpenMessage
+     * @static
+     * @param {OpenMessage.$Properties=} [properties] Properties to set
+     * @returns {OpenMessage} OpenMessage instance
+     * @type {{
+     *   (properties: OpenMessage.$Shape): OpenMessage & OpenMessage.$Shape;
+     *   (properties?: OpenMessage.$Properties): OpenMessage;
+     * }}
+     */
+    OpenMessage.create = function(properties) {
+        return new OpenMessage(properties);
+    };
+
+    /**
+     * Encodes the specified OpenMessage message. Does not implicitly {@link OpenMessage.verify|verify} messages.
+     * @function encode
+     * @memberof OpenMessage
+     * @static
+     * @param {OpenMessage.$Properties} message OpenMessage message or plain object to encode
+     * @param {$protobuf.Writer} [writer] Writer to encode to
+     * @returns {$protobuf.Writer} Writer
+     */
+    OpenMessage.encode = function (message, writer, _depth) {
+        if (!writer)
+            writer = $Writer.create();
+        if (_depth === $undefined)
+            _depth = 0;
+        if (_depth > $util.recursionLimit)
+            throw $Error("max depth exceeded");
+        if (message.singular != null && $Object.hasOwnProperty.call(message, "singular"))
+            writer.uint32(/* id 1, wireType 0 =*/8).int32(message.singular);
+        if (message.repeated != null && message.repeated.length)
+            for (var i = 0; i < message.repeated.length; ++i)
+                writer.uint32(/* id 2, wireType 0 =*/16).int32(message.repeated[i]);
+        if (message.packed != null && message.packed.length) {
+            writer.uint32(/* id 3, wireType 2 =*/26).fork();
+            for (var i = 0; i < message.packed.length; ++i)
+                writer.int32(message.packed[i]);
+            writer.ldelim();
+        }
+        if (message.values != null && $Object.hasOwnProperty.call(message, "values"))
+            for (var keys = $Object.keys(message.values), i = 0; i < keys.length; ++i)
+                writer.uint32(/* id 4, wireType 2 =*/34).fork().uint32(/* id 1, wireType 2 =*/10).string(keys[i]).uint32(/* id 2, wireType 0 =*/16).int32(message.values[keys[i]]).ldelim();
+        if (message.$unknowns != null && $Object.hasOwnProperty.call(message, "$unknowns"))
+            for (var i = 0; i < message.$unknowns.length; ++i)
+                writer.raw(message.$unknowns[i]);
+        return writer;
+    };
+
+    /**
+     * Encodes the specified OpenMessage message, length delimited. Does not implicitly {@link OpenMessage.verify|verify} messages.
+     * @function encodeDelimited
+     * @memberof OpenMessage
+     * @static
+     * @param {OpenMessage.$Properties} message OpenMessage message or plain object to encode
+     * @param {$protobuf.Writer} [writer] Writer to encode to
+     * @returns {$protobuf.Writer} Writer
+     */
+    OpenMessage.encodeDelimited = function(message, writer) {
+        return this.encode(message, writer && writer.len ? writer.fork() : writer).ldelim();
+    };
+
+    /**
+     * Decodes an OpenMessage message from the specified reader or buffer.
+     * @function decode
+     * @memberof OpenMessage
+     * @static
+     * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+     * @param {number} [length] Message length if known beforehand
+     * @returns {OpenMessage & OpenMessage.$Shape} OpenMessage
+     * @throws {Error} If the payload is not a reader or valid buffer
+     * @throws {$protobuf.util.ProtocolError} If required fields are missing
+     */
+    OpenMessage.decode = function (reader, length, _end, _depth, _target) {
+        if (!(reader instanceof $Reader))
+            reader = $Reader.create(reader);
+        if (_depth === $undefined)
+            _depth = 0;
+        if (_depth > $Reader.recursionLimit)
+            throw $Error("max depth exceeded");
+        var end = length === $undefined ? reader.len : reader.pos + length, message = _target || new $root.OpenMessage(), key, value;
+        while (reader.pos < end) {
+            var start = reader.pos;
+            var tag = reader.tag();
+            if (tag === _end) {
+                _end = $undefined;
+                break;
+            }
+            var wireType = tag & 7;
+            switch (tag >>>= 3) {
+            case 1: {
+                    if (wireType !== 0)
+                        break;
+                    message.singular = reader.int32();
+                    continue;
+                }
+            case 2: {
+                    if (wireType === 2) {
+                        if (!(message.repeated && message.repeated.length))
+                            message.repeated = [];
+                        var end2 = reader.uint32() + reader.pos;
+                        while (reader.pos < end2)
+                            message.repeated.push(reader.int32());
+                        continue;
+                    }
+                    if (wireType !== 0)
+                        break;
+                    if (!(message.repeated && message.repeated.length))
+                        message.repeated = [];
+                    message.repeated.push(reader.int32());
+                    continue;
+                }
+            case 3: {
+                    if (wireType === 2) {
+                        if (!(message.packed && message.packed.length))
+                            message.packed = [];
+                        var end2 = reader.uint32() + reader.pos;
+                        while (reader.pos < end2)
+                            message.packed.push(reader.int32());
+                        continue;
+                    }
+                    if (wireType !== 0)
+                        break;
+                    if (!(message.packed && message.packed.length))
+                        message.packed = [];
+                    message.packed.push(reader.int32());
+                    continue;
+                }
+            case 4: {
+                    if (wireType !== 2)
+                        break;
+                    if (message.values === $util.emptyObject)
+                        message.values = {};
+                    var end2 = reader.uint32() + reader.pos;
+                    key = "";
+                    value = 0;
+                    while (reader.pos < end2) {
+                        var tag2 = reader.tag();
+                        wireType = tag2 & 7;
+                        switch (tag2 >>>= 3) {
+                        case 1:
+                            if (wireType !== 2)
+                                break;
+                            key = reader.stringVerify();
+                            continue;
+                        case 2:
+                            if (wireType !== 0)
+                                break;
+                            value = reader.int32();
+                            continue;
+                        }
+                        reader.skipType(wireType, _depth, tag2);
+                    }
+                    if (key === "__proto__")
+                        $util.makeProp(message.values, key);
+                    message.values[key] = value;
+                    continue;
+                }
+            }
+            reader.skipType(wireType, _depth, tag);
+            if (!reader.discardUnknown) {
+                $util.makeProp(message, "$unknowns", false);
+                (message.$unknowns || (message.$unknowns = [])).push(reader.raw(start, reader.pos));
+            }
+        }
+        if (_end !== $undefined)
+            throw $Error("missing end group");
+        return message;
+    };
+
+    /**
+     * Decodes an OpenMessage message from the specified reader or buffer, length delimited.
+     * @function decodeDelimited
+     * @memberof OpenMessage
+     * @static
+     * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+     * @returns {OpenMessage & OpenMessage.$Shape} OpenMessage
+     * @throws {Error} If the payload is not a reader or valid buffer
+     * @throws {$protobuf.util.ProtocolError} If required fields are missing
+     */
+    OpenMessage.decodeDelimited = function(reader) {
+        if (!(reader instanceof $Reader))
+            reader = new $Reader(reader);
+        return this.decode(reader, reader.uint32());
+    };
+
+    /**
+     * Verifies an OpenMessage message.
+     * @function verify
+     * @memberof OpenMessage
+     * @static
+     * @param {Object.<string,*>} message Plain object to verify
+     * @returns {string|null} `null` if valid, otherwise the reason why it is not
+     */
+    OpenMessage.verify = function (message, _depth) {
+        if (typeof message !== "object" || message === null)
+            return "object expected";
+        if (_depth === $undefined)
+            _depth = 0;
+        if (_depth > $util.recursionLimit)
+            return "max depth exceeded";
+        if (message.singular != null && $Object.hasOwnProperty.call(message, "singular"))
+            if (typeof message.singular !== "number" || (message.singular | 0) !== message.singular)
+                return "singular: enum value expected";
+        if (message.repeated != null && $Object.hasOwnProperty.call(message, "repeated")) {
+            if (!$Array.isArray(message.repeated))
+                return "repeated: array expected";
+            for (var i = 0; i < message.repeated.length; ++i)
+                if (typeof message.repeated[i] !== "number" || (message.repeated[i] | 0) !== message.repeated[i])
+                    return "repeated: enum value[] expected";
+        }
+        if (message.packed != null && $Object.hasOwnProperty.call(message, "packed")) {
+            if (!$Array.isArray(message.packed))
+                return "packed: array expected";
+            for (var i = 0; i < message.packed.length; ++i)
+                if (typeof message.packed[i] !== "number" || (message.packed[i] | 0) !== message.packed[i])
+                    return "packed: enum value[] expected";
+        }
+        if (message.values != null && $Object.hasOwnProperty.call(message, "values")) {
+            if (!$util.isObject(message.values))
+                return "values: object expected";
+            var key = $Object.keys(message.values);
+            for (var i = 0; i < key.length; ++i)
+                if (typeof message.values[key[i]] !== "number" || (message.values[key[i]] | 0) !== message.values[key[i]])
+                    return "values: enum value{k:string} expected";
+        }
+        return null;
+    };
+
+    /**
+     * Creates an OpenMessage message from a plain object. Also converts values to their respective internal types.
+     * @function fromObject
+     * @memberof OpenMessage
+     * @static
+     * @param {Object.<string,*>} object Plain object
+     * @returns {OpenMessage} OpenMessage
+     */
+    OpenMessage.fromObject = function (object, _depth) {
+        if (object instanceof $root.OpenMessage)
+            return object;
+        if (!$util.isObject(object))
+            throw $TypeError(".OpenMessage: object expected");
+        if (_depth === $undefined)
+            _depth = 0;
+        if (_depth > $util.recursionLimit)
+            throw $Error("max depth exceeded");
+        var message = new $root.OpenMessage();
+        switch (object.singular) {
+        case "ZERO":
+        case 0:
+            message.singular = 0;
+            break;
+        case "ONE":
+        case 1:
+            message.singular = 1;
+            break;
+        default:
+            if (typeof object.singular === "number" && (object.singular | 0) === object.singular)
+                message.singular = object.singular;
+        }
+        if (object.repeated) {
+            if (!$Array.isArray(object.repeated))
+                throw $TypeError(".OpenMessage.repeated: array expected");
+            message.repeated = [];
+            for (var i = 0; i < object.repeated.length; ++i)
+                switch (object.repeated[i]) {
+                case "ZERO":
+                case 0:
+                    message.repeated[message.repeated.length] = 0;
+                    break;
+                case "ONE":
+                case 1:
+                    message.repeated[message.repeated.length] = 1;
+                    break;
+                default:
+                    if (typeof object.repeated[i] === "number" && (object.repeated[i] | 0) === object.repeated[i])
+                        message.repeated[message.repeated.length] = object.repeated[i];
+                }
+        }
+        if (object.packed) {
+            if (!$Array.isArray(object.packed))
+                throw $TypeError(".OpenMessage.packed: array expected");
+            message.packed = [];
+            for (var i = 0; i < object.packed.length; ++i)
+                switch (object.packed[i]) {
+                case "ZERO":
+                case 0:
+                    message.packed[message.packed.length] = 0;
+                    break;
+                case "ONE":
+                case 1:
+                    message.packed[message.packed.length] = 1;
+                    break;
+                default:
+                    if (typeof object.packed[i] === "number" && (object.packed[i] | 0) === object.packed[i])
+                        message.packed[message.packed.length] = object.packed[i];
+                }
+        }
+        if (object.values) {
+            if (!$util.isObject(object.values))
+                throw $TypeError(".OpenMessage.values: object expected");
+            message.values = {};
+            for (var keys = $Object.keys(object.values), i = 0; i < keys.length; ++i) {
+                if (keys[i] === "__proto__")
+                    $util.makeProp(message.values, keys[i]);
+                switch (object.values[keys[i]]) {
+                case "ZERO":
+                case 0:
+                    message.values[keys[i]] = 0;
+                    break;
+                case "ONE":
+                case 1:
+                    message.values[keys[i]] = 1;
+                    break;
+                default:
+                    if (typeof object.values[keys[i]] === "number" && (object.values[keys[i]] | 0) === object.values[keys[i]])
+                        message.values[keys[i]] = object.values[keys[i]];
+                }
+            }
+        }
+        return message;
+    };
+
+    /**
+     * Creates a plain object from an OpenMessage message. Also converts values to other types if specified.
+     * @function toObject
+     * @memberof OpenMessage
+     * @static
+     * @param {OpenMessage} message OpenMessage
+     * @param {$protobuf.IConversionOptions} [options] Conversion options
+     * @returns {Object.<string,*>} Plain object
+     */
+    OpenMessage.toObject = function (message, options, _depth) {
+        if (!options)
+            options = {};
+        if (_depth === $undefined)
+            _depth = 0;
+        if (_depth > $util.recursionLimit)
+            throw $Error("max depth exceeded");
+        var object = {};
+        if (options.arrays || options.defaults) {
+            object.repeated = [];
+            object.packed = [];
+        }
+        if (options.objects || options.defaults)
+            object.values = {};
+        if (options.defaults)
+            object.singular = options.enums === $String ? "ZERO" : 0;
+        if (message.singular != null && $Object.hasOwnProperty.call(message, "singular"))
+            object.singular = options.enums === $String ? $root.OpenMessage.OpenEnum[message.singular] === $undefined ? message.singular : $root.OpenMessage.OpenEnum[message.singular] : message.singular;
+        if (message.repeated && message.repeated.length) {
+            object.repeated = $Array(message.repeated.length);
+            for (var j = 0; j < message.repeated.length; ++j)
+                object.repeated[j] = options.enums === $String ? $root.OpenMessage.OpenEnum[message.repeated[j]] === $undefined ? message.repeated[j] : $root.OpenMessage.OpenEnum[message.repeated[j]] : message.repeated[j];
+        }
+        if (message.packed && message.packed.length) {
+            object.packed = $Array(message.packed.length);
+            for (var j = 0; j < message.packed.length; ++j)
+                object.packed[j] = options.enums === $String ? $root.OpenMessage.OpenEnum[message.packed[j]] === $undefined ? message.packed[j] : $root.OpenMessage.OpenEnum[message.packed[j]] : message.packed[j];
+        }
+        var keys2;
+        if (message.values && (keys2 = $Object.keys(message.values)).length) {
+            object.values = {};
+            for (var j = 0; j < keys2.length; ++j) {
+                if (keys2[j] === "__proto__")
+                    $util.makeProp(object.values, keys2[j]);
+                object.values[keys2[j]] = options.enums === $String ? $root.OpenMessage.OpenEnum[message.values[keys2[j]]] === $undefined ? message.values[keys2[j]] : $root.OpenMessage.OpenEnum[message.values[keys2[j]]] : message.values[keys2[j]];
+            }
+        }
+        return object;
+    };
+
+    /**
+     * Converts this OpenMessage to JSON.
+     * @function toJSON
+     * @memberof OpenMessage
+     * @instance
+     * @returns {Object.<string,*>} JSON object
+     */
+    OpenMessage.prototype.toJSON = function() {
+        return OpenMessage.toObject(this, $protobuf.util.toJSONOptions);
+    };
+
+    /**
+     * Gets the type url for OpenMessage
+     * @function getTypeUrl
+     * @memberof OpenMessage
+     * @static
+     * @param {string} [prefix] Custom type url prefix, defaults to `"type.googleapis.com"`
+     * @returns {string} The type url
+     */
+    OpenMessage.getTypeUrl = function(prefix) {
+        if (prefix === $undefined)
+            prefix = "type.googleapis.com";
+        return prefix + "/OpenMessage";
+    };
+
+    /**
+     * OpenEnum enum.
+     * @name OpenMessage.OpenEnum
+     * @enum {number}
+     * @property {number} ZERO=0 ZERO value
+     * @property {number} ONE=1 ONE value
+     */
+    OpenMessage.OpenEnum = (function() {
+        var valuesById = $Object.create(null), values = $Object.create(valuesById);
+        values[valuesById[0] = "ZERO"] = 0;
+        values[valuesById[1] = "ONE"] = 1;
+        return values;
+    })();
+
+    return OpenMessage;
+})();
+
+$root.ClosedMessage = (function() {
+
+    /**
+     * Properties of a ClosedMessage.
+     * @typedef {Object} ClosedMessage.$Properties
+     * @property {ClosedMessage.ClosedEnum|null} [singular] ClosedMessage singular
+     * @property {Array.<ClosedMessage.ClosedEnum>|null} [repeated] ClosedMessage repeated
+     * @property {Array.<ClosedMessage.ClosedEnum>|null} [packed] ClosedMessage packed
+     * @property {Object.<string,ClosedMessage.ClosedEnum>|null} [values] ClosedMessage values
+     * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding when enabled
+     */
+
+    /**
+     * Properties of a ClosedMessage.
+     * @exports IClosedMessage
+     * @interface IClosedMessage
+     * @augments ClosedMessage.$Properties
+     * @deprecated Use ClosedMessage.$Properties instead.
+     */
+
+    /**
+     * Shape of a ClosedMessage.
+     * @typedef {ClosedMessage.$Properties} ClosedMessage.$Shape
+     */
+
+    /**
+     * Constructs a new ClosedMessage.
+     * @exports ClosedMessage
+     * @classdesc Represents a ClosedMessage.
+     * @constructor
+     * @param {ClosedMessage.$Properties=} [properties] Properties to set
+     * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding when enabled
+     */
+    var ClosedMessage = function (properties) {
+        this.repeated = [];
+        this.packed = [];
+        this.values = {};
+        if (properties)
+            for (var keys = $Object.keys(properties), i = 0; i < keys.length; ++i)
+                if (properties[keys[i]] != null && keys[i] !== "__proto__")
+                    this[keys[i]] = properties[keys[i]];
+    };
+
+    /**
+     * ClosedMessage singular.
+     * @member {ClosedMessage.ClosedEnum} singular
+     * @memberof ClosedMessage
+     * @instance
+     */
+    ClosedMessage.prototype.singular = 0;
+
+    /**
+     * ClosedMessage repeated.
+     * @member {Array.<ClosedMessage.ClosedEnum>} repeated
+     * @memberof ClosedMessage
+     * @instance
+     */
+    ClosedMessage.prototype.repeated = $util.emptyArray;
+
+    /**
+     * ClosedMessage packed.
+     * @member {Array.<ClosedMessage.ClosedEnum>} packed
+     * @memberof ClosedMessage
+     * @instance
+     */
+    ClosedMessage.prototype.packed = $util.emptyArray;
+
+    /**
+     * ClosedMessage values.
+     * @member {Object.<string,ClosedMessage.ClosedEnum>} values
+     * @memberof ClosedMessage
+     * @instance
+     */
+    ClosedMessage.prototype.values = $util.emptyObject;
+
+    /**
+     * Creates a new ClosedMessage instance using the specified properties.
+     * @function create
+     * @memberof ClosedMessage
+     * @static
+     * @param {ClosedMessage.$Properties=} [properties] Properties to set
+     * @returns {ClosedMessage} ClosedMessage instance
+     * @type {{
+     *   (properties: ClosedMessage.$Shape): ClosedMessage & ClosedMessage.$Shape;
+     *   (properties?: ClosedMessage.$Properties): ClosedMessage;
+     * }}
+     */
+    ClosedMessage.create = function(properties) {
+        return new ClosedMessage(properties);
+    };
+
+    /**
+     * Encodes the specified ClosedMessage message. Does not implicitly {@link ClosedMessage.verify|verify} messages.
+     * @function encode
+     * @memberof ClosedMessage
+     * @static
+     * @param {ClosedMessage.$Properties} message ClosedMessage message or plain object to encode
+     * @param {$protobuf.Writer} [writer] Writer to encode to
+     * @returns {$protobuf.Writer} Writer
+     */
+    ClosedMessage.encode = function (message, writer, _depth) {
+        if (!writer)
+            writer = $Writer.create();
+        if (_depth === $undefined)
+            _depth = 0;
+        if (_depth > $util.recursionLimit)
+            throw $Error("max depth exceeded");
+        if (message.singular != null && $Object.hasOwnProperty.call(message, "singular"))
+            writer.uint32(/* id 1, wireType 0 =*/8).int32(message.singular);
+        if (message.repeated != null && message.repeated.length)
+            for (var i = 0; i < message.repeated.length; ++i)
+                writer.uint32(/* id 2, wireType 0 =*/16).int32(message.repeated[i]);
+        if (message.packed != null && message.packed.length) {
+            writer.uint32(/* id 3, wireType 2 =*/26).fork();
+            for (var i = 0; i < message.packed.length; ++i)
+                writer.int32(message.packed[i]);
+            writer.ldelim();
+        }
+        if (message.values != null && $Object.hasOwnProperty.call(message, "values"))
+            for (var keys = $Object.keys(message.values), i = 0; i < keys.length; ++i)
+                writer.uint32(/* id 4, wireType 2 =*/34).fork().uint32(/* id 1, wireType 2 =*/10).string(keys[i]).uint32(/* id 2, wireType 0 =*/16).int32(message.values[keys[i]]).ldelim();
+        if (message.$unknowns != null && $Object.hasOwnProperty.call(message, "$unknowns"))
+            for (var i = 0; i < message.$unknowns.length; ++i)
+                writer.raw(message.$unknowns[i]);
+        return writer;
+    };
+
+    /**
+     * Encodes the specified ClosedMessage message, length delimited. Does not implicitly {@link ClosedMessage.verify|verify} messages.
+     * @function encodeDelimited
+     * @memberof ClosedMessage
+     * @static
+     * @param {ClosedMessage.$Properties} message ClosedMessage message or plain object to encode
+     * @param {$protobuf.Writer} [writer] Writer to encode to
+     * @returns {$protobuf.Writer} Writer
+     */
+    ClosedMessage.encodeDelimited = function(message, writer) {
+        return this.encode(message, writer && writer.len ? writer.fork() : writer).ldelim();
+    };
+
+    /**
+     * Decodes a ClosedMessage message from the specified reader or buffer.
+     * @function decode
+     * @memberof ClosedMessage
+     * @static
+     * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+     * @param {number} [length] Message length if known beforehand
+     * @returns {ClosedMessage & ClosedMessage.$Shape} ClosedMessage
+     * @throws {Error} If the payload is not a reader or valid buffer
+     * @throws {$protobuf.util.ProtocolError} If required fields are missing
+     */
+    ClosedMessage.decode = function (reader, length, _end, _depth, _target) {
+        if (!(reader instanceof $Reader))
+            reader = $Reader.create(reader);
+        if (_depth === $undefined)
+            _depth = 0;
+        if (_depth > $Reader.recursionLimit)
+            throw $Error("max depth exceeded");
+        var end = length === $undefined ? reader.len : reader.pos + length, message = _target || new $root.ClosedMessage(), key, value;
+        while (reader.pos < end) {
+            var start = reader.pos;
+            var tag = reader.tag();
+            if (tag === _end) {
+                _end = $undefined;
+                break;
+            }
+            var wireType = tag & 7;
+            switch (tag >>>= 3) {
+            case 1: {
+                    if (wireType !== 0)
+                        break;
+                    value = reader.int32();
+                    if ($root.ClosedMessage.ClosedEnum[value] !== $undefined)
+                        message.singular = value;
+                    else if (!reader.discardUnknown) {
+                        $util.makeProp(message, "$unknowns", false);
+                        (message.$unknowns || (message.$unknowns = [])).push(reader.raw(start, reader.pos));
+                    }
+                    continue;
+                }
+            case 2: {
+                    if (wireType === 2) {
+                        var end2 = reader.uint32() + reader.pos;
+                        while (reader.pos < end2) {
+                            start = reader.pos;
+                            value = reader.int32();
+                            if ($root.ClosedMessage.ClosedEnum[value] !== $undefined) {
+                                if (!(message.repeated && message.repeated.length))
+                                    message.repeated = [];
+                                message.repeated.push(value);
+                            } else if (!reader.discardUnknown) {
+                                $util.makeProp(message, "$unknowns", false);
+                                (message.$unknowns || (message.$unknowns = [])).push($util.rawField(2, 0, reader.raw(start, reader.pos)));
+                            }
+                        }
+                        continue;
+                    }
+                    if (wireType !== 0)
+                        break;
+                    value = reader.int32();
+                    if ($root.ClosedMessage.ClosedEnum[value] !== $undefined) {
+                        if (!(message.repeated && message.repeated.length))
+                            message.repeated = [];
+                        message.repeated.push(value);
+                    } else if (!reader.discardUnknown) {
+                        $util.makeProp(message, "$unknowns", false);
+                        (message.$unknowns || (message.$unknowns = [])).push(reader.raw(start, reader.pos));
+                    }
+                    continue;
+                }
+            case 3: {
+                    if (wireType === 2) {
+                        var end2 = reader.uint32() + reader.pos;
+                        while (reader.pos < end2) {
+                            start = reader.pos;
+                            value = reader.int32();
+                            if ($root.ClosedMessage.ClosedEnum[value] !== $undefined) {
+                                if (!(message.packed && message.packed.length))
+                                    message.packed = [];
+                                message.packed.push(value);
+                            } else if (!reader.discardUnknown) {
+                                $util.makeProp(message, "$unknowns", false);
+                                (message.$unknowns || (message.$unknowns = [])).push($util.rawField(3, 0, reader.raw(start, reader.pos)));
+                            }
+                        }
+                        continue;
+                    }
+                    if (wireType !== 0)
+                        break;
+                    value = reader.int32();
+                    if ($root.ClosedMessage.ClosedEnum[value] !== $undefined) {
+                        if (!(message.packed && message.packed.length))
+                            message.packed = [];
+                        message.packed.push(value);
+                    } else if (!reader.discardUnknown) {
+                        $util.makeProp(message, "$unknowns", false);
+                        (message.$unknowns || (message.$unknowns = [])).push(reader.raw(start, reader.pos));
+                    }
+                    continue;
+                }
+            case 4: {
+                    if (wireType !== 2)
+                        break;
+                    var end2 = reader.uint32() + reader.pos;
+                    key = "";
+                    value = 0;
+                    while (reader.pos < end2) {
+                        var tag2 = reader.tag();
+                        wireType = tag2 & 7;
+                        switch (tag2 >>>= 3) {
+                        case 1:
+                            if (wireType !== 2)
+                                break;
+                            key = reader.stringVerify();
+                            continue;
+                        case 2:
+                            if (wireType !== 0)
+                                break;
+                            value = reader.int32();
+                            continue;
+                        }
+                        reader.skipType(wireType, _depth, tag2);
+                    }
+                    if ($root.ClosedMessage.ClosedEnum[value] === $undefined) {
+                        if (!reader.discardUnknown) {
+                            $util.makeProp(message, "$unknowns", false);
+                            (message.$unknowns || (message.$unknowns = [])).push(reader.raw(start, reader.pos));
+                        }
+                        continue;
+                    }
+                    if (message.values === $util.emptyObject)
+                        message.values = {};
+                    if (key === "__proto__")
+                        $util.makeProp(message.values, key);
+                    message.values[key] = value;
+                    continue;
+                }
+            }
+            reader.skipType(wireType, _depth, tag);
+            if (!reader.discardUnknown) {
+                $util.makeProp(message, "$unknowns", false);
+                (message.$unknowns || (message.$unknowns = [])).push(reader.raw(start, reader.pos));
+            }
+        }
+        if (_end !== $undefined)
+            throw $Error("missing end group");
+        return message;
+    };
+
+    /**
+     * Decodes a ClosedMessage message from the specified reader or buffer, length delimited.
+     * @function decodeDelimited
+     * @memberof ClosedMessage
+     * @static
+     * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+     * @returns {ClosedMessage & ClosedMessage.$Shape} ClosedMessage
+     * @throws {Error} If the payload is not a reader or valid buffer
+     * @throws {$protobuf.util.ProtocolError} If required fields are missing
+     */
+    ClosedMessage.decodeDelimited = function(reader) {
+        if (!(reader instanceof $Reader))
+            reader = new $Reader(reader);
+        return this.decode(reader, reader.uint32());
+    };
+
+    /**
+     * Verifies a ClosedMessage message.
+     * @function verify
+     * @memberof ClosedMessage
+     * @static
+     * @param {Object.<string,*>} message Plain object to verify
+     * @returns {string|null} `null` if valid, otherwise the reason why it is not
+     */
+    ClosedMessage.verify = function (message, _depth) {
+        if (typeof message !== "object" || message === null)
+            return "object expected";
+        if (_depth === $undefined)
+            _depth = 0;
+        if (_depth > $util.recursionLimit)
+            return "max depth exceeded";
+        if (message.singular != null && $Object.hasOwnProperty.call(message, "singular"))
+            switch (message.singular) {
+            default:
+                return "singular: enum value expected";
+            case 0:
+            case 1:
+                break;
+            }
+        if (message.repeated != null && $Object.hasOwnProperty.call(message, "repeated")) {
+            if (!$Array.isArray(message.repeated))
+                return "repeated: array expected";
+            for (var i = 0; i < message.repeated.length; ++i)
+                switch (message.repeated[i]) {
+                default:
+                    return "repeated: enum value[] expected";
+                case 0:
+                case 1:
+                    break;
+                }
+        }
+        if (message.packed != null && $Object.hasOwnProperty.call(message, "packed")) {
+            if (!$Array.isArray(message.packed))
+                return "packed: array expected";
+            for (var i = 0; i < message.packed.length; ++i)
+                switch (message.packed[i]) {
+                default:
+                    return "packed: enum value[] expected";
+                case 0:
+                case 1:
+                    break;
+                }
+        }
+        if (message.values != null && $Object.hasOwnProperty.call(message, "values")) {
+            if (!$util.isObject(message.values))
+                return "values: object expected";
+            var key = $Object.keys(message.values);
+            for (var i = 0; i < key.length; ++i)
+                switch (message.values[key[i]]) {
+                default:
+                    return "values: enum value{k:string} expected";
+                case 0:
+                case 1:
+                    break;
+                }
+        }
+        return null;
+    };
+
+    /**
+     * Creates a ClosedMessage message from a plain object. Also converts values to their respective internal types.
+     * @function fromObject
+     * @memberof ClosedMessage
+     * @static
+     * @param {Object.<string,*>} object Plain object
+     * @returns {ClosedMessage} ClosedMessage
+     */
+    ClosedMessage.fromObject = function (object, _depth) {
+        if (object instanceof $root.ClosedMessage)
+            return object;
+        if (!$util.isObject(object))
+            throw $TypeError(".ClosedMessage: object expected");
+        if (_depth === $undefined)
+            _depth = 0;
+        if (_depth > $util.recursionLimit)
+            throw $Error("max depth exceeded");
+        var message = new $root.ClosedMessage();
+        switch (object.singular) {
+        case "ZERO":
+        case 0:
+            message.singular = 0;
+            break;
+        case "ONE":
+        case 1:
+            message.singular = 1;
+            break;
+        default:
+        }
+        if (object.repeated) {
+            if (!$Array.isArray(object.repeated))
+                throw $TypeError(".ClosedMessage.repeated: array expected");
+            message.repeated = [];
+            for (var i = 0; i < object.repeated.length; ++i)
+                switch (object.repeated[i]) {
+                case "ZERO":
+                case 0:
+                    message.repeated[message.repeated.length] = 0;
+                    break;
+                case "ONE":
+                case 1:
+                    message.repeated[message.repeated.length] = 1;
+                    break;
+                default:
+                }
+        }
+        if (object.packed) {
+            if (!$Array.isArray(object.packed))
+                throw $TypeError(".ClosedMessage.packed: array expected");
+            message.packed = [];
+            for (var i = 0; i < object.packed.length; ++i)
+                switch (object.packed[i]) {
+                case "ZERO":
+                case 0:
+                    message.packed[message.packed.length] = 0;
+                    break;
+                case "ONE":
+                case 1:
+                    message.packed[message.packed.length] = 1;
+                    break;
+                default:
+                }
+        }
+        if (object.values) {
+            if (!$util.isObject(object.values))
+                throw $TypeError(".ClosedMessage.values: object expected");
+            message.values = {};
+            for (var keys = $Object.keys(object.values), i = 0; i < keys.length; ++i) {
+                if (keys[i] === "__proto__")
+                    $util.makeProp(message.values, keys[i]);
+                switch (object.values[keys[i]]) {
+                case "ZERO":
+                case 0:
+                    message.values[keys[i]] = 0;
+                    break;
+                case "ONE":
+                case 1:
+                    message.values[keys[i]] = 1;
+                    break;
+                default:
+                }
+            }
+        }
+        return message;
+    };
+
+    /**
+     * Creates a plain object from a ClosedMessage message. Also converts values to other types if specified.
+     * @function toObject
+     * @memberof ClosedMessage
+     * @static
+     * @param {ClosedMessage} message ClosedMessage
+     * @param {$protobuf.IConversionOptions} [options] Conversion options
+     * @returns {Object.<string,*>} Plain object
+     */
+    ClosedMessage.toObject = function (message, options, _depth) {
+        if (!options)
+            options = {};
+        if (_depth === $undefined)
+            _depth = 0;
+        if (_depth > $util.recursionLimit)
+            throw $Error("max depth exceeded");
+        var object = {};
+        if (options.arrays || options.defaults) {
+            object.repeated = [];
+            object.packed = [];
+        }
+        if (options.objects || options.defaults)
+            object.values = {};
+        if (options.defaults)
+            object.singular = options.enums === $String ? "ZERO" : 0;
+        if (message.singular != null && $Object.hasOwnProperty.call(message, "singular"))
+            object.singular = options.enums === $String ? $root.ClosedMessage.ClosedEnum[message.singular] === $undefined ? message.singular : $root.ClosedMessage.ClosedEnum[message.singular] : message.singular;
+        if (message.repeated && message.repeated.length) {
+            object.repeated = $Array(message.repeated.length);
+            for (var j = 0; j < message.repeated.length; ++j)
+                object.repeated[j] = options.enums === $String ? $root.ClosedMessage.ClosedEnum[message.repeated[j]] === $undefined ? message.repeated[j] : $root.ClosedMessage.ClosedEnum[message.repeated[j]] : message.repeated[j];
+        }
+        if (message.packed && message.packed.length) {
+            object.packed = $Array(message.packed.length);
+            for (var j = 0; j < message.packed.length; ++j)
+                object.packed[j] = options.enums === $String ? $root.ClosedMessage.ClosedEnum[message.packed[j]] === $undefined ? message.packed[j] : $root.ClosedMessage.ClosedEnum[message.packed[j]] : message.packed[j];
+        }
+        var keys2;
+        if (message.values && (keys2 = $Object.keys(message.values)).length) {
+            object.values = {};
+            for (var j = 0; j < keys2.length; ++j) {
+                if (keys2[j] === "__proto__")
+                    $util.makeProp(object.values, keys2[j]);
+                object.values[keys2[j]] = options.enums === $String ? $root.ClosedMessage.ClosedEnum[message.values[keys2[j]]] === $undefined ? message.values[keys2[j]] : $root.ClosedMessage.ClosedEnum[message.values[keys2[j]]] : message.values[keys2[j]];
+            }
+        }
+        return object;
+    };
+
+    /**
+     * Converts this ClosedMessage to JSON.
+     * @function toJSON
+     * @memberof ClosedMessage
+     * @instance
+     * @returns {Object.<string,*>} JSON object
+     */
+    ClosedMessage.prototype.toJSON = function() {
+        return ClosedMessage.toObject(this, $protobuf.util.toJSONOptions);
+    };
+
+    /**
+     * Gets the type url for ClosedMessage
+     * @function getTypeUrl
+     * @memberof ClosedMessage
+     * @static
+     * @param {string} [prefix] Custom type url prefix, defaults to `"type.googleapis.com"`
+     * @returns {string} The type url
+     */
+    ClosedMessage.getTypeUrl = function(prefix) {
+        if (prefix === $undefined)
+            prefix = "type.googleapis.com";
+        return prefix + "/ClosedMessage";
+    };
+
+    /**
+     * ClosedEnum enum.
+     * @name ClosedMessage.ClosedEnum
+     * @enum {number}
+     * @property {number} ZERO=0 ZERO value
+     * @property {number} ONE=1 ONE value
+     */
+    ClosedMessage.ClosedEnum = (function() {
+        var valuesById = $Object.create(null), values = $Object.create(valuesById);
+        values[valuesById[0] = "ZERO"] = 0;
+        values[valuesById[1] = "ONE"] = 1;
+        return values;
+    })();
+
+    return ClosedMessage;
+})();
+
+$root.ClosedImplicitMessage = (function() {
+
+    /**
+     * Properties of a ClosedImplicitMessage.
+     * @typedef {Object} ClosedImplicitMessage.$Properties
+     * @property {ClosedImplicitMessage.ClosedEnum|null} [singular] ClosedImplicitMessage singular
+     * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding when enabled
+     */
+
+    /**
+     * Properties of a ClosedImplicitMessage.
+     * @exports IClosedImplicitMessage
+     * @interface IClosedImplicitMessage
+     * @augments ClosedImplicitMessage.$Properties
+     * @deprecated Use ClosedImplicitMessage.$Properties instead.
+     */
+
+    /**
+     * Shape of a ClosedImplicitMessage.
+     * @typedef {ClosedImplicitMessage.$Properties} ClosedImplicitMessage.$Shape
+     */
+
+    /**
+     * Constructs a new ClosedImplicitMessage.
+     * @exports ClosedImplicitMessage
+     * @classdesc Represents a ClosedImplicitMessage.
+     * @constructor
+     * @param {ClosedImplicitMessage.$Properties=} [properties] Properties to set
+     * @property {Array.<Uint8Array>} [$unknowns] Unknown fields preserved while decoding when enabled
+     */
+    var ClosedImplicitMessage = function (properties) {
+        if (properties)
+            for (var keys = $Object.keys(properties), i = 0; i < keys.length; ++i)
+                if (properties[keys[i]] != null && keys[i] !== "__proto__")
+                    this[keys[i]] = properties[keys[i]];
+    };
+
+    /**
+     * ClosedImplicitMessage singular.
+     * @member {ClosedImplicitMessage.ClosedEnum} singular
+     * @memberof ClosedImplicitMessage
+     * @instance
+     */
+    ClosedImplicitMessage.prototype.singular = 0;
+
+    /**
+     * Creates a new ClosedImplicitMessage instance using the specified properties.
+     * @function create
+     * @memberof ClosedImplicitMessage
+     * @static
+     * @param {ClosedImplicitMessage.$Properties=} [properties] Properties to set
+     * @returns {ClosedImplicitMessage} ClosedImplicitMessage instance
+     * @type {{
+     *   (properties: ClosedImplicitMessage.$Shape): ClosedImplicitMessage & ClosedImplicitMessage.$Shape;
+     *   (properties?: ClosedImplicitMessage.$Properties): ClosedImplicitMessage;
+     * }}
+     */
+    ClosedImplicitMessage.create = function(properties) {
+        return new ClosedImplicitMessage(properties);
+    };
+
+    /**
+     * Encodes the specified ClosedImplicitMessage message. Does not implicitly {@link ClosedImplicitMessage.verify|verify} messages.
+     * @function encode
+     * @memberof ClosedImplicitMessage
+     * @static
+     * @param {ClosedImplicitMessage.$Properties} message ClosedImplicitMessage message or plain object to encode
+     * @param {$protobuf.Writer} [writer] Writer to encode to
+     * @returns {$protobuf.Writer} Writer
+     */
+    ClosedImplicitMessage.encode = function (message, writer, _depth) {
+        if (!writer)
+            writer = $Writer.create();
+        if (_depth === $undefined)
+            _depth = 0;
+        if (_depth > $util.recursionLimit)
+            throw $Error("max depth exceeded");
+        if (message.singular != null && $Object.hasOwnProperty.call(message, "singular"))
+            writer.uint32(/* id 1, wireType 0 =*/8).int32(message.singular);
+        if (message.$unknowns != null && $Object.hasOwnProperty.call(message, "$unknowns"))
+            for (var i = 0; i < message.$unknowns.length; ++i)
+                writer.raw(message.$unknowns[i]);
+        return writer;
+    };
+
+    /**
+     * Encodes the specified ClosedImplicitMessage message, length delimited. Does not implicitly {@link ClosedImplicitMessage.verify|verify} messages.
+     * @function encodeDelimited
+     * @memberof ClosedImplicitMessage
+     * @static
+     * @param {ClosedImplicitMessage.$Properties} message ClosedImplicitMessage message or plain object to encode
+     * @param {$protobuf.Writer} [writer] Writer to encode to
+     * @returns {$protobuf.Writer} Writer
+     */
+    ClosedImplicitMessage.encodeDelimited = function(message, writer) {
+        return this.encode(message, writer && writer.len ? writer.fork() : writer).ldelim();
+    };
+
+    /**
+     * Decodes a ClosedImplicitMessage message from the specified reader or buffer.
+     * @function decode
+     * @memberof ClosedImplicitMessage
+     * @static
+     * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+     * @param {number} [length] Message length if known beforehand
+     * @returns {ClosedImplicitMessage & ClosedImplicitMessage.$Shape} ClosedImplicitMessage
+     * @throws {Error} If the payload is not a reader or valid buffer
+     * @throws {$protobuf.util.ProtocolError} If required fields are missing
+     */
+    ClosedImplicitMessage.decode = function (reader, length, _end, _depth, _target) {
+        if (!(reader instanceof $Reader))
+            reader = $Reader.create(reader);
+        if (_depth === $undefined)
+            _depth = 0;
+        if (_depth > $Reader.recursionLimit)
+            throw $Error("max depth exceeded");
+        var end = length === $undefined ? reader.len : reader.pos + length, message = _target || new $root.ClosedImplicitMessage(), value;
+        while (reader.pos < end) {
+            var start = reader.pos;
+            var tag = reader.tag();
+            if (tag === _end) {
+                _end = $undefined;
+                break;
+            }
+            var wireType = tag & 7;
+            switch (tag >>>= 3) {
+            case 1: {
+                    if (wireType !== 0)
+                        break;
+                    value = reader.int32();
+                    if ($root.ClosedImplicitMessage.ClosedEnum[value] !== $undefined)
+                        if (value !== 0)
+                            message.singular = value;
+                        else
+                            delete message.singular;
+                    else if (!reader.discardUnknown) {
+                        $util.makeProp(message, "$unknowns", false);
+                        (message.$unknowns || (message.$unknowns = [])).push(reader.raw(start, reader.pos));
+                    }
+                    continue;
+                }
+            }
+            reader.skipType(wireType, _depth, tag);
+            if (!reader.discardUnknown) {
+                $util.makeProp(message, "$unknowns", false);
+                (message.$unknowns || (message.$unknowns = [])).push(reader.raw(start, reader.pos));
+            }
+        }
+        if (_end !== $undefined)
+            throw $Error("missing end group");
+        return message;
+    };
+
+    /**
+     * Decodes a ClosedImplicitMessage message from the specified reader or buffer, length delimited.
+     * @function decodeDelimited
+     * @memberof ClosedImplicitMessage
+     * @static
+     * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+     * @returns {ClosedImplicitMessage & ClosedImplicitMessage.$Shape} ClosedImplicitMessage
+     * @throws {Error} If the payload is not a reader or valid buffer
+     * @throws {$protobuf.util.ProtocolError} If required fields are missing
+     */
+    ClosedImplicitMessage.decodeDelimited = function(reader) {
+        if (!(reader instanceof $Reader))
+            reader = new $Reader(reader);
+        return this.decode(reader, reader.uint32());
+    };
+
+    /**
+     * Verifies a ClosedImplicitMessage message.
+     * @function verify
+     * @memberof ClosedImplicitMessage
+     * @static
+     * @param {Object.<string,*>} message Plain object to verify
+     * @returns {string|null} `null` if valid, otherwise the reason why it is not
+     */
+    ClosedImplicitMessage.verify = function (message, _depth) {
+        if (typeof message !== "object" || message === null)
+            return "object expected";
+        if (_depth === $undefined)
+            _depth = 0;
+        if (_depth > $util.recursionLimit)
+            return "max depth exceeded";
+        if (message.singular != null && $Object.hasOwnProperty.call(message, "singular"))
+            switch (message.singular) {
+            default:
+                return "singular: enum value expected";
+            case 0:
+            case 1:
+                break;
+            }
+        return null;
+    };
+
+    /**
+     * Creates a ClosedImplicitMessage message from a plain object. Also converts values to their respective internal types.
+     * @function fromObject
+     * @memberof ClosedImplicitMessage
+     * @static
+     * @param {Object.<string,*>} object Plain object
+     * @returns {ClosedImplicitMessage} ClosedImplicitMessage
+     */
+    ClosedImplicitMessage.fromObject = function (object, _depth) {
+        if (object instanceof $root.ClosedImplicitMessage)
+            return object;
+        if (!$util.isObject(object))
+            throw $TypeError(".ClosedImplicitMessage: object expected");
+        if (_depth === $undefined)
+            _depth = 0;
+        if (_depth > $util.recursionLimit)
+            throw $Error("max depth exceeded");
+        var message = new $root.ClosedImplicitMessage();
+        if (object.singular !== 0 && (typeof object.singular !== "string" || $root.ClosedImplicitMessage.ClosedEnum[object.singular] !== 0))
+            switch (object.singular) {
+            case "ZERO":
+            case 0:
+                message.singular = 0;
+                break;
+            case "ONE":
+            case 1:
+                message.singular = 1;
+                break;
+            default:
+            }
+        return message;
+    };
+
+    /**
+     * Creates a plain object from a ClosedImplicitMessage message. Also converts values to other types if specified.
+     * @function toObject
+     * @memberof ClosedImplicitMessage
+     * @static
+     * @param {ClosedImplicitMessage} message ClosedImplicitMessage
+     * @param {$protobuf.IConversionOptions} [options] Conversion options
+     * @returns {Object.<string,*>} Plain object
+     */
+    ClosedImplicitMessage.toObject = function (message, options, _depth) {
+        if (!options)
+            options = {};
+        if (_depth === $undefined)
+            _depth = 0;
+        if (_depth > $util.recursionLimit)
+            throw $Error("max depth exceeded");
+        var object = {};
+        if (options.defaults)
+            object.singular = options.enums === $String ? "ZERO" : 0;
+        if (message.singular != null && $Object.hasOwnProperty.call(message, "singular"))
+            object.singular = options.enums === $String ? $root.ClosedImplicitMessage.ClosedEnum[message.singular] === $undefined ? message.singular : $root.ClosedImplicitMessage.ClosedEnum[message.singular] : message.singular;
+        return object;
+    };
+
+    /**
+     * Converts this ClosedImplicitMessage to JSON.
+     * @function toJSON
+     * @memberof ClosedImplicitMessage
+     * @instance
+     * @returns {Object.<string,*>} JSON object
+     */
+    ClosedImplicitMessage.prototype.toJSON = function() {
+        return ClosedImplicitMessage.toObject(this, $protobuf.util.toJSONOptions);
+    };
+
+    /**
+     * Gets the type url for ClosedImplicitMessage
+     * @function getTypeUrl
+     * @memberof ClosedImplicitMessage
+     * @static
+     * @param {string} [prefix] Custom type url prefix, defaults to `"type.googleapis.com"`
+     * @returns {string} The type url
+     */
+    ClosedImplicitMessage.getTypeUrl = function(prefix) {
+        if (prefix === $undefined)
+            prefix = "type.googleapis.com";
+        return prefix + "/ClosedImplicitMessage";
+    };
+
+    /**
+     * ClosedEnum enum.
+     * @name ClosedImplicitMessage.ClosedEnum
+     * @enum {number}
+     * @property {number} ZERO=0 ZERO value
+     * @property {number} ONE=1 ONE value
+     */
+    ClosedImplicitMessage.ClosedEnum = (function() {
+        var valuesById = $Object.create(null), values = $Object.create(valuesById);
+        values[valuesById[0] = "ZERO"] = 0;
+        values[valuesById[1] = "ONE"] = 1;
+        return values;
+    })();
+
+    return ClosedImplicitMessage;
+})();
+
+module.exports = $root;

--- a/tests/data/enum-semantics.proto
+++ b/tests/data/enum-semantics.proto
@@ -1,0 +1,39 @@
+edition = "2023";
+
+message OpenMessage {
+    enum OpenEnum {
+        ZERO = 0;
+        ONE = 1;
+    }
+
+    OpenEnum singular = 1;
+    repeated OpenEnum repeated = 2 [features.repeated_field_encoding = EXPANDED];
+    repeated OpenEnum packed = 3 [features.repeated_field_encoding = PACKED];
+    map<string, OpenEnum> values = 4;
+}
+
+message ClosedMessage {
+    option features.enum_type = CLOSED;
+
+    enum ClosedEnum {
+        ZERO = 0;
+        ONE = 1;
+    }
+
+    ClosedEnum singular = 1;
+    repeated ClosedEnum repeated = 2 [features.repeated_field_encoding = EXPANDED];
+    repeated ClosedEnum packed = 3 [features.repeated_field_encoding = PACKED];
+    map<string, ClosedEnum> values = 4;
+}
+
+message ClosedImplicitMessage {
+    option features.enum_type = CLOSED;
+    option features.field_presence = IMPLICIT;
+
+    enum ClosedEnum {
+        ZERO = 0;
+        ONE = 1;
+    }
+
+    ClosedEnum singular = 1;
+}

--- a/tests/data/mapbox/vector_tile.js
+++ b/tests/data/mapbox/vector_tile.js
@@ -925,7 +925,7 @@ $root.vector_tile = (function() {
                     _depth = 0;
                 if (_depth > $Reader.recursionLimit)
                     throw $Error("max depth exceeded");
-                var end = length === $undefined ? reader.len : reader.pos + length, message = _target || new $root.vector_tile.Tile.Feature();
+                var end = length === $undefined ? reader.len : reader.pos + length, message = _target || new $root.vector_tile.Tile.Feature(), value;
                 while (reader.pos < end) {
                     var start = reader.pos;
                     var tag = reader.tag();
@@ -960,7 +960,13 @@ $root.vector_tile = (function() {
                     case 3: {
                             if (wireType !== 0)
                                 break;
-                            message.type = reader.int32();
+                            value = reader.int32();
+                            if ($root.vector_tile.Tile.GeomType[value] !== $undefined)
+                                message.type = value;
+                            else if (!reader.discardUnknown) {
+                                $util.makeProp(message, "$unknowns", false);
+                                (message.$unknowns || (message.$unknowns = [])).push(reader.raw(start, reader.pos));
+                            }
                             continue;
                         }
                     case 4: {
@@ -1087,12 +1093,6 @@ $root.vector_tile = (function() {
                         message.tags[i] = object.tags[i] >>> 0;
                 }
                 switch (object.type) {
-                default:
-                    if (typeof object.type === "number") {
-                        message.type = object.type;
-                        break;
-                    }
-                    break;
                 case "UNKNOWN":
                 case 0:
                     message.type = 0;
@@ -1109,6 +1109,7 @@ $root.vector_tile = (function() {
                 case 3:
                     message.type = 3;
                     break;
+                default:
                 }
                 if (object.geometry) {
                     if (!$Array.isArray(object.geometry))

--- a/tests/data/test.js
+++ b/tests/data/test.js
@@ -377,7 +377,7 @@ $root.jspb = (function() {
                     _depth = 0;
                 if (_depth > $Reader.recursionLimit)
                     throw $Error("max depth exceeded");
-                var end = length === $undefined ? reader.len : reader.pos + length, message = _target || new $root.jspb.test.EnumContainer();
+                var end = length === $undefined ? reader.len : reader.pos + length, message = _target || new $root.jspb.test.EnumContainer(), value;
                 while (reader.pos < end) {
                     var start = reader.pos;
                     var tag = reader.tag();
@@ -390,7 +390,13 @@ $root.jspb = (function() {
                     case 1: {
                             if (wireType !== 0)
                                 break;
-                            message.outerEnum = reader.int32();
+                            value = reader.int32();
+                            if ($root.jspb.test.OuterEnum[value] !== $undefined)
+                                message.outerEnum = value;
+                            else if (!reader.discardUnknown) {
+                                $util.makeProp(message, "$unknowns", false);
+                                (message.$unknowns || (message.$unknowns = [])).push(reader.raw(start, reader.pos));
+                            }
                             continue;
                         }
                     }
@@ -466,12 +472,6 @@ $root.jspb = (function() {
                     throw $Error("max depth exceeded");
                 var message = new $root.jspb.test.EnumContainer();
                 switch (object.outerEnum) {
-                default:
-                    if (typeof object.outerEnum === "number") {
-                        message.outerEnum = object.outerEnum;
-                        break;
-                    }
-                    break;
                 case "FOO":
                 case 1:
                     message.outerEnum = 1;
@@ -480,6 +480,7 @@ $root.jspb = (function() {
                 case 2:
                     message.outerEnum = 2;
                     break;
+                default:
                 }
                 return message;
             };
@@ -4401,7 +4402,7 @@ $root.jspb = (function() {
                     _depth = 0;
                 if (_depth > $Reader.recursionLimit)
                     throw $Error("max depth exceeded");
-                var end = length === $undefined ? reader.len : reader.pos + length, message = _target || new $root.jspb.test.DefaultValues();
+                var end = length === $undefined ? reader.len : reader.pos + length, message = _target || new $root.jspb.test.DefaultValues(), value;
                 while (reader.pos < end) {
                     var start = reader.pos;
                     var tag = reader.tag();
@@ -4432,7 +4433,13 @@ $root.jspb = (function() {
                     case 4: {
                             if (wireType !== 0)
                                 break;
-                            message.enumField = reader.int32();
+                            value = reader.int32();
+                            if ($root.jspb.test.DefaultValues.Enum[value] !== $undefined)
+                                message.enumField = value;
+                            else if (!reader.discardUnknown) {
+                                $util.makeProp(message, "$unknowns", false);
+                                (message.$unknowns || (message.$unknowns = [])).push(reader.raw(start, reader.pos));
+                            }
                             continue;
                         }
                     case 6: {
@@ -4548,12 +4555,6 @@ $root.jspb = (function() {
                     else if (typeof object.intField === "object")
                         message.intField = new $util.LongBits(object.intField.low >>> 0, object.intField.high >>> 0).toNumber();
                 switch (object.enumField) {
-                default:
-                    if (typeof object.enumField === "number") {
-                        message.enumField = object.enumField;
-                        break;
-                    }
-                    break;
                 case "E1":
                 case 13:
                     message.enumField = 13;
@@ -4562,6 +4563,7 @@ $root.jspb = (function() {
                 case 77:
                     message.enumField = 77;
                     break;
+                default:
                 }
                 if (object.emptyField != null)
                     message.emptyField = $String(object.emptyField);
@@ -7764,7 +7766,7 @@ $root.jspb = (function() {
                         _depth = 0;
                     if (_depth > $Reader.recursionLimit)
                         throw $Error("max depth exceeded");
-                    var end = length === $undefined ? reader.len : reader.pos + length, message = _target || new $root.jspb.test.TestGroup.EnumInGroup();
+                    var end = length === $undefined ? reader.len : reader.pos + length, message = _target || new $root.jspb.test.TestGroup.EnumInGroup(), value;
                     while (reader.pos < end) {
                         var start = reader.pos;
                         var tag = reader.tag();
@@ -7777,7 +7779,13 @@ $root.jspb = (function() {
                         case 1: {
                                 if (wireType !== 0)
                                     break;
-                                message.id = reader.int32();
+                                value = reader.int32();
+                                if ($root.jspb.test.TestGroup.EnumInGroup.NestedEnum[value] !== $undefined)
+                                    message.id = value;
+                                else if (!reader.discardUnknown) {
+                                    $util.makeProp(message, "$unknowns", false);
+                                    (message.$unknowns || (message.$unknowns = [])).push(reader.raw(start, reader.pos));
+                                }
                                 continue;
                             }
                         }
@@ -7854,12 +7862,6 @@ $root.jspb = (function() {
                         throw $Error("max depth exceeded");
                     var message = new $root.jspb.test.TestGroup.EnumInGroup();
                     switch (object.id) {
-                    default:
-                        if (typeof object.id === "number") {
-                            message.id = object.id;
-                            break;
-                        }
-                        break;
                     case "first":
                     case 0:
                         message.id = 0;
@@ -7868,6 +7870,7 @@ $root.jspb = (function() {
                     case 1:
                         message.id = 1;
                         break;
+                    default:
                     }
                     return message;
                 };
@@ -10039,8 +10042,6 @@ $root.jspb = (function() {
                     case 6: {
                             if (wireType !== 2)
                                 break;
-                            if (message.mapStringEnum === $util.emptyObject)
-                                message.mapStringEnum = {};
                             var end2 = reader.uint32() + reader.pos;
                             key = "";
                             value = 0;
@@ -10061,6 +10062,15 @@ $root.jspb = (function() {
                                 }
                                 reader.skipType(wireType, _depth, tag2);
                             }
+                            if ($root.jspb.test.MapValueEnumNoBinary[value] === $undefined) {
+                                if (!reader.discardUnknown) {
+                                    $util.makeProp(message, "$unknowns", false);
+                                    (message.$unknowns || (message.$unknowns = [])).push(reader.raw(start, reader.pos));
+                                }
+                                continue;
+                            }
+                            if (message.mapStringEnum === $util.emptyObject)
+                                message.mapStringEnum = {};
                             if (key === "__proto__")
                                 $util.makeProp(message.mapStringEnum, key);
                             message.mapStringEnum[key] = value;
@@ -10457,12 +10467,6 @@ $root.jspb = (function() {
                         if (keys[i] === "__proto__")
                             $util.makeProp(message.mapStringEnum, keys[i]);
                         switch (object.mapStringEnum[keys[i]]) {
-                        default:
-                            if (typeof object.mapStringEnum[keys[i]] === "number") {
-                                message.mapStringEnum[keys[i]] = object.mapStringEnum[keys[i]];
-                                break;
-                            }
-                            break;
                         case "MAP_VALUE_FOO_NOBINARY":
                         case 0:
                             message.mapStringEnum[keys[i]] = 0;
@@ -10475,6 +10479,7 @@ $root.jspb = (function() {
                         case 2:
                             message.mapStringEnum[keys[i]] = 2;
                             break;
+                        default:
                         }
                     }
                 }
@@ -12276,7 +12281,7 @@ $root.google = (function() {
                     _depth = 0;
                 if (_depth > $Reader.recursionLimit)
                     throw $Error("max depth exceeded");
-                var end = length === $undefined ? reader.len : reader.pos + length, message = _target || new $root.google.protobuf.FileDescriptorProto();
+                var end = length === $undefined ? reader.len : reader.pos + length, message = _target || new $root.google.protobuf.FileDescriptorProto(), value;
                 while (reader.pos < end) {
                     var start = reader.pos;
                     var tag = reader.tag();
@@ -12399,7 +12404,13 @@ $root.google = (function() {
                     case 14: {
                             if (wireType !== 0)
                                 break;
-                            message.edition = reader.int32();
+                            value = reader.int32();
+                            if ($root.google.protobuf.Edition[value] !== $undefined)
+                                message.edition = value;
+                            else if (!reader.discardUnknown) {
+                                $util.makeProp(message, "$unknowns", false);
+                                (message.$unknowns || (message.$unknowns = [])).push(reader.raw(start, reader.pos));
+                            }
                             continue;
                         }
                     }
@@ -12652,12 +12663,6 @@ $root.google = (function() {
                 if (object.syntax != null)
                     message.syntax = $String(object.syntax);
                 switch (object.edition) {
-                default:
-                    if (typeof object.edition === "number") {
-                        message.edition = object.edition;
-                        break;
-                    }
-                    break;
                 case "EDITION_UNKNOWN":
                 case 0:
                     message.edition = 0;
@@ -12706,6 +12711,7 @@ $root.google = (function() {
                 case 2147483647:
                     message.edition = 2147483647;
                     break;
+                default:
                 }
                 return message;
             };
@@ -13070,7 +13076,7 @@ $root.google = (function() {
                     _depth = 0;
                 if (_depth > $Reader.recursionLimit)
                     throw $Error("max depth exceeded");
-                var end = length === $undefined ? reader.len : reader.pos + length, message = _target || new $root.google.protobuf.DescriptorProto();
+                var end = length === $undefined ? reader.len : reader.pos + length, message = _target || new $root.google.protobuf.DescriptorProto(), value;
                 while (reader.pos < end) {
                     var start = reader.pos;
                     var tag = reader.tag();
@@ -13159,7 +13165,13 @@ $root.google = (function() {
                     case 11: {
                             if (wireType !== 0)
                                 break;
-                            message.visibility = reader.int32();
+                            value = reader.int32();
+                            if ($root.google.protobuf.SymbolVisibility[value] !== $undefined)
+                                message.visibility = value;
+                            else if (!reader.discardUnknown) {
+                                $util.makeProp(message, "$unknowns", false);
+                                (message.$unknowns || (message.$unknowns = [])).push(reader.raw(start, reader.pos));
+                            }
                             continue;
                         }
                     }
@@ -13398,12 +13410,6 @@ $root.google = (function() {
                         message.reservedName[i] = $String(object.reservedName[i]);
                 }
                 switch (object.visibility) {
-                default:
-                    if (typeof object.visibility === "number") {
-                        message.visibility = object.visibility;
-                        break;
-                    }
-                    break;
                 case "VISIBILITY_UNSET":
                 case 0:
                     message.visibility = 0;
@@ -13416,6 +13422,7 @@ $root.google = (function() {
                 case 2:
                     message.visibility = 2;
                     break;
+                default:
                 }
                 return message;
             };
@@ -14276,7 +14283,7 @@ $root.google = (function() {
                     _depth = 0;
                 if (_depth > $Reader.recursionLimit)
                     throw $Error("max depth exceeded");
-                var end = length === $undefined ? reader.len : reader.pos + length, message = _target || new $root.google.protobuf.ExtensionRangeOptions();
+                var end = length === $undefined ? reader.len : reader.pos + length, message = _target || new $root.google.protobuf.ExtensionRangeOptions(), value;
                 while (reader.pos < end) {
                     var start = reader.pos;
                     var tag = reader.tag();
@@ -14311,7 +14318,13 @@ $root.google = (function() {
                     case 3: {
                             if (wireType !== 0)
                                 break;
-                            message.verification = reader.int32();
+                            value = reader.int32();
+                            if ($root.google.protobuf.ExtensionRangeOptions.VerificationState[value] !== $undefined)
+                                message.verification = value;
+                            else if (!reader.discardUnknown) {
+                                $util.makeProp(message, "$unknowns", false);
+                                (message.$unknowns || (message.$unknowns = [])).push(reader.raw(start, reader.pos));
+                            }
                             continue;
                         }
                     }
@@ -14439,16 +14452,11 @@ $root.google = (function() {
                 case 0:
                     message.verification = 0;
                     break;
-                default:
-                    if (typeof object.verification === "number") {
-                        message.verification = object.verification;
-                        break;
-                    }
-                    break;
                 case "UNVERIFIED":
                 case 1:
                     message.verification = 1;
                     break;
+                default:
                 }
                 return message;
             };
@@ -15120,7 +15128,7 @@ $root.google = (function() {
                     _depth = 0;
                 if (_depth > $Reader.recursionLimit)
                     throw $Error("max depth exceeded");
-                var end = length === $undefined ? reader.len : reader.pos + length, message = _target || new $root.google.protobuf.FieldDescriptorProto();
+                var end = length === $undefined ? reader.len : reader.pos + length, message = _target || new $root.google.protobuf.FieldDescriptorProto(), value;
                 while (reader.pos < end) {
                     var start = reader.pos;
                     var tag = reader.tag();
@@ -15145,13 +15153,25 @@ $root.google = (function() {
                     case 4: {
                             if (wireType !== 0)
                                 break;
-                            message.label = reader.int32();
+                            value = reader.int32();
+                            if ($root.google.protobuf.FieldDescriptorProto.Label[value] !== $undefined)
+                                message.label = value;
+                            else if (!reader.discardUnknown) {
+                                $util.makeProp(message, "$unknowns", false);
+                                (message.$unknowns || (message.$unknowns = [])).push(reader.raw(start, reader.pos));
+                            }
                             continue;
                         }
                     case 5: {
                             if (wireType !== 0)
                                 break;
-                            message.type = reader.int32();
+                            value = reader.int32();
+                            if ($root.google.protobuf.FieldDescriptorProto.Type[value] !== $undefined)
+                                message.type = value;
+                            else if (!reader.discardUnknown) {
+                                $util.makeProp(message, "$unknowns", false);
+                                (message.$unknowns || (message.$unknowns = [])).push(reader.raw(start, reader.pos));
+                            }
                             continue;
                         }
                     case 6: {
@@ -15327,12 +15347,6 @@ $root.google = (function() {
                 if (object.number != null)
                     message.number = object.number | 0;
                 switch (object.label) {
-                default:
-                    if (typeof object.label === "number") {
-                        message.label = object.label;
-                        break;
-                    }
-                    break;
                 case "LABEL_OPTIONAL":
                 case 1:
                     message.label = 1;
@@ -15345,14 +15359,9 @@ $root.google = (function() {
                 case 2:
                     message.label = 2;
                     break;
+                default:
                 }
                 switch (object.type) {
-                default:
-                    if (typeof object.type === "number") {
-                        message.type = object.type;
-                        break;
-                    }
-                    break;
                 case "TYPE_DOUBLE":
                 case 1:
                     message.type = 1;
@@ -15425,6 +15434,7 @@ $root.google = (function() {
                 case 18:
                     message.type = 18;
                     break;
+                default:
                 }
                 if (object.typeName != null)
                     message.typeName = $String(object.typeName);
@@ -16055,7 +16065,7 @@ $root.google = (function() {
                     _depth = 0;
                 if (_depth > $Reader.recursionLimit)
                     throw $Error("max depth exceeded");
-                var end = length === $undefined ? reader.len : reader.pos + length, message = _target || new $root.google.protobuf.EnumDescriptorProto();
+                var end = length === $undefined ? reader.len : reader.pos + length, message = _target || new $root.google.protobuf.EnumDescriptorProto(), value;
                 while (reader.pos < end) {
                     var start = reader.pos;
                     var tag = reader.tag();
@@ -16104,7 +16114,13 @@ $root.google = (function() {
                     case 6: {
                             if (wireType !== 0)
                                 break;
-                            message.visibility = reader.int32();
+                            value = reader.int32();
+                            if ($root.google.protobuf.SymbolVisibility[value] !== $undefined)
+                                message.visibility = value;
+                            else if (!reader.discardUnknown) {
+                                $util.makeProp(message, "$unknowns", false);
+                                (message.$unknowns || (message.$unknowns = [])).push(reader.raw(start, reader.pos));
+                            }
                             continue;
                         }
                     }
@@ -16248,12 +16264,6 @@ $root.google = (function() {
                         message.reservedName[i] = $String(object.reservedName[i]);
                 }
                 switch (object.visibility) {
-                default:
-                    if (typeof object.visibility === "number") {
-                        message.visibility = object.visibility;
-                        break;
-                    }
-                    break;
                 case "VISIBILITY_UNSET":
                 case 0:
                     message.visibility = 0;
@@ -16266,6 +16276,7 @@ $root.google = (function() {
                 case 2:
                     message.visibility = 2;
                     break;
+                default:
                 }
                 return message;
             };
@@ -18002,7 +18013,7 @@ $root.google = (function() {
                     _depth = 0;
                 if (_depth > $Reader.recursionLimit)
                     throw $Error("max depth exceeded");
-                var end = length === $undefined ? reader.len : reader.pos + length, message = _target || new $root.google.protobuf.FileOptions();
+                var end = length === $undefined ? reader.len : reader.pos + length, message = _target || new $root.google.protobuf.FileOptions(), value;
                 while (reader.pos < end) {
                     var start = reader.pos;
                     var tag = reader.tag();
@@ -18045,7 +18056,13 @@ $root.google = (function() {
                     case 9: {
                             if (wireType !== 0)
                                 break;
-                            message.optimizeFor = reader.int32();
+                            value = reader.int32();
+                            if ($root.google.protobuf.FileOptions.OptimizeMode[value] !== $undefined)
+                                message.optimizeFor = value;
+                            else if (!reader.discardUnknown) {
+                                $util.makeProp(message, "$unknowns", false);
+                                (message.$unknowns || (message.$unknowns = [])).push(reader.raw(start, reader.pos));
+                            }
                             continue;
                         }
                     case 11: {
@@ -18292,12 +18309,6 @@ $root.google = (function() {
                 if (object.javaStringCheckUtf8 != null)
                     message.javaStringCheckUtf8 = $Boolean(object.javaStringCheckUtf8);
                 switch (object.optimizeFor) {
-                default:
-                    if (typeof object.optimizeFor === "number") {
-                        message.optimizeFor = object.optimizeFor;
-                        break;
-                    }
-                    break;
                 case "SPEED":
                 case 1:
                     message.optimizeFor = 1;
@@ -18310,6 +18321,7 @@ $root.google = (function() {
                 case 3:
                     message.optimizeFor = 3;
                     break;
+                default:
                 }
                 if (object.goPackage != null)
                     message.goPackage = $String(object.goPackage);
@@ -19187,7 +19199,7 @@ $root.google = (function() {
                     _depth = 0;
                 if (_depth > $Reader.recursionLimit)
                     throw $Error("max depth exceeded");
-                var end = length === $undefined ? reader.len : reader.pos + length, message = _target || new $root.google.protobuf.FieldOptions();
+                var end = length === $undefined ? reader.len : reader.pos + length, message = _target || new $root.google.protobuf.FieldOptions(), value;
                 while (reader.pos < end) {
                     var start = reader.pos;
                     var tag = reader.tag();
@@ -19200,7 +19212,13 @@ $root.google = (function() {
                     case 1: {
                             if (wireType !== 0)
                                 break;
-                            message.ctype = reader.int32();
+                            value = reader.int32();
+                            if ($root.google.protobuf.FieldOptions.CType[value] !== $undefined)
+                                message.ctype = value;
+                            else if (!reader.discardUnknown) {
+                                $util.makeProp(message, "$unknowns", false);
+                                (message.$unknowns || (message.$unknowns = [])).push(reader.raw(start, reader.pos));
+                            }
                             continue;
                         }
                     case 2: {
@@ -19212,7 +19230,13 @@ $root.google = (function() {
                     case 6: {
                             if (wireType !== 0)
                                 break;
-                            message.jstype = reader.int32();
+                            value = reader.int32();
+                            if ($root.google.protobuf.FieldOptions.JSType[value] !== $undefined)
+                                message.jstype = value;
+                            else if (!reader.discardUnknown) {
+                                $util.makeProp(message, "$unknowns", false);
+                                (message.$unknowns || (message.$unknowns = [])).push(reader.raw(start, reader.pos));
+                            }
                             continue;
                         }
                     case 5: {
@@ -19248,23 +19272,43 @@ $root.google = (function() {
                     case 17: {
                             if (wireType !== 0)
                                 break;
-                            message.retention = reader.int32();
+                            value = reader.int32();
+                            if ($root.google.protobuf.FieldOptions.OptionRetention[value] !== $undefined)
+                                message.retention = value;
+                            else if (!reader.discardUnknown) {
+                                $util.makeProp(message, "$unknowns", false);
+                                (message.$unknowns || (message.$unknowns = [])).push(reader.raw(start, reader.pos));
+                            }
                             continue;
                         }
                     case 19: {
                             if (wireType === 2) {
-                                if (!(message.targets && message.targets.length))
-                                    message.targets = [];
                                 var end2 = reader.uint32() + reader.pos;
-                                while (reader.pos < end2)
-                                    message.targets.push(reader.int32());
+                                while (reader.pos < end2) {
+                                    start = reader.pos;
+                                    value = reader.int32();
+                                    if ($root.google.protobuf.FieldOptions.OptionTargetType[value] !== $undefined) {
+                                        if (!(message.targets && message.targets.length))
+                                            message.targets = [];
+                                        message.targets.push(value);
+                                    } else if (!reader.discardUnknown) {
+                                        $util.makeProp(message, "$unknowns", false);
+                                        (message.$unknowns || (message.$unknowns = [])).push($util.rawField(19, 0, reader.raw(start, reader.pos)));
+                                    }
+                                }
                                 continue;
                             }
                             if (wireType !== 0)
                                 break;
-                            if (!(message.targets && message.targets.length))
-                                message.targets = [];
-                            message.targets.push(reader.int32());
+                            value = reader.int32();
+                            if ($root.google.protobuf.FieldOptions.OptionTargetType[value] !== $undefined) {
+                                if (!(message.targets && message.targets.length))
+                                    message.targets = [];
+                                message.targets.push(value);
+                            } else if (!reader.discardUnknown) {
+                                $util.makeProp(message, "$unknowns", false);
+                                (message.$unknowns || (message.$unknowns = [])).push(reader.raw(start, reader.pos));
+                            }
                             continue;
                         }
                     case 20: {
@@ -19453,12 +19497,6 @@ $root.google = (function() {
                     throw $Error("max depth exceeded");
                 var message = new $root.google.protobuf.FieldOptions();
                 switch (object.ctype) {
-                default:
-                    if (typeof object.ctype === "number") {
-                        message.ctype = object.ctype;
-                        break;
-                    }
-                    break;
                 case "STRING":
                 case 0:
                     message.ctype = 0;
@@ -19471,16 +19509,11 @@ $root.google = (function() {
                 case 2:
                     message.ctype = 2;
                     break;
+                default:
                 }
                 if (object.packed != null)
                     message.packed = $Boolean(object.packed);
                 switch (object.jstype) {
-                default:
-                    if (typeof object.jstype === "number") {
-                        message.jstype = object.jstype;
-                        break;
-                    }
-                    break;
                 case "JS_NORMAL":
                 case 0:
                     message.jstype = 0;
@@ -19493,6 +19526,7 @@ $root.google = (function() {
                 case 2:
                     message.jstype = 2;
                     break;
+                default:
                 }
                 if (object.lazy != null)
                     message.lazy = $Boolean(object.lazy);
@@ -19505,12 +19539,6 @@ $root.google = (function() {
                 if (object.debugRedact != null)
                     message.debugRedact = $Boolean(object.debugRedact);
                 switch (object.retention) {
-                default:
-                    if (typeof object.retention === "number") {
-                        message.retention = object.retention;
-                        break;
-                    }
-                    break;
                 case "RETENTION_UNKNOWN":
                 case 0:
                     message.retention = 0;
@@ -19523,58 +19551,55 @@ $root.google = (function() {
                 case 2:
                     message.retention = 2;
                     break;
+                default:
                 }
                 if (object.targets) {
                     if (!$Array.isArray(object.targets))
                         throw $TypeError(".google.protobuf.FieldOptions.targets: array expected");
-                    message.targets = $Array(object.targets.length);
+                    message.targets = [];
                     for (var i = 0; i < object.targets.length; ++i)
                         switch (object.targets[i]) {
-                        default:
-                            if (typeof object.targets[i] === "number") {
-                                message.targets[i] = object.targets[i];
-                                break;
-                            }
                         case "TARGET_TYPE_UNKNOWN":
                         case 0:
-                            message.targets[i] = 0;
+                            message.targets[message.targets.length] = 0;
                             break;
                         case "TARGET_TYPE_FILE":
                         case 1:
-                            message.targets[i] = 1;
+                            message.targets[message.targets.length] = 1;
                             break;
                         case "TARGET_TYPE_EXTENSION_RANGE":
                         case 2:
-                            message.targets[i] = 2;
+                            message.targets[message.targets.length] = 2;
                             break;
                         case "TARGET_TYPE_MESSAGE":
                         case 3:
-                            message.targets[i] = 3;
+                            message.targets[message.targets.length] = 3;
                             break;
                         case "TARGET_TYPE_FIELD":
                         case 4:
-                            message.targets[i] = 4;
+                            message.targets[message.targets.length] = 4;
                             break;
                         case "TARGET_TYPE_ONEOF":
                         case 5:
-                            message.targets[i] = 5;
+                            message.targets[message.targets.length] = 5;
                             break;
                         case "TARGET_TYPE_ENUM":
                         case 6:
-                            message.targets[i] = 6;
+                            message.targets[message.targets.length] = 6;
                             break;
                         case "TARGET_TYPE_ENUM_ENTRY":
                         case 7:
-                            message.targets[i] = 7;
+                            message.targets[message.targets.length] = 7;
                             break;
                         case "TARGET_TYPE_SERVICE":
                         case 8:
-                            message.targets[i] = 8;
+                            message.targets[message.targets.length] = 8;
                             break;
                         case "TARGET_TYPE_METHOD":
                         case 9:
-                            message.targets[i] = 9;
+                            message.targets[message.targets.length] = 9;
                             break;
+                        default:
                         }
                 }
                 if (object.editionDefaults) {
@@ -19915,7 +19940,7 @@ $root.google = (function() {
                         _depth = 0;
                     if (_depth > $Reader.recursionLimit)
                         throw $Error("max depth exceeded");
-                    var end = length === $undefined ? reader.len : reader.pos + length, message = _target || new $root.google.protobuf.FieldOptions.EditionDefault();
+                    var end = length === $undefined ? reader.len : reader.pos + length, message = _target || new $root.google.protobuf.FieldOptions.EditionDefault(), value;
                     while (reader.pos < end) {
                         var start = reader.pos;
                         var tag = reader.tag();
@@ -19928,7 +19953,13 @@ $root.google = (function() {
                         case 3: {
                                 if (wireType !== 0)
                                     break;
-                                message.edition = reader.int32();
+                                value = reader.int32();
+                                if ($root.google.protobuf.Edition[value] !== $undefined)
+                                    message.edition = value;
+                                else if (!reader.discardUnknown) {
+                                    $util.makeProp(message, "$unknowns", false);
+                                    (message.$unknowns || (message.$unknowns = [])).push(reader.raw(start, reader.pos));
+                                }
                                 continue;
                             }
                         case 2: {
@@ -20023,12 +20054,6 @@ $root.google = (function() {
                         throw $Error("max depth exceeded");
                     var message = new $root.google.protobuf.FieldOptions.EditionDefault();
                     switch (object.edition) {
-                    default:
-                        if (typeof object.edition === "number") {
-                            message.edition = object.edition;
-                            break;
-                        }
-                        break;
                     case "EDITION_UNKNOWN":
                     case 0:
                         message.edition = 0;
@@ -20077,6 +20102,7 @@ $root.google = (function() {
                     case 2147483647:
                         message.edition = 2147483647;
                         break;
+                    default:
                     }
                     if (object.value != null)
                         message.value = $String(object.value);
@@ -20288,7 +20314,7 @@ $root.google = (function() {
                         _depth = 0;
                     if (_depth > $Reader.recursionLimit)
                         throw $Error("max depth exceeded");
-                    var end = length === $undefined ? reader.len : reader.pos + length, message = _target || new $root.google.protobuf.FieldOptions.FeatureSupport();
+                    var end = length === $undefined ? reader.len : reader.pos + length, message = _target || new $root.google.protobuf.FieldOptions.FeatureSupport(), value;
                     while (reader.pos < end) {
                         var start = reader.pos;
                         var tag = reader.tag();
@@ -20301,13 +20327,25 @@ $root.google = (function() {
                         case 1: {
                                 if (wireType !== 0)
                                     break;
-                                message.editionIntroduced = reader.int32();
+                                value = reader.int32();
+                                if ($root.google.protobuf.Edition[value] !== $undefined)
+                                    message.editionIntroduced = value;
+                                else if (!reader.discardUnknown) {
+                                    $util.makeProp(message, "$unknowns", false);
+                                    (message.$unknowns || (message.$unknowns = [])).push(reader.raw(start, reader.pos));
+                                }
                                 continue;
                             }
                         case 2: {
                                 if (wireType !== 0)
                                     break;
-                                message.editionDeprecated = reader.int32();
+                                value = reader.int32();
+                                if ($root.google.protobuf.Edition[value] !== $undefined)
+                                    message.editionDeprecated = value;
+                                else if (!reader.discardUnknown) {
+                                    $util.makeProp(message, "$unknowns", false);
+                                    (message.$unknowns || (message.$unknowns = [])).push(reader.raw(start, reader.pos));
+                                }
                                 continue;
                             }
                         case 3: {
@@ -20319,7 +20357,13 @@ $root.google = (function() {
                         case 4: {
                                 if (wireType !== 0)
                                     break;
-                                message.editionRemoved = reader.int32();
+                                value = reader.int32();
+                                if ($root.google.protobuf.Edition[value] !== $undefined)
+                                    message.editionRemoved = value;
+                                else if (!reader.discardUnknown) {
+                                    $util.makeProp(message, "$unknowns", false);
+                                    (message.$unknowns || (message.$unknowns = [])).push(reader.raw(start, reader.pos));
+                                }
                                 continue;
                             }
                         }
@@ -20444,12 +20488,6 @@ $root.google = (function() {
                         throw $Error("max depth exceeded");
                     var message = new $root.google.protobuf.FieldOptions.FeatureSupport();
                     switch (object.editionIntroduced) {
-                    default:
-                        if (typeof object.editionIntroduced === "number") {
-                            message.editionIntroduced = object.editionIntroduced;
-                            break;
-                        }
-                        break;
                     case "EDITION_UNKNOWN":
                     case 0:
                         message.editionIntroduced = 0;
@@ -20498,14 +20536,9 @@ $root.google = (function() {
                     case 2147483647:
                         message.editionIntroduced = 2147483647;
                         break;
+                    default:
                     }
                     switch (object.editionDeprecated) {
-                    default:
-                        if (typeof object.editionDeprecated === "number") {
-                            message.editionDeprecated = object.editionDeprecated;
-                            break;
-                        }
-                        break;
                     case "EDITION_UNKNOWN":
                     case 0:
                         message.editionDeprecated = 0;
@@ -20554,16 +20587,11 @@ $root.google = (function() {
                     case 2147483647:
                         message.editionDeprecated = 2147483647;
                         break;
+                    default:
                     }
                     if (object.deprecationWarning != null)
                         message.deprecationWarning = $String(object.deprecationWarning);
                     switch (object.editionRemoved) {
-                    default:
-                        if (typeof object.editionRemoved === "number") {
-                            message.editionRemoved = object.editionRemoved;
-                            break;
-                        }
-                        break;
                     case "EDITION_UNKNOWN":
                     case 0:
                         message.editionRemoved = 0;
@@ -20612,6 +20640,7 @@ $root.google = (function() {
                     case 2147483647:
                         message.editionRemoved = 2147483647;
                         break;
+                    default:
                     }
                     return message;
                 };
@@ -22267,7 +22296,7 @@ $root.google = (function() {
                     _depth = 0;
                 if (_depth > $Reader.recursionLimit)
                     throw $Error("max depth exceeded");
-                var end = length === $undefined ? reader.len : reader.pos + length, message = _target || new $root.google.protobuf.MethodOptions();
+                var end = length === $undefined ? reader.len : reader.pos + length, message = _target || new $root.google.protobuf.MethodOptions(), value;
                 while (reader.pos < end) {
                     var start = reader.pos;
                     var tag = reader.tag();
@@ -22286,7 +22315,13 @@ $root.google = (function() {
                     case 34: {
                             if (wireType !== 0)
                                 break;
-                            message.idempotencyLevel = reader.int32();
+                            value = reader.int32();
+                            if ($root.google.protobuf.MethodOptions.IdempotencyLevel[value] !== $undefined)
+                                message.idempotencyLevel = value;
+                            else if (!reader.discardUnknown) {
+                                $util.makeProp(message, "$unknowns", false);
+                                (message.$unknowns || (message.$unknowns = [])).push(reader.raw(start, reader.pos));
+                            }
                             continue;
                         }
                     case 35: {
@@ -22396,12 +22431,6 @@ $root.google = (function() {
                 if (object.deprecated != null)
                     message.deprecated = $Boolean(object.deprecated);
                 switch (object.idempotencyLevel) {
-                default:
-                    if (typeof object.idempotencyLevel === "number") {
-                        message.idempotencyLevel = object.idempotencyLevel;
-                        break;
-                    }
-                    break;
                 case "IDEMPOTENCY_UNKNOWN":
                 case 0:
                     message.idempotencyLevel = 0;
@@ -22414,6 +22443,7 @@ $root.google = (function() {
                 case 2:
                     message.idempotencyLevel = 2;
                     break;
+                default:
                 }
                 if (object.features != null) {
                     if (!$util.isObject(object.features))
@@ -23460,7 +23490,7 @@ $root.google = (function() {
                     _depth = 0;
                 if (_depth > $Reader.recursionLimit)
                     throw $Error("max depth exceeded");
-                var end = length === $undefined ? reader.len : reader.pos + length, message = _target || new $root.google.protobuf.FeatureSet();
+                var end = length === $undefined ? reader.len : reader.pos + length, message = _target || new $root.google.protobuf.FeatureSet(), value;
                 while (reader.pos < end) {
                     var start = reader.pos;
                     var tag = reader.tag();
@@ -23473,49 +23503,97 @@ $root.google = (function() {
                     case 1: {
                             if (wireType !== 0)
                                 break;
-                            message.fieldPresence = reader.int32();
+                            value = reader.int32();
+                            if ($root.google.protobuf.FeatureSet.FieldPresence[value] !== $undefined)
+                                message.fieldPresence = value;
+                            else if (!reader.discardUnknown) {
+                                $util.makeProp(message, "$unknowns", false);
+                                (message.$unknowns || (message.$unknowns = [])).push(reader.raw(start, reader.pos));
+                            }
                             continue;
                         }
                     case 2: {
                             if (wireType !== 0)
                                 break;
-                            message.enumType = reader.int32();
+                            value = reader.int32();
+                            if ($root.google.protobuf.FeatureSet.EnumType[value] !== $undefined)
+                                message.enumType = value;
+                            else if (!reader.discardUnknown) {
+                                $util.makeProp(message, "$unknowns", false);
+                                (message.$unknowns || (message.$unknowns = [])).push(reader.raw(start, reader.pos));
+                            }
                             continue;
                         }
                     case 3: {
                             if (wireType !== 0)
                                 break;
-                            message.repeatedFieldEncoding = reader.int32();
+                            value = reader.int32();
+                            if ($root.google.protobuf.FeatureSet.RepeatedFieldEncoding[value] !== $undefined)
+                                message.repeatedFieldEncoding = value;
+                            else if (!reader.discardUnknown) {
+                                $util.makeProp(message, "$unknowns", false);
+                                (message.$unknowns || (message.$unknowns = [])).push(reader.raw(start, reader.pos));
+                            }
                             continue;
                         }
                     case 4: {
                             if (wireType !== 0)
                                 break;
-                            message.utf8Validation = reader.int32();
+                            value = reader.int32();
+                            if ($root.google.protobuf.FeatureSet.Utf8Validation[value] !== $undefined)
+                                message.utf8Validation = value;
+                            else if (!reader.discardUnknown) {
+                                $util.makeProp(message, "$unknowns", false);
+                                (message.$unknowns || (message.$unknowns = [])).push(reader.raw(start, reader.pos));
+                            }
                             continue;
                         }
                     case 5: {
                             if (wireType !== 0)
                                 break;
-                            message.messageEncoding = reader.int32();
+                            value = reader.int32();
+                            if ($root.google.protobuf.FeatureSet.MessageEncoding[value] !== $undefined)
+                                message.messageEncoding = value;
+                            else if (!reader.discardUnknown) {
+                                $util.makeProp(message, "$unknowns", false);
+                                (message.$unknowns || (message.$unknowns = [])).push(reader.raw(start, reader.pos));
+                            }
                             continue;
                         }
                     case 6: {
                             if (wireType !== 0)
                                 break;
-                            message.jsonFormat = reader.int32();
+                            value = reader.int32();
+                            if ($root.google.protobuf.FeatureSet.JsonFormat[value] !== $undefined)
+                                message.jsonFormat = value;
+                            else if (!reader.discardUnknown) {
+                                $util.makeProp(message, "$unknowns", false);
+                                (message.$unknowns || (message.$unknowns = [])).push(reader.raw(start, reader.pos));
+                            }
                             continue;
                         }
                     case 7: {
                             if (wireType !== 0)
                                 break;
-                            message.enforceNamingStyle = reader.int32();
+                            value = reader.int32();
+                            if ($root.google.protobuf.FeatureSet.EnforceNamingStyle[value] !== $undefined)
+                                message.enforceNamingStyle = value;
+                            else if (!reader.discardUnknown) {
+                                $util.makeProp(message, "$unknowns", false);
+                                (message.$unknowns || (message.$unknowns = [])).push(reader.raw(start, reader.pos));
+                            }
                             continue;
                         }
                     case 8: {
                             if (wireType !== 0)
                                 break;
-                            message.defaultSymbolVisibility = reader.int32();
+                            value = reader.int32();
+                            if ($root.google.protobuf.FeatureSet.VisibilityFeature.DefaultSymbolVisibility[value] !== $undefined)
+                                message.defaultSymbolVisibility = value;
+                            else if (!reader.discardUnknown) {
+                                $util.makeProp(message, "$unknowns", false);
+                                (message.$unknowns || (message.$unknowns = [])).push(reader.raw(start, reader.pos));
+                            }
                             continue;
                         }
                     }
@@ -23658,12 +23736,6 @@ $root.google = (function() {
                     throw $Error("max depth exceeded");
                 var message = new $root.google.protobuf.FeatureSet();
                 switch (object.fieldPresence) {
-                default:
-                    if (typeof object.fieldPresence === "number") {
-                        message.fieldPresence = object.fieldPresence;
-                        break;
-                    }
-                    break;
                 case "FIELD_PRESENCE_UNKNOWN":
                 case 0:
                     message.fieldPresence = 0;
@@ -23680,14 +23752,9 @@ $root.google = (function() {
                 case 3:
                     message.fieldPresence = 3;
                     break;
+                default:
                 }
                 switch (object.enumType) {
-                default:
-                    if (typeof object.enumType === "number") {
-                        message.enumType = object.enumType;
-                        break;
-                    }
-                    break;
                 case "ENUM_TYPE_UNKNOWN":
                 case 0:
                     message.enumType = 0;
@@ -23700,14 +23767,9 @@ $root.google = (function() {
                 case 2:
                     message.enumType = 2;
                     break;
+                default:
                 }
                 switch (object.repeatedFieldEncoding) {
-                default:
-                    if (typeof object.repeatedFieldEncoding === "number") {
-                        message.repeatedFieldEncoding = object.repeatedFieldEncoding;
-                        break;
-                    }
-                    break;
                 case "REPEATED_FIELD_ENCODING_UNKNOWN":
                 case 0:
                     message.repeatedFieldEncoding = 0;
@@ -23720,14 +23782,9 @@ $root.google = (function() {
                 case 2:
                     message.repeatedFieldEncoding = 2;
                     break;
+                default:
                 }
                 switch (object.utf8Validation) {
-                default:
-                    if (typeof object.utf8Validation === "number") {
-                        message.utf8Validation = object.utf8Validation;
-                        break;
-                    }
-                    break;
                 case "UTF8_VALIDATION_UNKNOWN":
                 case 0:
                     message.utf8Validation = 0;
@@ -23740,14 +23797,9 @@ $root.google = (function() {
                 case 3:
                     message.utf8Validation = 3;
                     break;
+                default:
                 }
                 switch (object.messageEncoding) {
-                default:
-                    if (typeof object.messageEncoding === "number") {
-                        message.messageEncoding = object.messageEncoding;
-                        break;
-                    }
-                    break;
                 case "MESSAGE_ENCODING_UNKNOWN":
                 case 0:
                     message.messageEncoding = 0;
@@ -23760,14 +23812,9 @@ $root.google = (function() {
                 case 2:
                     message.messageEncoding = 2;
                     break;
+                default:
                 }
                 switch (object.jsonFormat) {
-                default:
-                    if (typeof object.jsonFormat === "number") {
-                        message.jsonFormat = object.jsonFormat;
-                        break;
-                    }
-                    break;
                 case "JSON_FORMAT_UNKNOWN":
                 case 0:
                     message.jsonFormat = 0;
@@ -23780,14 +23827,9 @@ $root.google = (function() {
                 case 2:
                     message.jsonFormat = 2;
                     break;
+                default:
                 }
                 switch (object.enforceNamingStyle) {
-                default:
-                    if (typeof object.enforceNamingStyle === "number") {
-                        message.enforceNamingStyle = object.enforceNamingStyle;
-                        break;
-                    }
-                    break;
                 case "ENFORCE_NAMING_STYLE_UNKNOWN":
                 case 0:
                     message.enforceNamingStyle = 0;
@@ -23800,14 +23842,9 @@ $root.google = (function() {
                 case 2:
                     message.enforceNamingStyle = 2;
                     break;
+                default:
                 }
                 switch (object.defaultSymbolVisibility) {
-                default:
-                    if (typeof object.defaultSymbolVisibility === "number") {
-                        message.defaultSymbolVisibility = object.defaultSymbolVisibility;
-                        break;
-                    }
-                    break;
                 case "DEFAULT_SYMBOL_VISIBILITY_UNKNOWN":
                 case 0:
                     message.defaultSymbolVisibility = 0;
@@ -23828,6 +23865,7 @@ $root.google = (function() {
                 case 4:
                     message.defaultSymbolVisibility = 4;
                     break;
+                default:
                 }
                 return message;
             };
@@ -24399,7 +24437,7 @@ $root.google = (function() {
                     _depth = 0;
                 if (_depth > $Reader.recursionLimit)
                     throw $Error("max depth exceeded");
-                var end = length === $undefined ? reader.len : reader.pos + length, message = _target || new $root.google.protobuf.FeatureSetDefaults();
+                var end = length === $undefined ? reader.len : reader.pos + length, message = _target || new $root.google.protobuf.FeatureSetDefaults(), value;
                 while (reader.pos < end) {
                     var start = reader.pos;
                     var tag = reader.tag();
@@ -24420,13 +24458,25 @@ $root.google = (function() {
                     case 4: {
                             if (wireType !== 0)
                                 break;
-                            message.minimumEdition = reader.int32();
+                            value = reader.int32();
+                            if ($root.google.protobuf.Edition[value] !== $undefined)
+                                message.minimumEdition = value;
+                            else if (!reader.discardUnknown) {
+                                $util.makeProp(message, "$unknowns", false);
+                                (message.$unknowns || (message.$unknowns = [])).push(reader.raw(start, reader.pos));
+                            }
                             continue;
                         }
                     case 5: {
                             if (wireType !== 0)
                                 break;
-                            message.maximumEdition = reader.int32();
+                            value = reader.int32();
+                            if ($root.google.protobuf.Edition[value] !== $undefined)
+                                message.maximumEdition = value;
+                            else if (!reader.discardUnknown) {
+                                $util.makeProp(message, "$unknowns", false);
+                                (message.$unknowns || (message.$unknowns = [])).push(reader.raw(start, reader.pos));
+                            }
                             continue;
                         }
                     }
@@ -24549,12 +24599,6 @@ $root.google = (function() {
                     }
                 }
                 switch (object.minimumEdition) {
-                default:
-                    if (typeof object.minimumEdition === "number") {
-                        message.minimumEdition = object.minimumEdition;
-                        break;
-                    }
-                    break;
                 case "EDITION_UNKNOWN":
                 case 0:
                     message.minimumEdition = 0;
@@ -24603,14 +24647,9 @@ $root.google = (function() {
                 case 2147483647:
                     message.minimumEdition = 2147483647;
                     break;
+                default:
                 }
                 switch (object.maximumEdition) {
-                default:
-                    if (typeof object.maximumEdition === "number") {
-                        message.maximumEdition = object.maximumEdition;
-                        break;
-                    }
-                    break;
                 case "EDITION_UNKNOWN":
                 case 0:
                     message.maximumEdition = 0;
@@ -24659,6 +24698,7 @@ $root.google = (function() {
                 case 2147483647:
                     message.maximumEdition = 2147483647;
                     break;
+                default:
                 }
                 return message;
             };
@@ -24861,7 +24901,7 @@ $root.google = (function() {
                         _depth = 0;
                     if (_depth > $Reader.recursionLimit)
                         throw $Error("max depth exceeded");
-                    var end = length === $undefined ? reader.len : reader.pos + length, message = _target || new $root.google.protobuf.FeatureSetDefaults.FeatureSetEditionDefault();
+                    var end = length === $undefined ? reader.len : reader.pos + length, message = _target || new $root.google.protobuf.FeatureSetDefaults.FeatureSetEditionDefault(), value;
                     while (reader.pos < end) {
                         var start = reader.pos;
                         var tag = reader.tag();
@@ -24874,7 +24914,13 @@ $root.google = (function() {
                         case 3: {
                                 if (wireType !== 0)
                                     break;
-                                message.edition = reader.int32();
+                                value = reader.int32();
+                                if ($root.google.protobuf.Edition[value] !== $undefined)
+                                    message.edition = value;
+                                else if (!reader.discardUnknown) {
+                                    $util.makeProp(message, "$unknowns", false);
+                                    (message.$unknowns || (message.$unknowns = [])).push(reader.raw(start, reader.pos));
+                                }
                                 continue;
                             }
                         case 4: {
@@ -24982,12 +25028,6 @@ $root.google = (function() {
                         throw $Error("max depth exceeded");
                     var message = new $root.google.protobuf.FeatureSetDefaults.FeatureSetEditionDefault();
                     switch (object.edition) {
-                    default:
-                        if (typeof object.edition === "number") {
-                            message.edition = object.edition;
-                            break;
-                        }
-                        break;
                     case "EDITION_UNKNOWN":
                     case 0:
                         message.edition = 0;
@@ -25036,6 +25076,7 @@ $root.google = (function() {
                     case 2147483647:
                         message.edition = 2147483647;
                         break;
+                    default:
                     }
                     if (object.overridableFeatures != null) {
                         if (!$util.isObject(object.overridableFeatures))
@@ -26257,7 +26298,7 @@ $root.google = (function() {
                         _depth = 0;
                     if (_depth > $Reader.recursionLimit)
                         throw $Error("max depth exceeded");
-                    var end = length === $undefined ? reader.len : reader.pos + length, message = _target || new $root.google.protobuf.GeneratedCodeInfo.Annotation();
+                    var end = length === $undefined ? reader.len : reader.pos + length, message = _target || new $root.google.protobuf.GeneratedCodeInfo.Annotation(), value;
                     while (reader.pos < end) {
                         var start = reader.pos;
                         var tag = reader.tag();
@@ -26304,7 +26345,13 @@ $root.google = (function() {
                         case 5: {
                                 if (wireType !== 0)
                                     break;
-                                message.semantic = reader.int32();
+                                value = reader.int32();
+                                if ($root.google.protobuf.GeneratedCodeInfo.Annotation.Semantic[value] !== $undefined)
+                                    message.semantic = value;
+                                else if (!reader.discardUnknown) {
+                                    $util.makeProp(message, "$unknowns", false);
+                                    (message.$unknowns || (message.$unknowns = [])).push(reader.raw(start, reader.pos));
+                                }
                                 continue;
                             }
                         }
@@ -26410,12 +26457,6 @@ $root.google = (function() {
                     if (object.end != null)
                         message.end = object.end | 0;
                     switch (object.semantic) {
-                    default:
-                        if (typeof object.semantic === "number") {
-                            message.semantic = object.semantic;
-                            break;
-                        }
-                        break;
                     case "NONE":
                     case 0:
                         message.semantic = 0;
@@ -26428,6 +26469,7 @@ $root.google = (function() {
                     case 2:
                         message.semantic = 2;
                         break;
+                    default:
                     }
                     return message;
                 };


### PR DESCRIPTION
Implements OPEN and CLOSED enum semantics across codegen and the ProtoJSON and Text Format extensions, covering the relevant singular, repeated unpacked, repeated packed, and map-entry cases.

Background: Open enum fields accept any signed int32 value, while closed enum fields reject or drop unknown values. During decode, unknown closed enum values are preserved in `$unknowns` when unknown-field preservation is enabled.