### PR TITLE
feat(parse): enforce edition 2024 local visibility across files

### DIFF
--- a/src/field.js
+++ b/src/field.js
@@ -334,6 +334,26 @@ Field.prototype.toJSON = function toJSON(toJSONOptions) {
 };
 
 /**
+ * Verifies that a resolved type or enum may be referenced by the given field.
+ * A symbol declared `local` (edition 2024) is only visible within its own file.
+ * If either file name is unknown - programmatic construction, `fromJSON`, bundled
+ * common types - the reference cannot be proven to cross files and is allowed.
+ * @param {Field} field Referencing field
+ * @param {Type|Enum} resolved Resolved type or enum
+ * @returns {undefined}
+ * @throws {Error} If the referenced symbol is local to another file
+ * @inner
+ */
+function checkVisibility(field, resolved) {
+    if (resolved.visibility !== "local")
+        return;
+    var from = (field.declaringField || field).filename;
+    if (!from || !resolved.filename || from === resolved.filename)
+        return;
+    throw Error("'" + resolved.fullName + "' is local to '" + resolved.filename + "' and cannot be referenced from '" + from + "'");
+}
+
+/**
  * Resolves this field's type references.
  * @returns {Field} `this`
  * @throws {Error} If any reference cannot be resolved
@@ -345,6 +365,7 @@ Field.prototype.resolve = function resolve() {
 
     if ((this.typeDefault = types.defaults[this.type]) === undefined) { // if not a basic type, resolve it
         this.resolvedType = (this.declaringField ? this.declaringField.parent : this.parent).lookupTypeOrEnum(this.type);
+        checkVisibility(this, this.resolvedType);
         if (this.resolvedType instanceof Type)
             this.typeDefault = null;
         else // instanceof Enum

--- a/src/parse.js
+++ b/src/parse.js
@@ -318,6 +318,7 @@ function parse(source, root, options) {
 
 
     function parseCommon(parent, token, depth) {
+        var visibility;
         if (depth === undefined)
             depth = 0;
         // depth is checked by dispatched functions
@@ -341,6 +342,7 @@ function parse(source, root, options) {
                 if (edition < "2024") {
                     return false;
                 }
+                visibility = token;
                 token = next();
                 if (token === "export" || token === "local") {
                     return false;
@@ -348,9 +350,13 @@ function parse(source, root, options) {
                 if (token !== "message" && token !== "enum") {
                     return false;
                 }
-                /* eslint-disable no-warning-comments */
-                // TODO: actually enforce visiblity modifiers like protoc does.
-                return parseCommon(parent, token, depth);
+                // Recorded on the object so that resolution can reject references to
+                // a "local" symbol from another file, see Field#resolve.
+                (token === "message"
+                    ? parseType(parent, token, depth + 1)
+                    : parseEnum(parent, token)
+                ).visibility = visibility;
+                return true;
 
             case "service":
                 parseService(parent, token, depth + 1);
