### PR TITLE
fix: handle EOF during options parsing

### DIFF
--- a/src/parse.js
+++ b/src/parse.js
@@ -745,6 +745,9 @@ function parse(source, root, options) {
             }
 
             while (token !== "=") {
+                if (token === null) {
+                    throw illegal(token, "end of input");
+                }
                 if (token === "(") {
                     var parensValue = next();
                     skip(")");

--- a/tests/comp_options-parse.js
+++ b/tests/comp_options-parse.js
@@ -1,6 +1,5 @@
 var tape = require("tape");
 var protobuf = require("..");
-var childProcess = require("child_process");
 
 tape.test("Options", function (test) {
     var root = protobuf.loadSync("tests/data/options_test.proto");
@@ -166,21 +165,7 @@ tape.test("Options", function (test) {
     });
 
     test.test(test.name + " - unterminated option name", function (test) {
-        var result = childProcess.spawnSync(process.execPath, ["-e",
-            "var protobuf = require(process.cwd());" +
-            "try {" +
-            "  protobuf.parse('option foo');" +
-            "  process.exit(1);" +
-            "} catch (e) {" +
-            "  process.exit(0);" +
-            "}"
-        ], {
-            cwd: process.cwd(),
-            timeout: 1000
-        });
-
-        test.error(result.error, "should terminate before timeout");
-        test.equal(result.status, 0, "should throw for an unterminated option name");
+        test.throws(() => { protobuf.parse('option foo')});
         test.end();
     });
 

--- a/tests/comp_options-parse.js
+++ b/tests/comp_options-parse.js
@@ -1,5 +1,6 @@
 var tape = require("tape");
 var protobuf = require("..");
+var childProcess = require("child_process");
 
 tape.test("Options", function (test) {
     var root = protobuf.loadSync("tests/data/options_test.proto");
@@ -161,6 +162,25 @@ tape.test("Options", function (test) {
 
     test.test(test.name + " - invalid option", function (test) {
         test.throws(() => { protobuf.parse("option (foo).whatever = {")});
+        test.end();
+    });
+
+    test.test(test.name + " - unterminated option name", function (test) {
+        var result = childProcess.spawnSync(process.execPath, ["-e",
+            "var protobuf = require(process.cwd());" +
+            "try {" +
+            "  protobuf.parse('option foo');" +
+            "  process.exit(1);" +
+            "} catch (e) {" +
+            "  process.exit(0);" +
+            "}"
+        ], {
+            cwd: process.cwd(),
+            timeout: 1000
+        });
+
+        test.error(result.error, "should terminate before timeout");
+        test.equal(result.status, 0, "should throw for an unterminated option name");
         test.end();
     });
 


### PR DESCRIPTION
Incomplete option in the proto file might cause an infinite loop when parsing. Follow up for #1923.