### PR TITLE
fix: accept repeated NullValue elements in ProtoJSON

### DIFF
--- a/ext/protojson.js
+++ b/ext/protojson.js
@@ -295,7 +295,7 @@ function readField(field, value, options, depth) {
             throw invalid(field.fullName, value, "expected array");
         var arr = [], i = 0;
         for (; i < value.length; ++i) {
-            if (value[i] === null && !isValueType(field.resolvedType))
+            if (value[i] === null && !isValueType(field.resolvedType) && !isNullValueType(field.resolvedType))
                 throw invalid(field.fullName, null, "null element");
             var el = readSingular(field, value[i], options, depth);
             if (el !== SKIP)
@@ -316,6 +316,10 @@ function readSingular(field, value, options, depth) {
 
 function isValueType(type) {
     return type instanceof Type && type.fullName === ".google.protobuf.Value";
+}
+
+function isNullValueType(type) {
+    return type instanceof Enum && type.fullName === ".google.protobuf.NullValue";
 }
 
 function isImplicitDefault(field, value) {

--- a/tests/api_protojson.js
+++ b/tests/api_protojson.js
@@ -142,6 +142,7 @@ message NullMsg {\
   google.protobuf.Duration duration = 4;\
   google.protobuf.StringValue string_wrapper = 5;\
   google.protobuf.Value value_msg = 6;\
+  repeated google.protobuf.NullValue null_values = 7;\
 }", root);
     return root.resolveAll();
 }
@@ -532,6 +533,23 @@ tape.test("protojson - rejects null repeated elements and map values", function(
     test.throws(function() {
         protojson.fromJson(MapMsg, { stringMap: { key: null } });
     }, /expected string/, "rejects null map value");
+
+    test.end();
+});
+
+tape.test("protojson - round trips repeated google.protobuf.NullValue elements", function(test) {
+    for (var i = 0; i < wktRoots.length; ++i) {
+        var NullMsg = wktRoots[i].root.lookupType("test.NullMsg"),
+            label = wktRoots[i].name,
+            message = protojson.fromJson(NullMsg, {
+                nullValues: [null, null]
+            });
+
+        test.deepEqual(message.nullValues, [0, 0], label + ": parses null elements as NULL_VALUE");
+        test.deepEqual(protojson.toJson(NullMsg, message), {
+            nullValues: [null, null]
+        }, label + ": emits NULL_VALUE elements as null");
+    }
 
     test.end();
 });


### PR DESCRIPTION
## Summary

ProtoJSON currently rejects `null` elements in repeated `google.protobuf.NullValue` fields before enum conversion runs.

Repeated `null` elements are generally rejected, but `google.protobuf.NullValue` is the documented exception because its JSON representation is `null`. This change allows repeated `google.protobuf.NullValue` elements to reach the existing `readEnum` handling, which already converts `null` to `NULL_VALUE`.

## Behavior

Before this change:

```js
protojson.fromJson(NullMsg, {
  nullValues: [null, null]
});
```

throws:

```txt
.test.NullMsg.nullValues: null element: null
```

After this change, the same input parses as:

```js
{
  nullValues: [0, 0]
}
```

and serializes back to:

```js
{
  nullValues: [null, null]
}
```

Ordinary repeated `null` elements remain rejected.

## Tests

Added regression coverage in `tests/api_protojson.js` for repeated `google.protobuf.NullValue` fields.

The test extends the existing `test.NullMsg` fixture with:

```proto
repeated google.protobuf.NullValue null_values = 7;
```

It then verifies both supported well-known-type root paths already used by the ProtoJSON tests:

- parsed `.proto` root
- JSON descriptor root

For each root, the test checks both directions:

- `fromJson` accepts `nullValues: [null, null]` and parses it as `[0, 0]`
- `toJson` serializes `[0, 0]` back as `nullValues: [null, null]`

This specifically covers the bug where repeated `null` elements were rejected before the existing `readEnum` handling could convert `google.protobuf.NullValue` from `null` to `NULL_VALUE`.

Existing tests continue to cover the general rule that ordinary repeated `null` elements are rejected, so this change only adds the documented `google.protobuf.NullValue` exception.