### PR TITLE
fix: Filter Any type_url lookups to message types

### DIFF
--- a/src/wrappers.js
+++ b/src/wrappers.js
@@ -45,7 +45,7 @@ wrappers[".google.protobuf.Any"] = {
         if (object && object["@type"]) {
              // Only use fully qualified type name after the last '/'
             var name = object["@type"].substring(object["@type"].lastIndexOf("/") + 1);
-            var type = this.lookup(name);
+            var type = this.lookup(name, [ this.constructor ]);
             /* istanbul ignore else */
             if (type) {
                 // type_url does not accept leading "."
@@ -81,7 +81,7 @@ wrappers[".google.protobuf.Any"] = {
             name = message.type_url.substring(message.type_url.lastIndexOf("/") + 1);
             // Separate the prefix used
             prefix = message.type_url.substring(0, message.type_url.lastIndexOf("/") + 1);
-            var type = this.lookup(name);
+            var type = this.lookup(name, [ this.constructor ]);
             /* istanbul ignore else */
             if (type)
                 message = type.decode(message.value, undefined, undefined, depth + 1);

--- a/tests/comp_google_protobuf_any.js
+++ b/tests/comp_google_protobuf_any.js
@@ -19,6 +19,22 @@ var root = new protobuf.Root().addJSON(protobuf.common["google/protobuf/any.prot
             }
         }
     },
+    Status: {
+        values: {
+            UNKNOWN: 0
+        }
+    },
+    Svc: {
+        methods: {
+            Call: {
+                requestType: "Bar",
+                responseType: "Bar"
+            }
+        }
+    },
+    Ns: {
+        nested: {}
+    },
     Loop: {
         fields: {
             next: {
@@ -68,6 +84,30 @@ tape.test("google.protobuf.Any", function(test) {
     });
     obj = Foo.toObject(baz, { json: true });
     test.same(obj.foo, { "@type": "type.someurl.com/Bar", bar: "a" }, "should keep prefix in type url");
+
+    test.end();
+});
+
+tape.test("google.protobuf.Any - ignores non-message type_url targets", function(test) {
+
+    [ ".Status", ".Svc", ".Ns" ].forEach(function(typeUrl) {
+        var any = Any.fromObject({
+            "@type": typeUrl,
+            bar: "a"
+        });
+        test.same(any, {}, "should not unwrap " + typeUrl + " in fromObject");
+    });
+
+    [ "type.googleapis.com/Status", "type.googleapis.com/Svc", "type.googleapis.com/Ns" ].forEach(function(typeUrl) {
+        var any = Any.create({
+            type_url: typeUrl,
+            value: protobuf.util.newBuffer([10, 1, 97])
+        });
+        test.same(Any.toObject(any, { json: true }), {
+            type_url: typeUrl,
+            value: protobuf.util.newBuffer([10, 1, 97])
+        }, "should not unwrap " + typeUrl + " in toObject");
+    });
 
     test.end();
 });


### PR DESCRIPTION
Filters `google.protobuf.Any` wrapper `type_url` resolution to message types in both `fromObject` and `toObject` instead of attempting to use enums, services, or namespaces as message types.

Preserves the existing fallback behavior for unresolved `type_url`s: when the target is not a message type, the `Any` value remains represented as `type_url` plus raw `value` bytes.