### PR TITLE
perf: batch String.fromCharCode in @protobufjs/utf8 read (7.x)

### DIFF
--- a/lib/utf8/index.js
+++ b/lib/utf8/index.js
@@ -39,34 +39,45 @@ utf8.length = function utf8_length(string) {
  * @returns {string} String read
  */
 utf8.read = function utf8_read(buffer, start, end) {
-    if (end - start < 1) {
+    if (end - start < 1)
         return "";
-    }
-
-    var str = "";
-    for (var i = start; i < end;) {
-        var t = buffer[i++];
+    // Batch code units and flush via String.fromCharCode.apply in 8192-unit
+    // chunks to avoid the per-character ConsString buildup of `str += ...`.
+    var parts = null,
+        chunk = [],
+        i = 0, // chunk write index
+        t, t2, c2, c3;
+    while (start < end) {
+        t = buffer[start++];
         if (t <= 0x7F) {
-            str += String.fromCharCode(t);
+            chunk[i++] = t;
         } else if (t >= 0xC0 && t < 0xE0) {
-            var c2 = (t & 0x1F) << 6 | buffer[i++] & 0x3F;
-            str += c2 >= 0x80 ? String.fromCharCode(c2) : replacementChar;
+            c2 = (t & 0x1F) << 6 | buffer[start++] & 0x3F;
+            chunk[i++] = c2 >= 0x80 ? c2 : 0xFFFD;
         } else if (t >= 0xE0 && t < 0xF0) {
-            var c3 = (t & 0xF) << 12 | (buffer[i++] & 0x3F) << 6 | buffer[i++] & 0x3F;
-            str += c3 >= 0x800 ? String.fromCharCode(c3) : replacementChar;
+            c3 = (t & 0xF) << 12 | (buffer[start++] & 0x3F) << 6 | buffer[start++] & 0x3F;
+            chunk[i++] = c3 >= 0x800 ? c3 : 0xFFFD;
         } else if (t >= 0xF0) {
-            var t2 = (t & 7) << 18 | (buffer[i++] & 0x3F) << 12 | (buffer[i++] & 0x3F) << 6 | buffer[i++] & 0x3F;
+            t2 = (t & 7) << 18 | (buffer[start++] & 0x3F) << 12 | (buffer[start++] & 0x3F) << 6 | buffer[start++] & 0x3F;
             if (t2 < 0x10000 || t2 > 0x10FFFF)
-                str += replacementChar;
+                chunk[i++] = 0xFFFD;
             else {
                 t2 -= 0x10000;
-                str += String.fromCharCode(0xD800 + (t2 >> 10));
-                str += String.fromCharCode(0xDC00 + (t2 & 0x3FF));
+                chunk[i++] = 0xD800 + (t2 >> 10);
+                chunk[i++] = 0xDC00 + (t2 & 0x3FF);
             }
         }
+        if (i > 8191) {
+            (parts || (parts = [])).push(String.fromCharCode.apply(String, chunk.slice(0, i)));
+            i = 0;
+        }
     }
-
-    return str;
+    if (parts) {
+        if (i)
+            parts.push(String.fromCharCode.apply(String, chunk.slice(0, i)));
+        return parts.join("");
+    }
+    return String.fromCharCode.apply(String, chunk.slice(0, i));
 };
 
 /**

--- a/lib/utf8/index.js
+++ b/lib/utf8/index.js
@@ -6,7 +6,7 @@
  * @namespace
  */
 var utf8 = exports,
-    replacementChar = "\ufffd";
+    replacementCharCode = 0xFFFD; // U+FFFD REPLACEMENT CHARACTER
 
 /**
  * Calculates the UTF8 byte length of a string.
@@ -53,14 +53,14 @@ utf8.read = function utf8_read(buffer, start, end) {
             chunk[i++] = t;
         } else if (t >= 0xC0 && t < 0xE0) {
             c2 = (t & 0x1F) << 6 | buffer[start++] & 0x3F;
-            chunk[i++] = c2 >= 0x80 ? c2 : 0xFFFD;
+            chunk[i++] = c2 >= 0x80 ? c2 : replacementCharCode;
         } else if (t >= 0xE0 && t < 0xF0) {
             c3 = (t & 0xF) << 12 | (buffer[start++] & 0x3F) << 6 | buffer[start++] & 0x3F;
-            chunk[i++] = c3 >= 0x800 ? c3 : 0xFFFD;
+            chunk[i++] = c3 >= 0x800 ? c3 : replacementCharCode;
         } else if (t >= 0xF0) {
             t2 = (t & 7) << 18 | (buffer[start++] & 0x3F) << 12 | (buffer[start++] & 0x3F) << 6 | buffer[start++] & 0x3F;
             if (t2 < 0x10000 || t2 > 0x10FFFF)
-                chunk[i++] = 0xFFFD;
+                chunk[i++] = replacementCharCode;
             else {
                 t2 -= 0x10000;
                 chunk[i++] = 0xD800 + (t2 >> 10);

--- a/lib/utf8/tests/index.js
+++ b/lib/utf8/tests/index.js
@@ -47,6 +47,11 @@ tape.test("utf8", function(test) {
             test.equal(comp, "\ufffd", "should decode overlong UTF-8 sequences as replacement characters");
         });
 
+        var longMultibyteStr = "\u20ac\u00df\u7a7a\u03bb\ud835\udd4f".repeat(20000); // 3-byte, 2-byte and surrogate-pair code points
+        var longMultibyte = Buffer.from(longMultibyteStr, "utf8");
+        comp = utf8.read(longMultibyte, 0, longMultibyte.length);
+        test.equal(comp, longMultibyteStr, "should decode a large multibyte string spanning many flush boundaries");
+
         test.end();
     });
 


### PR DESCRIPTION
Follow-up to #2354, targeting the standalone `@protobufjs/utf8` package on `protobufjs-v7.x` (as suggested there).

## Problem

The standalone `@protobufjs/utf8` package — depended on by all protobufjs 7.x consumers — builds the decoded string with per-character `str += String.fromCharCode(...)`. For a large string this makes V8 construct a deep tree of [`ConsString`](https://gist.github.com/mraleph/3397008) rope nodes, so decode becomes super-linear and churns a large amount of short-lived garbage (heavy GC pressure). This is the same shape as #2020, and it regressed in `1.1.1` relative to the batched `1.1.0` implementation.

Unlike the 8.x line, the 7.x standalone package has no ASCII fast path, so **every** string over a few KB hits this — ASCII or not.

## Change

Accumulate code units into a chunk array and flush via `String.fromCharCode.apply` in 8192-unit batches — the same strategy `1.1.0` used. Validation is unchanged: CVE-2026-44288 overlong / out-of-range sequences still decode to U+FFFD.

The intermediate flush slices to the write index (`chunk.slice(0, i)`), so a surrogate pair straddling the 8192-unit boundary (which writes 2 units and can push the index 8191 → 8193) cannot leave a stale trailing unit behind. The existing `surrogate_pair_bug.txt` test covers exactly this case.

## Benchmark

2 MB all-`λ` (U+03BB) string, 20 iterations, Node 26:

| | ms/read |
|---|---|
| before (per-char) | ~80 |
| after (batched) | ~6.8 |

**~11× faster**; allocation drops from O(n) rope nodes to ~ceil(n/8192) intermediate strings.

## Tests

`node lib/utf8/tests/index.js` → 16/16 pass, including the existing surrogate-pair-over-chunk case and a new large-multibyte string spanning many flush boundaries.

Related: #2354, #2353, #2020, CVE-2026-44288 (GHSA-q6x5-8v7m-xcrf)