### PR TITLE
chore: Simplify CLI dependencies and update Renovate config

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -9,7 +9,6 @@
       "version": "2.6.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "chalk": "^4.0.0",
         "escodegen": "^1.13.0",
         "espree": "^9.6.1",
         "estraverse": "^5.1.0",
@@ -30,7 +29,7 @@
         "node": ">=12.0.0"
       },
       "peerDependencies": {
-        "protobufjs": "^8.5.0"
+        "protobufjs": "^8.7.0"
       }
     },
     "..": {
@@ -49,7 +48,7 @@
         "bundle-collapser": "^1.3.0",
         "escodegen": "^1.13.0",
         "eslint": "^10.0.0",
-        "eslint-plugin-jsdoc": "^62.9.0",
+        "eslint-plugin-jsdoc": "^63.0.0",
         "espree": "^9.0.0",
         "estraverse": "^5.1.0",
         "gh-pages": "^6.0.0",
@@ -173,20 +172,6 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
-    "node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -222,37 +207,6 @@
       "engines": {
         "node": ">= 10"
       }
-    },
-    "node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
@@ -399,14 +353,6 @@
       "version": "4.2.10",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
       "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
-    },
-    "node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/inflight": {
       "version": "1.0.6",
@@ -663,17 +609,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/tmp": {
       "version": "0.2.7",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
@@ -792,14 +727,6 @@
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
       "requires": {}
     },
-    "ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "requires": {
-        "color-convert": "^2.0.1"
-      }
-    },
     "argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -830,28 +757,6 @@
       "requires": {
         "lodash": "^4.17.15"
       }
-    },
-    "chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "requires": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      }
-    },
-    "color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "requires": {
-        "color-name": "~1.1.4"
-      }
-    },
-    "color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "deep-is": {
       "version": "0.1.4",
@@ -943,11 +848,6 @@
       "version": "4.2.10",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
       "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
