### PR TITLE
fix: escape bytes field default value in generated toObject (GHSA-66ff-xgx4-vchm)

### DIFF
--- a/src/converter.js
+++ b/src/converter.js
@@ -245,11 +245,11 @@ converter.toObject = function toObject(mtype) {
         ("}else")
             ("d%s=o.longs===String?%j:%i", prop, field.typeDefault.toString(), field.typeDefault.toNumber());
             else if (field.bytes) {
-                var arrayDefault = "[" + Array.prototype.slice.call(field.typeDefault).join(",") + "]";
+                var arrayDefault = Array.prototype.slice.call(field.typeDefault);
                 gen
         ("if(o.bytes===String)d%s=%j", prop, String.fromCharCode.apply(String, field.typeDefault))
         ("else{")
-            ("d%s=%s", prop, arrayDefault)
+            ("d%s=%j", prop, arrayDefault)
             ("if(o.bytes!==Array)d%s=util.newBuffer(d%s)", prop, prop)
         ("}");
             } else gen

--- a/tests/api_converter_bytes_default.js
+++ b/tests/api_converter_bytes_default.js
@@ -1,0 +1,29 @@
+var tape = require("tape");
+
+var protobuf = require("..");
+
+// A schema-controlled, non-string default value for a bytes field must not
+// reach the generated toObject conversion code unescaped. See GHSA-66ff-xgx4-vchm.
+tape.test("converter - bytes field default is not emitted as raw code", function(test) {
+
+    var root = protobuf.Root.fromJSON({
+        nested: {
+            Test: {
+                fields: {
+                    b: {
+                        type: "bytes",
+                        id: 1,
+                        options: { "default": ["1];test.fail('bytes default executed as code');void[2"] }
+                    }
+                }
+            }
+        }
+    });
+
+    var Test = root.lookupType("Test");
+    var obj = Test.toObject(Test.create(), { defaults: true, bytes: Array });
+
+    test.same(obj.b, ["1];test.fail('bytes default executed as code');void[2"], "should keep the default as data, not execute it");
+
+    test.end();
+});


### PR DESCRIPTION
The 6.x line still generates `toObject` code that writes a bytes field's default value into the generated function as code. A schema-controlled, non-string default for a `bytes` field reaches the generated conversion function unescaped, so a crafted descriptor can run arbitrary JavaScript (GHSA-66ff-xgx4-vchm / CVE-2026-44293).

This was fixed on 7.x and 8.x in 75392ea1, released in `protobufjs-v7.5.6` and `protobufjs-v8.0.2`, but the same change was not carried to the 6.11.x line. 6.11.x is still published as the `latest-6` dist-tag (6.11.6, May 2026), and 6.11.6 only picked up the type-name filter from that batch, not this one.

### Root cause

In `converter.toObject`, the bytes default was turned into a literal string `"[" + slice(typeDefault).join(",") + "]"` and emitted with `%s`, which is inserted into the generated function body as-is. `field.js` only converts a default to a buffer when it is a string, so a non-string default (for example an array supplied through a JSON descriptor) keeps its raw value, and the joined text can close the array literal and append statements.

### Fix

Mirror the 7.x/8.x change: keep the default as an array and emit it with `%j` instead of building the literal by hand and emitting it with `%s`.

### Reproduction (published-version layer)

```js
const protobuf = require("protobufjs");
const root = protobuf.Root.fromJSON({ nested: { Test: { fields: {
  b: { type: "bytes", id: 1, options: { default: ["1];globalThis.PWNED=true;void[2"] } }
} } } });
const Test = root.lookupType("Test");
Test.toObject(Test.create(), { defaults: true, bytes: Array });
console.log(globalThis.PWNED); // 6.11.6: true,  7.5.6 / 8.0.2: undefined
```

### Verification

Added a regression test in `tests/api_converter_bytes_default.js`. Reverting only the `src/converter.js` change makes that test fail (the injected code runs inside the generated `toObject`); with the change it passes. The full source suite is green (1248/1248). For ordinary bytes defaults the generated output is unchanged, since `%j` of a numeric byte array produces the same text the old code built by hand.

Refs: GHSA-66ff-xgx4-vchm, CVE-2026-44293, 75392ea1
