### PR TITLE
fix: base64-encode bytes field defaults in toObject

### DIFF
--- a/src/converter.js
+++ b/src/converter.js
@@ -298,7 +298,7 @@ converter.toObject = function toObject(mtype) {
             else if (field.bytes) {
                 var arrayDefault = Array.prototype.slice.call(field.typeDefault);
                 gen
-        ("if(o.bytes===String)d%s=%j", prop, String.fromCharCode.apply(String, field.typeDefault))
+        ("if(o.bytes===String)d%s=%j", prop, util.base64.encode(field.typeDefault, 0, field.typeDefault.length))
         ("else{")
             ("d%s=%j", prop, arrayDefault)
             ("if(o.bytes!==Array)d%s=util.newBuffer(d%s)", prop, prop)

--- a/tests/api_converters.js
+++ b/tests/api_converters.js
@@ -370,3 +370,22 @@ tape.test("converters", function(test) {
     });
 
 });
+
+tape.test("converters - bytes field default with bytes = String", function(test) {
+    var proto = "syntax = \"proto2\";\
+    message DefaultBytes {\
+        optional bytes bytes_field = 1 [default = \"moo\"];\
+    }";
+    var Message = protobuf.parse(proto).root.lookupType("DefaultBytes");
+
+    var withDefault = Message.toObject(Message.create({}), { defaults: true, bytes: String });
+    var withValue = Message.toObject(Message.create({ bytesField: protobuf.util.newBuffer([109, 111, 111]) }), { defaults: true, bytes: String });
+
+    test.equal(withDefault.bytesField, "bW9v", "should base64 encode the default value");
+    test.equal(withDefault.bytesField, withValue.bytesField, "should match an explicitly set value");
+
+    var back = Message.fromObject(withDefault);
+    test.same(Array.prototype.slice.call(back.bytesField), [109, 111, 111], "should round-trip through fromObject");
+
+    test.end();
+});


### PR DESCRIPTION
`Type#toObject` with `{ bytes: String }` is documented to return base64 strings, and the path for explicitly set values already does. The defaults path built the string with `String.fromCharCode`, which produces a raw latin1 string. A non-empty bytes default (proto2 or editions) came out as binary text that did not match a set value and could not be read back by `fromObject`. `tests/data/test.proto` documents the expected base64 for its `moo` default (`bW9v`).

This encodes the default with `util.base64.encode`, matching the set-value branch. Adds a converter test covering the default, the match with a set value, and the `fromObject` round trip. The empty-default case is unchanged.
