### PR TITLE
fix: Parse aggregate objects in option arrays

### DIFF
--- a/src/parse.js
+++ b/src/parse.js
@@ -826,16 +826,21 @@ function parse(source, root, options) {
                     value = parseOptionValue(parent, name + "." + propName, depth + 1);
                 } else if (peek() === "[") {
                     value = [];
-                    var lastValue;
+                    var lastValue,
+                        lastValueIsAggregate;
                     if (skip("[", true)) {
                         if (!skip("]", true)) {
                             do {
-                                lastValue = readValue(true);
+                                lastValueIsAggregate = peek() === "{";
+                                lastValue = lastValueIsAggregate
+                                    ? parseOptionValue(parent, name + "." + propName, depth + 1)
+                                    : readValue(true);
                                 value.push(lastValue);
                             } while (skip(",", true));
                             skip("]");
                             if (typeof lastValue !== "undefined") {
-                                setOption(parent, name + "." + propName, lastValue);
+                                if (!lastValueIsAggregate)
+                                    setOption(parent, name + "." + propName, lastValue);
                             }
                         }
                     }

--- a/tests/comp_options-parse.js
+++ b/tests/comp_options-parse.js
@@ -213,6 +213,31 @@ tape.test("Options", function (test) {
         test.end();
     });
 
+    test.test(test.name + " - aggregate option arrays", function(test) {
+        var root = protobuf.parse(
+            "syntax = \"proto2\";" +
+            "message Test {" +
+            "  optional string value = 1 [(foo) = {" +
+            "    rules: [" +
+            "      { field: \"id\" }," +
+            "      { field: \"display_name\" }" +
+            "    ]" +
+            "  }];" +
+            "}"
+        ).root;
+        var field = root.lookupType("Test").fields.value,
+            option = field.parsedOptions[0]["(foo)"];
+
+        test.same(option, {
+            rules: [
+                { field: "id" },
+                { field: "display_name" }
+            ]
+        }, "should preserve aggregate option arrays");
+        test.equal(field.options["(foo).rules.field"], "display_name", "should keep the last repeated aggregate field in flat options");
+        test.end();
+    });
+
     test.end();
 });
 


### PR DESCRIPTION
Allows aggregate option arrays to contain message literals, e.g. `rules: [{ field: "id" }]`, matching protobuf text-format option syntax.

Fixes #1878