### PR TITLE
fix: Remove circular LongBits dependency

### DIFF
--- a/src/index-minimal.js
+++ b/src/index-minimal.js
@@ -26,6 +26,7 @@ exports.configure    = configure;
  * @returns {undefined}
  */
 function configure() {
+    exports.util.LongBits._configure(exports.util.Long);
     exports.Writer._configure(exports.BufferWriter);
     exports.Reader._configure(exports.BufferReader);
 }

--- a/src/util/longbits.js
+++ b/src/util/longbits.js
@@ -1,7 +1,7 @@
 "use strict";
 module.exports = LongBits;
 
-var util = require("../util/minimal");
+var Long;
 
 /**
  * Constructs new long bits.
@@ -80,10 +80,10 @@ LongBits.fromNumber = function fromNumber(value) {
 LongBits.from = function from(value) {
     if (typeof value === "number")
         return LongBits.fromNumber(value);
-    if (util.isString(value)) {
+    if (typeof value === "string" || value instanceof String) {
         /* istanbul ignore else */
-        if (util.Long)
-            value = util.Long.fromString(value);
+        if (Long)
+            value = Long.fromString(value);
         else
             return LongBits.fromNumber(parseInt(value, 10));
     }
@@ -112,8 +112,8 @@ LongBits.prototype.toNumber = function toNumber(unsigned) {
  * @returns {Long} Long
  */
 LongBits.prototype.toLong = function toLong(unsigned) {
-    return util.Long
-        ? new util.Long(this.lo | 0, this.hi | 0, Boolean(unsigned))
+    return Long
+        ? new Long(this.lo | 0, this.hi | 0, Boolean(unsigned))
         /* istanbul ignore next */
         : { low: this.lo | 0, high: this.hi | 0, unsigned: Boolean(unsigned) };
 };
@@ -197,4 +197,8 @@ LongBits.prototype.length = function length() {
              ? part1 < 128 ? 5 : 6
              : part1 < 2097152 ? 7 : 8
          : part2 < 128 ? 9 : 10;
+};
+
+LongBits._configure = function(Long_) {
+    Long = Long_;
 };

--- a/tests/api_longbits.js
+++ b/tests/api_longbits.js
@@ -23,8 +23,11 @@ tape.test("longbits", function(test) {
         test.equal(protobuf.util.longToHash(0), "\0\0\0\0\0\0\0\0", "should convert to a binary hash of 8x0 (number 0 through util.longToHash)");
         test.equal(LongBits.fromHash("\0\0\0\0\0\0\0\0"), zero, "should be returned for a binary hash of 8x0");
         protobuf.util.Long = null;
+        protobuf.configure();
+        test.notOk(Long.isLong(zero.toLong()), "should not return a Long when disabled");
         test.equal(protobuf.util.longFromHash("\0\0\0\0\0\0\0\0"), 0, "should be returned for a binary hash of 8x0 (number 0 through util.longFromHash)");
         protobuf.util.Long = Long;
+        protobuf.configure();
         test.end();
     });
 


### PR DESCRIPTION
Defers configuration of `LongBits` with the selected `Long` implementation, resolving the circular dependency between `util/minimal` and `util/longbits` that can produce cycle warnings in Expo and React Native.

Fixes #1137