### PR TITLE
fix(cli): Resolve imports from cwd by default

### DIFF
--- a/cli/pbjs.js
+++ b/cli/pbjs.js
@@ -221,6 +221,9 @@ exports.main = function main(args, callback) {
     var files  = argv._,
         paths  = typeof argv.path === "string" ? [ argv.path ] : argv.path || [];
 
+    if (!paths.length)
+        paths.push(".");
+
     // protobuf.js package directory contains additional, otherwise non-bundled google types
     paths.push(path.relative(process.cwd(), path.join(__dirname, "../protobufjs")) || ".");
 

--- a/tests/cli-pbjs.js
+++ b/tests/cli-pbjs.js
@@ -318,6 +318,24 @@ tape.test("pbjs generates correct ES module static-module imports", function(tes
     });
 });
 
+tape.test("pbjs resolves imports from cwd by default", function(test) {
+    cliTest(test, function() {
+        var output = child_process.execFileSync(process.execPath, [
+            path.resolve("cli", "bin", "pbjs"),
+            "-t", "json",
+            path.join("proto", "a.proto"),
+            path.join("proto", "b.proto")
+        ], {
+            cwd: path.resolve("tests", "data", "cli", "default-path"),
+            encoding: "utf8"
+        });
+        var json = JSON.parse(output);
+        test.ok(json.nested.proto.nested.A, "includes imported type");
+        test.ok(json.nested.proto.nested.B, "includes importing type");
+        test.end();
+    });
+});
+
 tape.test("pbjs emits file overview comments on one line", function(test) {
     cliTest(test, function() {
         var root = new protobuf.Root();

--- a/tests/data/cli/default-path/proto/a.proto
+++ b/tests/data/cli/default-path/proto/a.proto
@@ -1,0 +1,5 @@
+syntax = "proto3";
+
+package proto;
+
+message A {}

--- a/tests/data/cli/default-path/proto/b.proto
+++ b/tests/data/cli/default-path/proto/b.proto
@@ -1,0 +1,9 @@
+syntax = "proto3";
+
+package proto;
+
+import "proto/a.proto";
+
+message B {
+  A a = 1;
+}


### PR DESCRIPTION
Makes `pbjs` use the current working directory as its default include path when no `-p/--path` option is provided.

Fixes #1855