### PR TITLE
fix: reject truncated declarations without TypeError

### DIFF
--- a/src/parse.js
+++ b/src/parse.js
@@ -220,6 +220,9 @@ function parse(source, root, options) {
     }
 
     function parseId(token, acceptNegative, max) {
+        if (token === null) {
+            throw illegal(token, "end of input");
+        }
         switch (token) {
             case "max": case "MAX": case "Max":
                 return max || maxFieldId;
@@ -456,6 +459,9 @@ function parse(source, root, options) {
 
     function parseField(parent, rule, extend, depth) {
         var type = next();
+        if (type === null) {
+            throw illegal(type, "end of input");
+        }
         if (type === "group") {
             parseGroup(parent, rule, extend, depth);
             return;
@@ -467,8 +473,12 @@ function parse(source, root, options) {
         //    package  .subpackage field       tokens: "package" ".subpackage" [TYPE NAME ENDS HERE] "field"
         // Keep reading tokens until we get a type name with no period at the end,
         // and the next token does not start with a period.
-        while (type.endsWith(".") || peek().startsWith(".")) {
-            type += next();
+        while (type.endsWith(".") || (peek() || "").startsWith(".")) {
+            var part = next();
+            if (part === null) {
+                throw illegal(part, "end of input");
+            }
+            type += part;
         }
 
         /* istanbul ignore if */
@@ -476,6 +486,9 @@ function parse(source, root, options) {
             throw illegal(type, "type");
 
         var name = next();
+        if (name === null) {
+            throw illegal(name, "end of input");
+        }
 
         /* istanbul ignore if */
 

--- a/src/parse.js
+++ b/src/parse.js
@@ -255,7 +255,7 @@ function parse(source, root, options) {
         pkg = next();
 
         /* istanbul ignore if */
-        if (!typeRefRe.test(pkg))
+        if (pkg === null || !typeRefRe.test(pkg))
             throw illegal(pkg, "name");
 
         ptr = ptr.define(pkg);
@@ -392,7 +392,7 @@ function parse(source, root, options) {
             throw Error("max depth exceeded");
 
         /* istanbul ignore if */
-        if (!nameRe.test(token = next()))
+        if ((token = next()) === null || !nameRe.test(token))
             throw illegal(token, "type name");
 
         var type = new Type(token);
@@ -541,7 +541,7 @@ function parse(source, root, options) {
         var name = next();
 
         /* istanbul ignore if */
-        if (!nameRe.test(name))
+        if (name === null || !nameRe.test(name))
             throw illegal(name, "name");
 
         var fieldName = util.lcFirst(name);
@@ -639,7 +639,7 @@ function parse(source, root, options) {
         var name = next();
 
         /* istanbul ignore if */
-        if (!nameRe.test(name))
+        if (name === null || !nameRe.test(name))
             throw illegal(name, "name");
 
         skip("=");
@@ -666,7 +666,7 @@ function parse(source, root, options) {
     function parseOneOf(parent, token, depth) {
 
         /* istanbul ignore if */
-        if (!nameRe.test(token = next()))
+        if ((token = next()) === null || !nameRe.test(token))
             throw illegal(token, "name");
 
         var oneof = new OneOf(applyCase(token));
@@ -685,7 +685,7 @@ function parse(source, root, options) {
     function parseEnum(parent, token) {
 
         /* istanbul ignore if */
-        if (!nameRe.test(token = next()))
+        if ((token = next()) === null || !nameRe.test(token))
             throw illegal(token, "name");
 
         var enm = new Enum(token);
@@ -897,7 +897,7 @@ function parse(source, root, options) {
             throw Error("max depth exceeded");
 
         /* istanbul ignore if */
-        if (!nameRe.test(token = next()))
+        if ((token = next()) === null || !nameRe.test(token))
             throw illegal(token, "service name");
 
         var service = new Service(token);
@@ -975,7 +975,7 @@ function parse(source, root, options) {
     function parseExtension(parent, token, depth) {
 
         /* istanbul ignore if */
-        if (!typeRefRe.test(token = next()))
+        if ((token = next()) === null || !typeRefRe.test(token))
             throw illegal(token, "reference");
 
         var reference = token;

--- a/tests/comp_parse-uncommon.js
+++ b/tests/comp_parse-uncommon.js
@@ -192,5 +192,13 @@ tape.test("EOF / truncated input", function(test) {
     throwsIllegalNotTypeError("message M { repeated int32 f = ", "should reject missing field id");
     throwsIllegalNotTypeError("message M { repeated ", "should reject missing field type");
     throwsIllegalNotTypeError("message M { repeated int32", "should reject missing field name");
+    throwsIllegalNotTypeError("message ", "should reject missing message type name");
+    throwsIllegalNotTypeError("message M { oneof ", "should reject missing oneof name");
+    throwsIllegalNotTypeError("message M { optional group ", "should reject missing group name");
+    throwsIllegalNotTypeError("message M { map<string, Foo> ", "should reject missing map field name");
+    throwsIllegalNotTypeError("enum ", "should reject missing enum name");
+    throwsIllegalNotTypeError("service ", "should reject missing service name");
+    throwsIllegalNotTypeError("extend ", "should reject missing extend reference");
+    throwsIllegalNotTypeError("package ", "should reject missing package name");
     test.end();
 });

--- a/tests/comp_parse-uncommon.js
+++ b/tests/comp_parse-uncommon.js
@@ -200,5 +200,7 @@ tape.test("EOF / truncated input", function(test) {
     throwsIllegalNotTypeError("service ", "should reject missing service name");
     throwsIllegalNotTypeError("extend ", "should reject missing extend reference");
     throwsIllegalNotTypeError("package ", "should reject missing package name");
+    throwsIllegalNotTypeError("message M { reserved ", "should reject missing reserved range");
+    throwsIllegalNotTypeError("message M { optional Foo.", "should reject truncated dotted field type");
     test.end();
 });

--- a/tests/comp_parse-uncommon.js
+++ b/tests/comp_parse-uncommon.js
@@ -177,3 +177,20 @@ tape.test("parser nesting", function(test) {
     test.end();
 });
 
+tape.test("EOF / truncated input", function(test) {
+    function throwsIllegalNotTypeError(source, message) {
+        test.throws(function() {
+            try {
+                protobuf.parse(source);
+            } catch (err) {
+                test.notEqual(err && err.name, "TypeError", message + " should not throw TypeError");
+                throw err;
+            }
+        }, /illegal/, message);
+    }
+
+    throwsIllegalNotTypeError("message M { repeated int32 f = ", "should reject missing field id");
+    throwsIllegalNotTypeError("message M { repeated ", "should reject missing field type");
+    throwsIllegalNotTypeError("message M { repeated int32", "should reject missing field name");
+    test.end();
+});


### PR DESCRIPTION
Truncated `.proto` input could hit parser null reads and throw a raw `TypeError` instead of the parser's normal `illegal ...` error. Several guards were written `if (!nameRe.test(token = next()))`, which a null end-of-input token slips past because `nameRe.test(null)` is `true` (`null` stringifies to `"null"`) — so the null reached a downstream deref and crashed.

This keeps those EOF cases on the same catchable parse-error path as the options guard from #2352. It covers the field paths (type, name, id) plus the remaining statements that had the same gap: `oneof`, `group`, map fields, top-level message/enum/service names, `extend` reference, and `package`. Valid input is unchanged.

I checked each truncated input against the old `TypeError` path, added parse tests for them, then ran `npm run lint:sources`, `npm run test:sources`, and `npm test`.
