### PR TITLE
fix(cli): Match declaration imports to generated modules

### DIFF
--- a/cli/pbjs.js
+++ b/cli/pbjs.js
@@ -86,6 +86,10 @@ function normalizeOptions(options) {
     return options;
 }
 
+function getTarget(name) {
+    return Object.prototype.hasOwnProperty.call(targets, name) ? targets[name] : null;
+}
+
 /**
  * Generates JavaScript and optional TypeScript declarations from a root.
  * @param {Root} root Reflected root
@@ -96,7 +100,7 @@ function normalizeOptions(options) {
  */
 exports.generate = function generate(root, options, callback) {
     options = normalizeOptions(options);
-    var target = targets[options.target];
+    var target = getTarget(options.target);
     if (!target) {
         // Require custom target
         try {
@@ -129,7 +133,10 @@ function deriveDtsPath(out) {
 
 function generateDts(root, argv, output, done) {
     function runPbts(jsOutput) {
-        var pbtsArgs = [];
+        var pbtsArgs = [],
+            target = getTarget(argv.target);
+        if (target && target.getDependency)
+            pbtsArgs.push("--import", "\\$protobuf=" + target.getDependency(argv));
         if (argv.target === "json-module")
             pbtsArgs.push("--no-constructor");
         if (!argv.comments)

--- a/cli/targets/json-module.js
+++ b/cli/targets/json-module.js
@@ -11,6 +11,13 @@ var Type      = protobuf.Type,
     Namespace = protobuf.Namespace;
 
 json_module.description = "JSON bundle as a module";
+
+json_module.getDependency = function getDependency(options) {
+    return options.dependency || (util.isEsmWrapper(options.wrap)
+        ? "protobufjs/light.js"
+        : "protobufjs/light");
+};
+
 json_module.defaultExportDoc =
     "/**\n" +
     " * Reflected root namespace.\n" +
@@ -64,9 +71,7 @@ function json_module(root, options, callback) {
         }
 
         output = util.wrap(output.join(""), protobuf.util.merge({
-            dependency: util.isEsmWrapper(options.wrap)
-                ? "protobufjs/light.js"
-                : "protobufjs/light",
+            dependency: json_module.getDependency(options),
             defaultExport: options.comments !== false
                 ? json_module.defaultExportDoc
                 : undefined

--- a/cli/targets/static-module.js
+++ b/cli/targets/static-module.js
@@ -11,6 +11,12 @@ var util          = require("../util"),
 
 static_module_target.description = "Static code without reflection as a module";
 
+static_module_target.getDependency = function getDependency(options) {
+    return options.dependency || (util.isEsmWrapper(options.wrap)
+        ? "protobufjs/minimal.js"
+        : "protobufjs/minimal");
+};
+
 function static_module_target(root, options, callback) {
     require("./static")(root, options, function(err, output) {
         if (err) {
@@ -19,9 +25,7 @@ function static_module_target(root, options, callback) {
         }
         try {
             output = util.wrap(output, protobuf.util.merge({
-                dependency: util.isEsmWrapper(options.wrap)
-                    ? "protobufjs/minimal.js"
-                    : "protobufjs/minimal"
+                dependency: static_module_target.getDependency(options)
             }, options));
         } catch (e) {
             callback(e);

--- a/tests/cli-pbjs.js
+++ b/tests/cli-pbjs.js
@@ -706,6 +706,7 @@ tape.test("pbjs --dts writes module declarations", function(test) {
             test.ok(fs.existsSync(staticOut), "writes static-module javascript");
             test.ok(fs.existsSync(staticDts), "writes static-module declarations");
             var staticTypes = fs.readFileSync(staticDts, "utf8");
+            test.ok(staticTypes.indexOf("import * as $protobuf from \"protobufjs/minimal\";") >= 0, "uses the static-module dependency in declarations");
             test.ok(staticTypes.indexOf("constructor(properties?: Package.$Properties);") >= 0, "keeps constructable static declarations");
             test.ok(staticTypes.indexOf("type $Shape = Package.$Properties;") >= 0, "aliases shape to properties when there is no narrowing");
 
@@ -720,6 +721,7 @@ tape.test("pbjs --dts writes module declarations", function(test) {
                 test.ok(fs.existsSync(jsonOut), "writes json-module javascript");
                 test.ok(fs.existsSync(jsonDts), "writes json-module declarations");
                 var jsonTypes = fs.readFileSync(jsonDts, "utf8");
+                test.ok(jsonTypes.indexOf("import * as $protobuf from \"protobufjs/light\";") >= 0, "uses the json-module dependency in declarations");
                 test.ok(jsonTypes.indexOf("private constructor();") >= 0, "marks reflection-backed declarations as non-constructable");
                 test.ok(jsonTypes.indexOf("Reflection-backed declarations are not constructable. Use Package.create(...) instead.") >= 0, "explains create usage");
                 test.ok(jsonTypes.indexOf("static create(properties?: Package.$Properties): Package;") >= 0, "keeps reflection Type create declaration");
@@ -736,6 +738,7 @@ tape.test("pbjs --dts writes module declarations", function(test) {
                     test.ok(fs.existsSync(jsonEsmOut), "writes json-module esm javascript");
                     test.ok(fs.existsSync(jsonEsmDts), "writes json-module esm declarations");
                     var jsonEsmTypes = fs.readFileSync(jsonEsmDts, "utf8");
+                    test.ok(jsonEsmTypes.indexOf("import * as $protobuf from \"protobufjs/light.js\";") >= 0, "uses the ESM dependency in declarations");
                     test.ok(jsonEsmTypes.indexOf("declare const _default: $protobuf.Root;") >= 0, "declares the default root export");
                     test.ok(jsonEsmTypes.indexOf("export default _default;") >= 0, "exports the default root declaration");
                     test.ok(jsonEsmTypes.indexOf("export class Package") >= 0, "emits message declarations");
@@ -746,6 +749,7 @@ tape.test("pbjs --dts writes module declarations", function(test) {
                         "--wrap", "commonjs",
                         "--out", jsonMinimalOut,
                         "--dts",
+                        "--dependency", "custom-protobuf",
                         "--no-create",
                         "--no-encode",
                         "--no-decode",
@@ -758,7 +762,10 @@ tape.test("pbjs --dts writes module declarations", function(test) {
                         test.error(jsonMinimalErr, "json-module --dts respects static method flags");
                         test.ok(fs.existsSync(jsonMinimalOut), "writes minimal json-module javascript");
                         test.ok(fs.existsSync(jsonMinimalDts), "writes minimal json-module declarations");
+                        var minimalCode = fs.readFileSync(jsonMinimalOut, "utf8");
                         var minimalTypes = fs.readFileSync(jsonMinimalDts, "utf8");
+                        test.ok(minimalCode.indexOf("require(\"custom-protobuf\")") >= 0, "uses a custom dependency in javascript");
+                        test.ok(minimalTypes.indexOf("import * as $protobuf from \"custom-protobuf\";") >= 0, "uses a custom dependency in declarations");
                         test.equal(minimalTypes.indexOf("static create("), -1, "omits disabled create declaration");
                         test.equal(minimalTypes.indexOf("static encode("), -1, "omits disabled encode declaration");
                         test.equal(minimalTypes.indexOf("static decode("), -1, "omits disabled decode declaration");


### PR DESCRIPTION
Passes the effective protobuf dependency through to `pbts` when using `pbjs --dts`, so generated code and declarations import the same runtime variant or custom `--dependency`.

Fixes #1228