### PR TITLE
fix: omit proto3 implicit-presence defaults when encoding from parse().root

### DIFF
--- a/src/type.js
+++ b/src/type.js
@@ -494,6 +494,13 @@ Type.prototype.setup = function setup() {
     // Sets up everything at once so that the prototype chain does not have to be re-evaluated
     // multiple times (V8, soft-deopt prototype-check).
 
+    // Resolve feature defaults (e.g. proto3 implicit field presence) before the
+    // codecs are generated, so encoders built from a parsed-but-not-resolveAll'd
+    // root omit implicit-presence default values per the proto3/editions spec.
+    var root = this.root;
+    if (root && root._needsRecursiveFeatureResolution && (root._edition || this._edition))
+        root._resolveFeaturesRecursive(root._edition);
+
     var fullName = this.fullName,
         types    = [];
     for (var i = 0; i < /* initializes */ this.fieldsArray.length; ++i)

--- a/src/type.js
+++ b/src/type.js
@@ -494,12 +494,13 @@ Type.prototype.setup = function setup() {
     // Sets up everything at once so that the prototype chain does not have to be re-evaluated
     // multiple times (V8, soft-deopt prototype-check).
 
-    // Resolve feature defaults (e.g. proto3 implicit field presence) before the
-    // codecs are generated, so encoders built from a parsed-but-not-resolveAll'd
-    // root omit implicit-presence default values per the proto3/editions spec.
+    // Resolve feature defaults incl. field presence before generating codecs
     var root = this.root;
-    if (root && root._needsRecursiveFeatureResolution && (root._edition || this._edition))
-        root._resolveFeaturesRecursive(root._edition);
+    if (root && root._needsRecursiveFeatureResolution) {
+        var edition = root._edition || this._edition;
+        if (edition)
+            root._resolveFeaturesRecursive(edition);
+    }
 
     var fullName = this.fullName,
         types    = [];

--- a/tests/comp_optional.js
+++ b/tests/comp_optional.js
@@ -114,3 +114,25 @@ tape.test("proto3 implicit scalar conversion defaults", function(test) {
 
     test.end();
 });
+
+tape.test("proto3 implicit scalar defaults without an explicit resolveAll", function(test) {
+    // parse().root builds its codecs lazily via setup(); it must omit
+    // implicit-presence defaults the same way load()/fromJSON() do (those
+    // resolveAll internally), instead of requiring a manual resolveAll first.
+    var root = protobuf.parse(proto).root;
+
+    var Message = root.lookupType("Message");
+
+    function encode(message) {
+        return Array.prototype.slice.call(Message.encode(message).finish());
+    }
+
+    test.same(encode({ regularInt32: 0 }), [], "should omit default int32");
+    test.same(encode({ regularString: "" }), [], "should omit default string");
+    test.same(encode({ regularBool: false }), [], "should omit default bool");
+    test.same(encode({ regularEnum: 0 }), [], "should omit default enum");
+    test.same(encode({ regularInt32: 5 }), [8, 5], "should still emit non-default values");
+    test.same(encode({ optionalInt32: 0 }), [16, 0], "should still emit proto3 optional presence");
+
+    test.end();
+});


### PR DESCRIPTION
A proto3 singular scalar set to its **default** value is incorrectly serialized onto the wire when the type is built via `parse(proto).root` or `new Root().addJSON(json)` and encoded without first calling `resolveAll()`.

```js
const M = protobuf.parse('syntax="proto3"; message M { int32 i32=1; string s=2; bool b=3; }')
  .root.lookupType("M");

M.encode({ i32: 0 }).finish()    // [8, 0]   — spec requires []
M.encode({ s: "" }).finish()     // [18, 0]  — spec requires []
M.encode({ b: false }).finish()  // [24, 0]  — spec requires []
M.encode({ i32: 5 }).finish()    // [8, 5]   — correct
```

Calling `root.resolveAll()` first (or using `load()`/`loadSync()`/`fromJSON()`, which resolve internally) produces the correct `[]`, so only the lazy `parse().root` encode path is affected.

### Cause
`Type#setup()` — the lazy initializer that builds the encoder on first `encode()` — resolves field **types** (`field.resolve()`) but never resolves **feature defaults**. So at codegen time `field._features.field_presence` is still `undefined`, and `Field#hasPresence` returns `undefined !== "IMPLICIT"` → `true`. The generated encoder then takes the presence-tracking branch (no default-value check) for an implicit-presence field and emits its default.

### Impact
Non-canonical proto3 output from the most common inline-proto path: larger payloads, and byte-mismatches against peers that omit defaults (Go/C++/Python, and protobuf.js's own `load()`), which breaks deterministic serialization, signing/hashing of serialized bytes, and golden-file/conformance comparisons. Decoding is unaffected.

### Fix
Resolve feature defaults in `setup()` before the codecs are generated — the same resolution `load()`/`loadSync()`/`fromJSON()` already perform — so `parse().root` produces the same wire form. Verified across syntaxes: proto3 implicit fields now omit defaults (`[]`); proto2, proto3 `optional`, and editions explicit-presence fields still emit them (`[8,0]`); `-0.0` is still preserved.

### Tests
Added a `comp_optional` case mirroring the existing "implicit scalar conversion defaults" test but **without** the `resolveAll()` call. It fails on the current code (`[8,0]`…) and passes with the fix. Full `test:sources` green (2723 passing, 0 failing); no regressions.
