### PR TITLE
fix: Apply enum options regardless of declaration order

### DIFF
--- a/src/parse.js
+++ b/src/parse.js
@@ -688,7 +688,8 @@ function parse(source, root, options) {
         if ((token = next()) === null || !nameRe.test(token))
             throw illegal(token, "name");
 
-        var enm = new Enum(token);
+        var enm = new Enum(token),
+            values = [];
         ifBlock(enm, function parseEnum_block(token) {
           switch(token) {
             case ";":
@@ -705,16 +706,18 @@ function parse(source, root, options) {
               break;
 
             default:
-              parseEnumValue(enm, token);
+              values.push(parseEnumValue(token));
           }
         });
+        for (var i = 0; i < values.length; ++i)
+            enm.add(values[i].name, values[i].id, values[i].comment, values[i].options);
         parent.add(enm);
         if (parent === ptr) {
             topLevelObjects.push(enm);
         }
     }
 
-    function parseEnumValue(parent, token) {
+    function parseEnumValue(token) {
 
         /* istanbul ignore if */
         if (!nameRe.test(token))
@@ -746,7 +749,12 @@ function parse(source, root, options) {
         }, function parseEnumValue_line() {
             parseInlineOptions(dummy); // skip
         });
-        parent.add(token, value, dummy.comment, dummy.parsedOptions || dummy.options);
+        return {
+            name: token,
+            id: value,
+            comment: dummy.comment,
+            options: dummy.parsedOptions || dummy.options
+        };
     }
 
     function parseOption(parent, token) {

--- a/tests/comp_parse-uncommon.js
+++ b/tests/comp_parse-uncommon.js
@@ -51,6 +51,27 @@ tape.test("negative enum reserved values", function(test) {
     test.end();
 });
 
+tape.test("enum declarations are order-independent", function(test) {
+    var Enum = protobuf.parse("syntax = \"proto3\"; enum Values { INVALID = 0; UNKNOWN = 0; option allow_alias = true; OK = 1; }").root.lookupEnum("Values");
+    test.same(Object.keys(Enum.values).map(function(name) {
+        return [name, Enum.values[name]];
+    }), [
+        ["INVALID", 0],
+        ["UNKNOWN", 0],
+        ["OK", 1]
+    ], "should allow aliases declared before allow_alias");
+
+    test.throws(function() {
+        protobuf.parse("syntax = \"proto3\"; enum Values { INVALID = 0; UNKNOWN = 0; option allow_alias = false; }");
+    }, /duplicate id 0/, "should reject aliases when allow_alias is false");
+
+    test.throws(function() {
+        protobuf.parse("syntax = \"proto3\"; enum Values { INVALID = 0; RESERVED = 1; reserved 1; }");
+    }, /id 1 is reserved/, "should apply reserved declarations to preceding values");
+
+    test.end();
+});
+
 function traverseTypes(current, fn) {
     if (current instanceof protobuf.Type) // and/or protobuf.Enum, protobuf.Service etc.
         fn(current);


### PR DESCRIPTION
Defers adding enum values until the complete enum block has been parsed, so `allow_alias` and `reserved` declarations apply regardless of where they appear.

Fixes #1521