### PR TITLE
fix: handle EOF during options parsing (#2352)

### DIFF
--- a/src/parse.js
+++ b/src/parse.js
@@ -678,6 +678,9 @@ function parse(source, root, options) {
             }
 
             while (token !== "=") {
+                if (token === null) {
+                    throw illegal(token, "end of input");
+                }
                 if (token === "(") {
                     var parensValue = next();
                     skip(")");

--- a/tests/comp_options-parse.js
+++ b/tests/comp_options-parse.js
@@ -162,6 +162,11 @@ tape.test("Options", function (test) {
         test.end();
     });
 
+    test.test(test.name + " - unterminated option name", function (test) {
+        test.throws(() => { protobuf.parse('option foo')});
+        test.end();
+    });
+
     test.test(test.name + " - reserved aggregate option keys", function(test) {
         var parsed = protobuf.parse(
             "syntax = \"proto2\";" +


### PR DESCRIPTION
Backporting the fix from #2352 to the 7.x branch.