-    },
-    "has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
     },
     "inflight": {
       "version": "1.0.6",
@@ -1106,7 +1006,7 @@
         "bundle-collapser": "^1.3.0",
         "escodegen": "^1.13.0",
         "eslint": "^10.0.0",
-        "eslint-plugin-jsdoc": "^62.9.0",
+        "eslint-plugin-jsdoc": "^63.0.0",
         "espree": "^9.0.0",
         "estraverse": "^5.1.0",
         "gh-pages": "^6.0.0",
@@ -1152,14 +1052,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="
-    },
-    "supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "requires": {
-        "has-flag": "^4.0.0"
-      }
     },
     "tmp": {
       "version": "0.2.7",

--- a/cli/package.json
+++ b/cli/package.json
@@ -23,7 +23,6 @@
     "protobufjs": "^8.7.0"
   },
   "dependencies": {
-    "chalk": "^4.0.0",
     "escodegen": "^1.13.0",
     "espree": "^9.6.1",
     "estraverse": "^5.1.0",

--- a/cli/pbjs.js
+++ b/cli/pbjs.js
@@ -2,13 +2,13 @@
 var path     = require("path"),
     fs       = require("fs"),
     minimist = require("minimist"),
-    chalk    = require("chalk"),
     pkg      = require("./package.json"),
     util     = require("./util"),
     glob     = require("glob"),
     protobuf = require("protobufjs");
 
 var targets  = util.requireAll("./targets");
+var color    = util.color;
 
 var lintDefault = "eslint-disable " + [
     "block-scoped-var",
@@ -234,7 +234,7 @@ exports.main = function main(args, callback) {
             process.stderr.write([
                 "protobuf.js v" + pkg.version + " CLI for JavaScript",
                 "",
-                chalk.bold.white("Translates between file formats and generates static code."),
+                color.bold + color.white + "Translates between file formats and generates static code." + color.reset,
                 "",
                 "  -t, --target     Specifies the target format. Also accepts a path to require a custom target.",
                 "",
@@ -251,7 +251,7 @@ exports.main = function main(args, callback) {
                 "",
                 "  --sparse         Exports only those types referenced from a main file (experimental).",
                 "",
-                chalk.bold.gray("  Module targets only:"),
+                color.bold + color.gray + "  Module targets only:" + color.reset,
                 "",
                 "  -w, --wrap       Specifies the wrapper to use. Also accepts a path to require a custom wrapper.",
                 "",
@@ -271,12 +271,12 @@ exports.main = function main(args, callback) {
                 "",
                 "  --es6            Enables ES6 syntax (const/let instead of var)",
                 "",
-                chalk.bold.gray("  Proto sources only:"),
+                color.bold + color.gray + "  Proto sources only:" + color.reset,
                 "",
                 "  --keep-case      Keeps field casing instead of converting to camel case.",
                 "  --alt-comment    Turns on an alternate comment parsing mode that preserves more comments.",
                 "",
-                chalk.bold.gray("  Static targets only:"),
+                color.bold + color.gray + "  Static targets only:" + color.reset,
                 "",
                 "  --no-create      Does not generate create functions used for reflection compatibility.",
                 "  --no-encode      Does not generate encode functions.",
@@ -296,7 +296,7 @@ exports.main = function main(args, callback) {
                 "  --null-defaults  Default value for optional fields is null instead of zero value.",
                 "  --null-semantics Make nullable fields match protobuf semantics (overrides --null-defaults).",
                 "",
-                "usage: " + chalk.bold.green("pbjs") + " [options] file1.proto file2.json ..." + chalk.gray("  (or pipe)  ") + "other | " + chalk.bold.green("pbjs") + " [options] -",
+                "usage: " + color.bold + color.green + "pbjs" + color.reset + " [options] file1.proto file2.json ..." + color.gray + "  (or pipe)  " + color.reset + "other | " + color.bold + color.green + "pbjs" + color.reset + " [options] -",
                 ""
             ].join("\n"));
         return 1;

--- a/cli/pbts.js
+++ b/cli/pbts.js
@@ -4,9 +4,11 @@ var child_process = require("child_process"),
     fs       = require("fs"),
     pkg      = require("./package.json"),
     minimist = require("minimist"),
-    chalk    = require("chalk"),
+    util     = require("./util"),
     glob     = require("glob"),
     tmp      = require("tmp");
+
+var color = util.color;
 
 /**
  * Runs pbts programmatically.
@@ -72,7 +74,7 @@ function run(options) {
             process.stderr.write([
                 "protobuf.js v" + pkg.version + " CLI for TypeScript",
                 "",
-                chalk.bold.white("Generates TypeScript definitions from annotated JavaScript files."),
+                color.bold + color.white + "Generates TypeScript definitions from annotated JavaScript files." + color.reset,
                 "",
                 "  -o, --out       Saves to a file instead of writing to stdout.",
                 "",
@@ -84,13 +86,13 @@ function run(options) {
                 "",
                 "  --no-comments   Does not output any JSDoc comments.",
                 "",
-                chalk.bold.gray("  Internal flags:"),
+                color.bold + color.gray + "  Internal flags:" + color.reset,
                 "",
                 "  -n, --name      Wraps everything in a module of the specified name.",
                 "",
                 "  -m, --main      Whether building a standalone file without any imports.",
                 "",
-                "usage: " + chalk.bold.green("pbts") + " [options] file1.js file2.js ..." + chalk.bold.gray("  (or)  ") + "other | " + chalk.bold.green("pbts") + " [options] -",
+                "usage: " + color.bold + color.green + "pbts" + color.reset + " [options] file1.js file2.js ..." + color.bold + color.gray + "  (or)  " + color.reset + "other | " + color.bold + color.green + "pbts" + color.reset + " [options] -",
                 ""
             ].join("\n"));
         return 1;

--- a/cli/util.js
+++ b/cli/util.js
@@ -66,42 +66,24 @@ exports.isEsmWrapper = function isEsmWrapper(wrap) {
     return wrap === "esm" || wrap === "es6";
 };
 
-exports.inspect = function inspect(object, indent) {
-    if (!object)
-        return "";
-    var chalk = require("chalk");
-    var sb = [];
-    if (!indent)
-        indent = "";
-    var ind = indent ? indent.substring(0, indent.length - 2) + "└ " : "";
-    sb.push(
-        ind + chalk.bold(object.toString()) + (object.visible ? " (visible)" : ""),
-        indent + chalk.gray("parent: ") + object.parent
-    );
-    if (object instanceof protobuf.Field) {
-        if (object.extend !== undefined)
-            sb.push(indent + chalk.gray("extend: ") + object.extend);
-        if (object.partOf)
-            sb.push(indent + chalk.gray("oneof : ") + object.oneof);
-    }
-    sb.push("");
-    if (object.fieldsArray)
-        object.fieldsArray.forEach(function(field) {
-            sb.push(inspect(field, indent + "  "));
-        });
-    if (object.oneofsArray)
-        object.oneofsArray.forEach(function(oneof) {
-            sb.push(inspect(oneof, indent + "  "));
-        });
-    if (object.methodsArray)
-        object.methodsArray.forEach(function(service) {
-            sb.push(inspect(service, indent + "  "));
-        });
-    if (object.nestedArray)
-        object.nestedArray.forEach(function(nested) {
-            sb.push(inspect(nested, indent + "  "));
-        });
-    return sb.join("\n");
+var env = process.env; // eslint-disable-line no-process-env
+var colorEnabled =
+    env.NO_COLOR === undefined &&
+    env.FORCE_COLOR !== "0" &&
+    (env.FORCE_COLOR !== undefined || process.stderr && process.stderr.isTTY);
+
+exports.color = colorEnabled ? {
+    reset: "\x1b[0m",
+    bold: "\x1b[1m",
+    gray: "\x1b[90m",
+    green: "\x1b[32m",
+    white: "\x1b[37m"
+} : {
+    reset: "",
+    bold: "",
+    gray: "",
+    green: "",
+    white: ""
 };
 
 exports.wrap = function(OUTPUT, options) {

--- a/renovate.json
+++ b/renovate.json
@@ -1,18 +1,63 @@
 {
   "extends": [
-    "config:base",
+    "config:recommended",
     "docker:disable"
   ],
-  "pinVersions": false,
+  "enabledManagers": ["npm", "github-actions"],
+  "dependencyDashboard": true,
+  "dependencyDashboardLabels": ["dependencies"],
+  "addLabels": ["dependencies"],
+  "timezone": "Europe/Berlin",
   "rebaseStalePrs": true,
-  "schedule": [
-    "after 9am and before 3pm"
+  "schedule": ["after 9am and before 3pm"],
+  "ignorePaths": [
+    "lib/jsdoc-template/**"
   ],
-  "gitAuthor": null,
   "packageRules": [
     {
-      "extends": "packages:linters",
-      "groupName": "linters"
+      "matchUpdateTypes": ["major"],
+      "dependencyDashboardApproval": true
+    },
+    {
+      "matchFileNames": ["bench/package.json"],
+      "matchPackageNames": [
+        "@bufbuild/protobuf",
+        "@bufbuild/protoc-gen-es"
+      ],
+      "groupName": "protoc-gen-es benchmark target",
+      "dependencyDashboardApproval": true
+    },
+    {
+      "matchFileNames": ["bench/package.json"],
+      "matchPackageNames": [
+        "google-protobuf",
+        "@protocolbuffers/protoc-gen-js"
+      ],
+      "groupName": "protoc-gen-js benchmark target",
+      "dependencyDashboardApproval": true
+    },
+    {
+      "matchFileNames": ["package.json"],
+      "matchDepTypes": ["dependencies"],
+      "matchUpdateTypes": ["patch", "minor"],
+      "groupName": "runtime dependencies"
+    },
+    {
+      "matchFileNames": ["package.json"],
+      "matchDepTypes": ["devDependencies"],
+      "matchUpdateTypes": ["patch", "minor"],
+      "groupName": "dev dependencies"
+    },
+    {
+      "matchFileNames": ["cli/package.json"],
+      "matchUpdateTypes": ["patch", "minor"],
+      "groupName": "cli dependencies"
+    },
+    {
+      "matchFileNames": ["bench/package.json"],
+      "matchPackageNames": ["benchmark"],
+      "matchUpdateTypes": ["patch", "minor"],
+      "groupName": "bench dependencies"
     }
   ]
 }


### PR DESCRIPTION
Removes the CLI's `chalk` dependency by replacing the small amount of help-text coloring with local ANSI constants, and updates Renovate config so routine dependency PRs are grouped by area, majors require dependency dashboard approval, and Renovate PRs use the `dependencies` label.