### PR TITLE
fix: Parse Any type URLs in aggregate options

### DIFF
--- a/src/parse.js
+++ b/src/parse.js
@@ -803,7 +803,9 @@ function parse(source, root, options) {
                     throw illegal(token, "end of input");
                 if (token === "[") {
                     token = next();
-                    if (token === null || !typeRefRe.test(token))
+                    // Extension name or, for Any, a type URL: "<prefix>/<fully.qualified.Type>".
+                    var slash = token === null ? -1 : token.lastIndexOf("/");
+                    if (token === null || !typeRefRe.test(slash < 0 ? token : token.slice(slash + 1)))
                         throw illegal(token, "name");
                     propName = "[" + token + "]";
                     skip("]");

--- a/tests/comp_options-parse.js
+++ b/tests/comp_options-parse.js
@@ -213,6 +213,39 @@ tape.test("Options", function (test) {
         test.end();
     });
 
+    test.test(test.name + " - aggregate option Any type URL", function(test) {
+        var root = protobuf.parse(
+            "syntax = \"proto2\";" +
+            "message Test {" +
+            "  option (foo) = {" +
+            "    any {" +
+            "      [type.googleapis.com/pkg.Embedded] { s: \"x\" }" +
+            "    }" +
+            "  };" +
+            "}"
+        ).root;
+        var message = root.lookupType("Test"),
+            option = message.parsedOptions[0]["(foo)"];
+
+        test.same(option, {
+            any: { "[type.googleapis.com/pkg.Embedded]": { s: "x" } }
+        }, "should preserve the Any type URL as a bracketed field name");
+        test.equal(message.options["(foo).any.[type.googleapis.com/pkg.Embedded].s"], "x", "should keep the type URL in the flat option key");
+
+        // Like protoc, the type name is the segment after the last "/" and the URL
+        // prefix is opaque, so a multi-segment prefix parses and is preserved as-is.
+        var multi = protobuf.parse(
+            "syntax = \"proto2\";" +
+            "message Test2 {" +
+            "  option (foo) = { any { [example.com/a/b/pkg.Embedded] { s: \"y\" } } };" +
+            "}"
+        ).root.lookupType("Test2").parsedOptions[0]["(foo)"];
+        test.same(multi, {
+            any: { "[example.com/a/b/pkg.Embedded]": { s: "y" } }
+        }, "should accept and preserve a multi-slash type URL prefix");
+        test.end();
+    });
+
     test.end();
 });
 


### PR DESCRIPTION
Support an `Any` written as a type URL, e.g. `[type.googleapis.com/pkg.Msg] { ... }`, by mirroring protoc: Split the key on the last slash and validate the type name, treating the prefix as opaque.

See #1709