### PR TITLE
fix(cli): Preserve array element union precedence in pbts

### DIFF
--- a/cli/lib/tsd-jsdoc/publish.js
+++ b/cli/lib/tsd-jsdoc/publish.js
@@ -287,7 +287,10 @@ function getTypeOf(element) {
             return "{ [k: " + $1 + "]: " + $2 + " }";
         });
         name = name.replace(/\bArray\.?<([^<>]*)>/gi, function($0, $1) {
-            return $1 + "[]";
+            var elementType = $1.trim();
+            if (splitTypeList(elementType, "|").length > 1 || splitTypeList(elementType, "&").length > 1)
+                elementType = "(" + elementType + ")";
+            return elementType + "[]";
         });
         name = name.replace(/\b(?!Object|Array)([\w$]+)\.<([^<>]*)>/gi, function($0, $1, $2) {
             return $1 + "<" + $2 + ">";

--- a/tests/cli-pbts.js
+++ b/tests/cli-pbts.js
@@ -140,6 +140,26 @@ tape.test("pbts preserves multiline TypeScript @type expressions", function(test
     });
 });
 
+tape.test("pbts preserves array element union precedence", function(test) {
+    var pbts = require("../cli/pbts");
+
+    pbts.process([
+        "/**",
+        " * Repeated long-compatible field shape.",
+        " * @typedef {{",
+        " *   ids?: Array.<number|Long>|null;",
+        " *   combined?: Array.<Foo&Bar>|null;",
+        " * }} Shape",
+        " */"
+    ].join("\n"), [], function(err, tsCode) {
+        test.error(err, "definition generation worked");
+        test.ok(tsCode.indexOf("ids?: (number|Long)[]|null;") >= 0, "parenthesizes array element union");
+        test.equal(tsCode.indexOf("ids?: number|Long[]|null;"), -1, "does not emit union with array-only Long");
+        test.ok(tsCode.indexOf("combined?: (Foo&Bar)[]|null;") >= 0, "parenthesizes array element intersection");
+        test.end();
+    });
+});
+
 tape.test("pbts preserves qualified Object type names", function(test) {
     var pbts = require("../cli/pbts");
 


### PR DESCRIPTION
Fixes incorrect precedence within array types of union or intersection element types when emitting `$Shape`, so `Array.<number|Long>|null` becomes `(number|Long)[]|null` instead of `number|Long[]|null`.

Fixes #2376