@@ -455,6 +461,7 @@ function parse(source, root, options) {
         if (parent === ptr) {
             topLevelObjects.push(type);
         }
+        return type;
     }
 
     function parseField(parent, rule, extend, depth) {
@@ -719,6 +726,7 @@ function parse(source, root, options) {
         if (parent === ptr) {
             topLevelObjects.push(enm);
         }
+        return enm;
     }
 
     function parseEnumValue(token) {

--- a/tests/parse_editions.js
+++ b/tests/parse_editions.js
@@ -157,3 +157,96 @@ tape.test("edition 2024 import option", function(test) {
 
     test.end();
 });
+
+
+tape.test("edition 2024 local visibility enforcement", function(test) {
+
+    // Parses several sources into one Root, each under its own file name, the
+    // way Root#load does (it sets parse.filename before each parse call).
+    function parseFiles(files) {
+        var root = new protobuf.Root();
+        Object.keys(files).forEach(function(filename) {
+            protobuf.parse.filename = filename;
+            protobuf.parse(files[filename], root);
+        });
+        return root;
+    }
+
+    test.doesNotThrow(function() {
+        parseFiles({
+            "a.proto": `edition = "2024";
+                local message Hidden { int32 value = 1; }
+                message User { Hidden hidden = 1; }`
+        }).resolveAll();
+    }, "local message should resolve within its own file");
+
+    test.doesNotThrow(function() {
+        parseFiles({
+            "a.proto": `edition = "2024";
+                local enum Hidden { ZERO = 0; }
+                message User { Hidden hidden = 1; }`
+        }).resolveAll();
+    }, "local enum should resolve within its own file");
+
+    test.throws(function() {
+        parseFiles({
+            "a.proto": `edition = "2024"; local message Hidden { int32 value = 1; }`,
+            "b.proto": `edition = "2024"; message User { Hidden hidden = 1; }`
+        }).resolveAll();
+    }, /is local to 'a\.proto' and cannot be referenced from 'b\.proto'/, "local message should not resolve from another file");
+
+    test.throws(function() {
+        parseFiles({
+            "a.proto": `edition = "2024"; local enum Hidden { ZERO = 0; }`,
+            "b.proto": `edition = "2024"; message User { Hidden hidden = 1; }`
+        }).resolveAll();
+    }, /is local to 'a\.proto' and cannot be referenced from 'b\.proto'/, "local enum should not resolve from another file");
+
+    test.throws(function() {
+        parseFiles({
+            "a.proto": `edition = "2024"; message Outer { local message Hidden { int32 value = 1; } }`,
+            "b.proto": `edition = "2024"; message User { Outer.Hidden hidden = 1; }`
+        }).resolveAll();
+    }, /is local to 'a\.proto' and cannot be referenced from 'b\.proto'/, "nested local message should not resolve from another file");
+
+    test.doesNotThrow(function() {
+        parseFiles({
+            "a.proto": `edition = "2024"; export message Shared { int32 value = 1; }`,
+            "b.proto": `edition = "2024"; message User { Shared shared = 1; }`
+        }).resolveAll();
+    }, "export message should resolve from another file");
+
+    test.doesNotThrow(function() {
+        parseFiles({
+            "a.proto": `edition = "2024"; message Plain { int32 value = 1; }`,
+            "b.proto": `edition = "2024"; message User { Plain plain = 1; }`
+        }).resolveAll();
+    }, "unmodified message should resolve from another file");
+
+    test.doesNotThrow(function() {
+        parseFiles({
+            "a.proto": `edition = "2023"; message Plain { int32 value = 1; }`,
+            "b.proto": `edition = "2023"; message User { Plain plain = 1; }`
+        }).resolveAll();
+    }, "edition 2023 cross-file references should be untouched");
+
+    test.doesNotThrow(function() {
+        parseFiles({
+            "a.proto": `syntax = "proto2"; message Plain { optional int32 value = 1; }`,
+            "b.proto": `syntax = "proto3"; message User { Plain plain = 1; }`
+        }).resolveAll();
+    }, "proto2/proto3 cross-file references should be untouched");
+
+    // Objects built without a file name cannot be proven to be cross-file, so
+    // they must keep resolving (programmatic construction, fromJSON, commons).
+    test.doesNotThrow(function() {
+        protobuf.Root.fromJSON({
+            nested: {
+                Hidden: { fields: { value: { type: "int32", id: 1 } } },
+                User: { fields: { hidden: { type: "Hidden", id: 1 } } }
+            }
+        }).resolveAll();
+    }, "objects without a file name should keep resolving");
+
+    test.end();
+});

--- a/tests/parse_editions.js
+++ b/tests/parse_editions.js
@@ -157,3 +157,95 @@ tape.test("edition 2024 import option", function(test) {
 
     test.end();
 });
+
+tape.test("edition 2024 local visibility enforcement", function(test) {
+
+    // Parses several sources into one Root, each under its own file name, the
+    // way Root#load does (it sets parse.filename before each parse call).
+    function parseFiles(files) {
+        var root = new protobuf.Root();
+        Object.keys(files).forEach(function(filename) {
+            protobuf.parse.filename = filename;
+            protobuf.parse(files[filename], root);
+        });
+        return root;
+    }
+
+    test.doesNotThrow(function() {
+        parseFiles({
+            "a.proto": `edition = "2024";
+                local message Hidden { int32 value = 1; }
+                message User { Hidden hidden = 1; }`
+        }).resolveAll();
+    }, "local message should resolve within its own file");
+
+    test.doesNotThrow(function() {
+        parseFiles({
+            "a.proto": `edition = "2024";
+                local enum Hidden { ZERO = 0; }
+                message User { Hidden hidden = 1; }`
+        }).resolveAll();
+    }, "local enum should resolve within its own file");
+
+    test.throws(function() {
+        parseFiles({
+            "a.proto": `edition = "2024"; local message Hidden { int32 value = 1; }`,
+            "b.proto": `edition = "2024"; message User { Hidden hidden = 1; }`
+        }).resolveAll();
+    }, /is local to 'a\.proto' and cannot be referenced from 'b\.proto'/, "local message should not resolve from another file");
+
+    test.throws(function() {
+        parseFiles({
+            "a.proto": `edition = "2024"; local enum Hidden { ZERO = 0; }`,
+            "b.proto": `edition = "2024"; message User { Hidden hidden = 1; }`
+        }).resolveAll();
+    }, /is local to 'a\.proto' and cannot be referenced from 'b\.proto'/, "local enum should not resolve from another file");
+
+    test.throws(function() {
+        parseFiles({
+            "a.proto": `edition = "2024"; message Outer { local message Hidden { int32 value = 1; } }`,
+            "b.proto": `edition = "2024"; message User { Outer.Hidden hidden = 1; }`
+        }).resolveAll();
+    }, /is local to 'a\.proto' and cannot be referenced from 'b\.proto'/, "nested local message should not resolve from another file");
+
+    test.doesNotThrow(function() {
+        parseFiles({
+            "a.proto": `edition = "2024"; export message Shared { int32 value = 1; }`,
+            "b.proto": `edition = "2024"; message User { Shared shared = 1; }`
+        }).resolveAll();
+    }, "export message should resolve from another file");
+
+    test.doesNotThrow(function() {
+        parseFiles({
+            "a.proto": `edition = "2024"; message Plain { int32 value = 1; }`,
+            "b.proto": `edition = "2024"; message User { Plain plain = 1; }`
+        }).resolveAll();
+    }, "unmodified message should resolve from another file");
+
+    test.doesNotThrow(function() {
+        parseFiles({
+            "a.proto": `edition = "2023"; message Plain { int32 value = 1; }`,
+            "b.proto": `edition = "2023"; message User { Plain plain = 1; }`
+        }).resolveAll();
+    }, "edition 2023 cross-file references should be untouched");
+
+    test.doesNotThrow(function() {
+        parseFiles({
+            "a.proto": `syntax = "proto2"; message Plain { optional int32 value = 1; }`,
+            "b.proto": `syntax = "proto3"; message User { Plain plain = 1; }`
+        }).resolveAll();
+    }, "proto2/proto3 cross-file references should be untouched");
+
+    // Objects built without a file name cannot be proven to be cross-file, so
+    // they must keep resolving (programmatic construction, fromJSON, commons).
+    test.doesNotThrow(function() {
+        protobuf.Root.fromJSON({
+            nested: {
+                Hidden: { fields: { value: { type: "int32", id: 1 } } },
+                User: { fields: { hidden: { type: "Hidden", id: 1 } } }
+            }
+        }).resolveAll();
+    }, "objects without a file name should keep resolving");
+
+    test.end();
+});


### PR DESCRIPTION
Closes #2400.

Rebased onto master and reduced: #2415 landed the parsing and preservation half, so this is now only the resolution check, 21 lines in `src/field.js` plus tests.

After a successful lookup, `Field#resolve` rejects a resolved type or enum that is `local` to a different file:

```
'.a.Hidden' is local to 'a.proto' and cannot be referenced from 'c.proto'
```

If either side has no filename, which covers programmatic construction, `fromJSON`, and bundled common types, the reference cannot be proven to cross files and is allowed.

Tests sit in `tests/parse_editions.js` beside the existing export/local parsing cases: same-file references still resolve, cross-file `local` throws, `export` and unmodified symbols are unaffected, and pre-2024 editions plus proto2/proto3 behave exactly as before. That file goes 29 to 39 tests; the full suite 3201 to 3211, all green, with lint and type checks clean.

Two things left out on purpose, in case you would rather they were in:

- **Service RPC request and response types are not covered.** `Method#resolve` resolves them through `lookupType` and methods do carry a filename, so the same check would be live there. Sharing it across modules felt like a bigger structural decision than this change should make on its own; it is about 10 lines if you want it here.
- **`tryHandleExtension` in `root.js` is deliberately untouched.** It is a boolean try inside the deferred-retry loop, so throwing there would break deferred extensions and make errors depend on file load order. Extension fields are still checked through the sister field's own `resolve`.

The earlier note about `visibility` not surviving `toJSON` / `fromJSON` no longer applies, since #2415 carries it through the descriptor surface.
