### PR TITLE
fix: Preserve parsed json_name in field options

### DIFF
--- a/src/parse.js
+++ b/src/parse.js
@@ -867,15 +867,12 @@ function parse(source, root, options) {
         // lift json_name onto Field
         if (name === "json_name" && parent instanceof Field) {
             parent.jsonName = value;
-            return;
         }
         if (parent.setOption)
             parent.setOption(name, value);
     }
 
     function setParsedOption(parent, name, value, propName) {
-        if (name === "json_name" && parent instanceof Field)
-            return; // lifted onto Field#jsonName above
         if (parent.setParsedOption)
             parent.setParsedOption(name, value, propName);
     }

--- a/tests/comp_options-parse.js
+++ b/tests/comp_options-parse.js
@@ -190,3 +190,13 @@ tape.test("Options", function (test) {
 
     test.end();
 });
+
+tape.test("json_name field option", function(test) {
+    var root = protobuf.parse('syntax = "proto3"; message Test { string user_name = 1 [json_name = "customUserName"]; }').root;
+    var field = root.lookupType("Test").fields.userName;
+
+    test.equal(field.jsonName, "customUserName", "should populate Field#jsonName");
+    test.equal(field.options.json_name, "customUserName", "should preserve the declared field option");
+    test.same(field.parsedOptions, [{ json_name: "customUserName" }], "should preserve parsed option metadata");
+    test.end();
+});


### PR DESCRIPTION
Preserves declared `[json_name = "..."]` field options while still lifting the value onto `Field#jsonName`.

Fixes #2350