### PR TITLE
fix: preserve first enum alias from JSON descriptors

### DIFF
--- a/src/enum.js
+++ b/src/enum.js
@@ -82,8 +82,11 @@ function Enum(name, values, options, comment, comments, valuesOptions) {
 
     if (values)
         for (var keys = Object.keys(values), i = 0; i < keys.length; ++i)
-            if (keys[i] !== "__proto__" && typeof values[keys[i]] === "number") // use forward entries only
-                this.valuesById[ this.values[keys[i]] = values[keys[i]] ] = keys[i];
+            if (keys[i] !== "__proto__" && typeof values[keys[i]] === "number") { // use forward entries only
+                this.values[keys[i]] = values[keys[i]];
+                if (this.valuesById[values[keys[i]]] === undefined)
+                    this.valuesById[values[keys[i]]] = keys[i];
+            }
 }
 
 /**

--- a/tests/api_protojson.js
+++ b/tests/api_protojson.js
@@ -214,6 +214,31 @@ tape.test("protojson - rejects JSON name collisions", function(test) {
     test.end();
 });
 
+tape.test("protojson - emits first enum alias from JSON descriptor roots", function(test) {
+    var schema = "syntax = \"proto3\";\
+enum AliasChoice {\
+  option allow_alias = true;\
+  UNKNOWN = 0;\
+  OLD = 1;\
+  NEW = 1;\
+}\
+message AliasMessage {\
+  AliasChoice choice = 1;\
+}",
+        parsedRoot = protobuf.parse(schema).root.resolveAll(),
+        jsonRoot = protobuf.Root.fromJSON(parsedRoot.toJSON()).resolveAll(),
+        parsedMessage = parsedRoot.lookupType("AliasMessage").create({ choice: 1 }),
+        jsonMessage = jsonRoot.lookupType("AliasMessage").create({ choice: 1 });
+
+    test.deepEqual(protojson.toJson(parsedRoot.lookupType("AliasMessage"), parsedMessage), {
+        choice: "OLD"
+    }, "parsed proto root emits first enum alias");
+    test.deepEqual(protojson.toJson(jsonRoot.lookupType("AliasMessage"), jsonMessage), {
+        choice: "OLD"
+    }, "JSON descriptor root emits first enum alias");
+    test.end();
+});
+
 tape.test("protojson - reads legacy json_name reflection options", function(test) {
     var Legacy = protobuf.Root.fromJSON({
         nested: {


### PR DESCRIPTION
## Summary

JSON descriptor roots currently overwrite the reverse enum lookup for aliased enum values, causing ProtoJSON serialization to emit the last alias instead of the first alias.

ProtoJSON serializers should emit the first listed enum alias for a numeric value. Parsed `.proto` roots already preserve this behavior, but roots created through `Root.fromJSON(root.toJSON())` could emit a later alias because `Enum` construction overwrote `valuesById[id]`.

This change preserves the first reverse mapping while keeping all forward name-to-id mappings.

## Behavior

Given:

```proto
syntax = "proto3";

enum AliasChoice {
  option allow_alias = true;
  UNKNOWN = 0;
  OLD = 1;
  NEW = 1;
}

message AliasMessage {
  AliasChoice choice = 1;
}
```

Before this change:

```js
protojson.toJson(jsonRoot.lookupType("AliasMessage"), { choice: 1 });
```

could emit:

```js
{ choice: "NEW" }
```

After this change, JSON descriptor roots match parsed `.proto` roots and emit:

```js
{ choice: "OLD" }
```

Forward mappings remain unchanged, so both `OLD -> 1` and `NEW -> 1` are preserved.

## Tests

Added a focused ProtoJSON regression test in `tests/api_protojson.js`.

The test builds both:

- a parsed `.proto` root
- a JSON descriptor root using `Root.fromJSON(parsedRoot.toJSON())`

It verifies that both roots serialize the aliased enum value using the first listed alias.

## Commands run

```sh
npx tape tests/api_protojson.js
npm run lint:sources
npm test
```