### PR TITLE
docs: Document custom import path resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ const root = await protobuf.load("awesome.proto");
 const AwesomeMessage = root.lookupType("awesomepackage.AwesomeMessage");
 ```
 
-Optionally use `load()` with a callback, or `loadSync()` for synchronous loading on Node.js.
+Optionally use `load()` with a callback, or `loadSync()` for synchronous loading on Node.js. Imports resolve relative to the importing file by default. To resolve imports against a specific base directory, create a `Root` and override `root.resolvePath` before calling `root.load()`.
 
 ### Encode and decode
 


### PR DESCRIPTION
Documents that imports resolve relative to the importing file by default when using `load` or `loadSync`, and points to overriding `Root#resolvePath` when imports should resolve against a specific base directory.

Fixes #1089