### PR TITLE
fix: Preserve negative zero in codegen formatters

### DIFF
--- a/src/util/codegen.js
+++ b/src/util/codegen.js
@@ -64,7 +64,9 @@ function codegen(functionParams, functionName) {
         formatStringOrScope = formatStringOrScope.replace(/%([%dfijs])/g, function replace($0, $1) {
             var value = formatParams[formatOffset++];
             switch ($1) {
-                case "d": case "f": return String(Number(value));
+                case "d": case "f":
+                    value = Number(value);
+                    return Object.is(value, -0) ? "-0" : String(value);
                 case "i": return String(Math.floor(value));
                 case "j": return JSON.stringify(value);
                 case "s": return String(value);

--- a/tests/util_codegen.js
+++ b/tests/util_codegen.js
@@ -13,5 +13,17 @@ tape.test("codegen", function(test) {
 
     test.equal(add(1, 2), 3, "should generate a working function");
 
+    var floats = codegen()
+      ("return [%f,%f,%f,%f,%f,%d]", 1.5, Infinity, -Infinity, NaN, -0, -0)
+      ()
+      ();
+
+    test.equal(floats[0], 1.5, "should format finite floating-point values");
+    test.equal(floats[1], Infinity, "should format positive infinity");
+    test.equal(floats[2], -Infinity, "should format negative infinity");
+    test.ok(Number.isNaN(floats[3]), "should format NaN");
+    test.ok(Object.is(floats[4], -0), "should format negative zero");
+    test.ok(Object.is(floats[5], -0), "should format negative zero as a number");
+
     test.end();
 });


### PR DESCRIPTION
Preserves negative zero in the `%d` and `%f` codegen formatters instead of emitting it as positive zero.

Useful for generating correct floating-point defaults in #2393. Related: #2402.