### PR TITLE
fix: Parse numeric defaults according to field type

### DIFF
--- a/src/parse.js
+++ b/src/parse.js
@@ -23,6 +23,8 @@ var base10Re    = /^[1-9][0-9]*$/,
     base16NegRe = /^-?0[x][0-9a-fA-F]+$/,
     base8Re     = /^0[0-7]+$/,
     base8NegRe  = /^-?0[0-7]+$/,
+    integerTypeRe = /^(?:u?int|sint|s?fixed)(?:32|64)$/,
+    unsignedTypeRe = /^(?:uint|fixed)(?:32|64)$/,
     numberRe    = util.patterns.numberRe,
     nameRe      = /^[a-zA-Z_][a-zA-Z_0-9]*$/,
     typeRefRe   = util.patterns.typeRefRe;
@@ -202,7 +204,7 @@ function parse(source, root, options) {
             case "nan": case "NAN": case "Nan": case "NaN":
                 return NaN;
             case "0":
-                return 0;
+                return sign * 0;
         }
         if (base10Re.test(token))
             return sign * parseInt(token, 10);
@@ -219,32 +221,31 @@ function parse(source, root, options) {
         throw illegal(token, "number", insideTryCatch);
     }
 
-    function parseId(token, acceptNegative, max) {
-        if (token === null) {
+    function parseInteger(token, acceptNegative, name) {
+        if (token === null)
             throw illegal(token, "end of input");
-        }
+        if (!acceptNegative && token.charAt(0) === "-")
+            throw illegal(token, name || "integer");
+        if (token === "0" || token === "-0")
+            return 0;
+        var value;
+        if (base10NegRe.test(token))
+            value = parseInt(token, 10);
+        else if (base16NegRe.test(token))
+            value = parseInt(token, 16);
+        else if (base8NegRe.test(token))
+            value = parseInt(token, 8);
+        else
+            throw illegal(token, name || "integer");
+        return value || 0;
+    }
+
+    function parseId(token, acceptNegative, max) {
         switch (token) {
             case "max": case "MAX": case "Max":
                 return max || maxFieldId;
-            case "0":
-                return 0;
         }
-
-        /* istanbul ignore if */
-        if (!acceptNegative && token.charAt(0) === "-")
-            throw illegal(token, "id");
-
-        if (base10NegRe.test(token))
-            return parseInt(token, 10);
-        if (base16NegRe.test(token))
-            return parseInt(token, 16);
-
-        /* istanbul ignore else */
-        if (base8NegRe.test(token))
-            return parseInt(token, 8);
-
-        /* istanbul ignore next */
-        throw illegal(token, "id");
+        return parseInteger(token, acceptNegative, "id");
     }
 
     function parsePackage() {
@@ -881,7 +882,9 @@ function parse(source, root, options) {
             return objectResult;
         }
 
-        var simpleValue = readValue(true);
+        var simpleValue = name === "default" && parent instanceof Field && integerTypeRe.test(parent.type)
+            ? parseInteger(next(), !unsignedTypeRe.test(parent.type))
+            : readValue(true);
         setOption(parent, name, simpleValue);
         return simpleValue;
         // Does not enforce a delimiter to be universal

--- a/tests/comp_parse-uncommon.js
+++ b/tests/comp_parse-uncommon.js
@@ -26,6 +26,33 @@ tape.test("uncommon statements", function(test) {
     });
 });
 
+tape.test("numeric defaults", function(test) {
+    var Type = protobuf.parse("syntax = \"proto2\";\
+        message M {\
+            optional float float_value = 1 [default = -0];\
+            optional double double_value = 2 [default = -0];\
+            optional double zero_value = 3 [default = 0];\
+            optional int32 int_value = 4 [default = -0];\
+            optional int32 hex_int_value = 5 [default = -0x0];\
+        }").root.lookupType("M");
+
+    Type.resolveAll();
+    test.ok(Object.is(Type.fields.floatValue.defaultValue, -0), "should preserve a negative zero float default");
+    test.ok(Object.is(Type.fields.doubleValue.defaultValue, -0), "should preserve a negative zero double default");
+    test.ok(Object.is(Type.fields.zeroValue.defaultValue, 0), "should preserve a positive zero default");
+    test.ok(Object.is(Type.fields.intValue.defaultValue, 0), "should normalize a negative integer zero default");
+    test.ok(Object.is(Type.fields.hexIntValue.defaultValue, 0), "should normalize a negative hexadecimal zero default");
+    var Enum = protobuf.parse("syntax = \"proto3\"; enum E { ZERO = -0; }").root.lookupEnum("E");
+    test.ok(Object.is(Enum.values.ZERO, 0), "should normalize a negative zero enum value");
+    test.throws(function() {
+        protobuf.parse("syntax = \"proto2\"; message M { optional uint32 value = 1 [default = -0]; }");
+    }, /illegal integer '-0'/, "should reject a negative unsigned default");
+    test.throws(function() {
+        protobuf.parse("syntax = \"proto2\"; message M { optional int32 value = 1 [default = 1.5]; }");
+    }, /illegal integer '1\.5'/, "should reject a non-integer default");
+    test.end();
+});
+
 tape.test("negative enum reserved values", function(test) {
     test.doesNotThrow(function() {
         var Enum = protobuf.parse("syntax = \"proto3\"; enum Values { reserved -1; INVALID = 0; OK = 1; }").root.lookupEnum("Values");


### PR DESCRIPTION
Distinguishes integer and floating-point defaults during parsing, preserving floating-point `-0` while canonicalizing integer zero and rejecting negative unsigned or non-integer defaults.

Potentially useful for #2393 to cover negative zero as well.