### PR TITLE
fix: merge repeated message-valued fields within map entries

### DIFF
--- a/src/decoder.js
+++ b/src/decoder.js
@@ -102,7 +102,7 @@ function decoder(mtype) {
                                 ("break");
 
             if (types.basic[type] === undefined) gen
-                            ("v=types[%i].decode(r,r.uint32(),undefined,q+1)", i); // can't be groups
+                            ("v=types[%i].decode(r,r.uint32(),undefined,q+1,v)", i); // can't be groups
             else gen
                             ("v=r.%s()", type === "string" ? stringMethod(field) : type);
 

--- a/tests/comp_maps.js
+++ b/tests/comp_maps.js
@@ -105,6 +105,27 @@ tape.test("maps", function(test) {
         test.end();
     });
 
+    test.test(test.name + " - repeated message values merge", function(test) {
+
+        var dec = Outer.decode(Uint8Array.of(
+            0x0a, 0x12,
+            0x0a, 0x01, 0x61,
+            0x12, 0x08, 0x0a, 0x06, 0x6d, 0x65, 0x72, 0x67, 0x65, 0x64,
+            0x12, 0x03, 0x12, 0x01, 0x78
+        ));
+
+        test.deepEqual(Outer.toObject(dec), {
+            value: {
+                a: {
+                    key: "merged",
+                    values: [ "x" ]
+                }
+            }
+        }, "should merge repeated message-valued map entry fields");
+
+        test.end();
+    });
+
     test.test(test.name + " - special string key", function(test) {
 
         var map = {};

--- a/tests/comp_static_maps.js
+++ b/tests/comp_static_maps.js
@@ -17,3 +17,25 @@ tape.test("static maps - omitted message value", function(test) {
 
     test.end();
 });
+
+tape.test("static maps - repeated message values merge", function(test) {
+
+    var TestMapFields = staticRoot.jspb.test.TestMapFieldsNoBinary;
+
+    var dec = TestMapFields.decode(Uint8Array.of(
+        0x3a, 0x09,
+        0x0a, 0x01, 0x61,
+        0x12, 0x03, 0x08, 0x96, 0x01,
+        0x12, 0x00
+    ));
+
+    test.deepEqual(TestMapFields.toObject(dec), {
+        mapStringMsg: {
+            a: {
+                foo: 150
+            }
+        }
+    }, "should merge repeated message-valued map entry fields");
+
+    test.end();
+});

--- a/tests/data/test.js
+++ b/tests/data/test.js
@@ -10090,7 +10090,7 @@ $root.jspb = (function() {
                                 case 2:
                                     if (wireType !== 2)
                                         break;
-                                    value = $root.jspb.test.MapValueMessageNoBinary.decode(reader, reader.uint32(), $undefined, _depth + 1);
+                                    value = $root.jspb.test.MapValueMessageNoBinary.decode(reader, reader.uint32(), $undefined, _depth + 1, value);
                                     continue;
                                 }
                                 reader.skipType(wireType, _depth, tag2);
@@ -10210,7 +10210,7 @@ $root.jspb = (function() {
                                 case 2:
                                     if (wireType !== 2)
                                         break;
-                                    value = $root.jspb.test.TestMapFieldsNoBinary.decode(reader, reader.uint32(), $undefined, _depth + 1);
+                                    value = $root.jspb.test.TestMapFieldsNoBinary.decode(reader, reader.uint32(), $undefined, _depth + 1, value);
                                     continue;
                                 }
                                 reader.skipType(wireType, _depth, tag2);


### PR DESCRIPTION
## Summary

Message-valued map entries currently decode each repeated `value` field occurrence into a new message. When a single synthetic map entry contains the message-valued `value` field more than once, fields from earlier occurrences can be discarded.

This change passes the previously decoded map value as the merge target, matching the existing behavior for ordinary singular embedded-message fields.

## Behavior

For a valid wire payload where one map entry contains two message-valued `value` fields:

```txt
value #1: { key: "merged" }
value #2: { values: ["x"] }
```

Before this change, the first partial message was overwritten:

```js
{ value: { a: { values: ["x"] } } }
```

After this change, the message values are merged:

```js
{ value: { a: { key: "merged", values: ["x"] } } }
```

The merge target is reset for each synthetic map entry, so separate map entries and duplicate map keys keep their existing behavior.

## Tests

Added regression coverage for both decode paths affected by this generator change:

- `tests/comp_maps.js` covers the runtime/reflection decoder.
- `tests/comp_static_maps.js` covers the generated static decoder.

Both tests construct a valid wire payload where a single synthetic map entry contains the message-valued `value` field more than once. The first occurrence contains one field, and the second occurrence contains another field. The expected behavior is that those embedded message values are merged, not overwritten.

Regenerated the affected static fixture with:

```sh
npm run build:tests
```

This updates `tests/data/test.js` so the generated static decoder passes the existing map value as the merge target.