### PR TITLE
fix: Parse numeric descriptor defaults by field type

### DIFF
--- a/ext/descriptor.js
+++ b/ext/descriptor.js
@@ -13,7 +13,7 @@ var Namespace = $protobuf.Namespace,
     Method    = $protobuf.Method,
     patterns  = $protobuf.util.patterns;
 
-var numberRe  = patterns.numberRe,
+var integerRe = /^[+-]?[0-9]+$/,
     typeRefRe = patterns.typeRefRe;
 
 // --- Root ---
@@ -519,17 +519,33 @@ function Field_fromDescriptor(descriptor, ctx, nested) {
 
     if (descriptor.defaultValue && descriptor.defaultValue.length) {
         var defaultValue = descriptor.defaultValue;
-        switch (defaultValue) {
-            case "true": case "TRUE":
-                defaultValue = true;
+        switch (fieldType) {
+            case "double": case "float":
+                switch (defaultValue.toLowerCase()) {
+                    case "inf": defaultValue = Infinity; break;
+                    case "-inf": defaultValue = -Infinity; break;
+                    case "nan": case "-nan": defaultValue = NaN; break;
+                    default:
+                        defaultValue = Number(defaultValue);
+                        if (Number.isNaN(defaultValue))
+                            throw Error("illegal default value for " + fieldType);
+                        break;
+                }
                 break;
-            case "false": case "FALSE":
-                defaultValue = false;
+            case "int32": case "uint32": case "sint32": case "fixed32": case "sfixed32":
+                if (!integerRe.test(defaultValue))
+                    throw Error("illegal default value for " + fieldType);
+                defaultValue = parseInt(defaultValue, 10);
                 break;
-            default:
-                var match = numberRe.exec(defaultValue);
-                if (match)
-                    defaultValue = parseInt(defaultValue); // eslint-disable-line radix
+            case "int64": case "uint64": case "sint64": case "fixed64": case "sfixed64":
+                if (!integerRe.test(defaultValue))
+                    throw Error("illegal default value for " + fieldType);
+                break;
+            case "bool":
+                switch (defaultValue) {
+                    case "true": case "TRUE": defaultValue = true; break;
+                    case "false": case "FALSE": defaultValue = false; break;
+                }
                 break;
         }
         field.setOption("default", defaultValue);

--- a/src/field.js
+++ b/src/field.js
@@ -371,12 +371,17 @@ Field.prototype.resolve = function resolve() {
 
     // convert to internal data type if necesssary
     if (this.long) {
-        this.typeDefault = util.Long.fromNumber(this.typeDefault, this.type === "uint64" || this.type === "fixed64");
+        var unsigned = this.type === "uint64" || this.type === "fixed64";
+        this.typeDefault = typeof this.typeDefault === "string"
+            ? util.Long.fromString(this.typeDefault, unsigned)
+            : util.Long.fromNumber(this.typeDefault, unsigned);
 
         /* istanbul ignore else */
         if (Object.freeze)
             Object.freeze(this.typeDefault); // long instances are meant to be immutable anyway (i.e. use small int cache that even requires it)
 
+    } else if (types.long[this.type] !== undefined && typeof this.typeDefault === "string") {
+        this.typeDefault = parseInt(this.typeDefault, 10);
     } else if (this.bytes && typeof this.typeDefault === "string") {
         var buf;
         if (util.base64.test(this.typeDefault))

--- a/tests/api_descriptor.js
+++ b/tests/api_descriptor.js
@@ -64,6 +64,55 @@ tape.test("descriptor - proto2 roundtrip", function (test) {
     test.end();
 });
 
+tape.test("descriptor - numeric defaults", function(test) {
+    var root = protobuf.Root.fromDescriptor(descriptor.FileDescriptorSet.create({
+        file: [{
+            name: "defaults.proto",
+            syntax: "proto2",
+            messageType: [{
+                name: "Message",
+                field: [
+                    { name: "floatValue", number: 1, label: 1, type: 2, defaultValue: "8.999999488e+09" },
+                    { name: "doubleValue", number: 2, label: 1, type: 1, defaultValue: "7e+22" },
+                    { name: "negativeZero", number: 3, label: 1, type: 2, defaultValue: "-0" },
+                    { name: "positiveInfinity", number: 4, label: 1, type: 1, defaultValue: "inf" },
+                    { name: "negativeInfinity", number: 5, label: 1, type: 1, defaultValue: "-inf" },
+                    { name: "notANumber", number: 6, label: 1, type: 1, defaultValue: "nan" },
+                    { name: "int32Value", number: 7, label: 1, type: 5, defaultValue: "-123456789" },
+                    { name: "int64Value", number: 8, label: 1, type: 3, defaultValue: "-9123456789123456789" },
+                    { name: "uint64Value", number: 9, label: 1, type: 4, defaultValue: "10123456789123456789" },
+                    { name: "stringValue", number: 10, label: 1, type: 9, defaultValue: "123" }
+                ]
+            }]
+        }]
+    })).resolveAll();
+    var Message = root.lookupType("Message"),
+        message = Message.create();
+
+    test.equal(message.floatValue, 8999999488, "parses an exponent float default");
+    test.equal(message.doubleValue, 7e22, "parses an exponent double default");
+    test.ok(Object.is(message.negativeZero, -0), "preserves a negative zero float default");
+    test.equal(message.positiveInfinity, Infinity, "parses a positive infinity default");
+    test.equal(message.negativeInfinity, -Infinity, "parses a negative infinity default");
+    test.ok(Number.isNaN(message.notANumber), "parses a nan default");
+    test.equal(message.int32Value, -123456789, "parses a negative int32 default");
+    test.equal(message.int64Value.toString(), "-9123456789123456789", "parses an exact int64 default");
+    test.equal(message.uint64Value.toString(), "10123456789123456789", "parses an exact uint64 default");
+    test.equal(message.stringValue, "123", "keeps a numeric-looking string default");
+    test.throws(function() {
+        protobuf.Field.fromDescriptor(descriptor.FieldDescriptorProto.create({
+            name: "value", number: 1, label: 1, type: 1, defaultValue: "7junk"
+        }));
+    }, /illegal default value for double/, "rejects an invalid floating-point default");
+    test.throws(function() {
+        protobuf.Field.fromDescriptor(descriptor.FieldDescriptorProto.create({
+            name: "value", number: 1, label: 1, type: 3, defaultValue: "7junk"
+        }));
+    }, /illegal default value for int64/, "rejects an invalid integer default");
+
+    test.end();
+});
+
 tape.test("descriptor - ranges use descriptor end semantics at boundary", function (test) {
     var root = protobuf.parse(`syntax = "proto2";
 


### PR DESCRIPTION
Correctly parses numeric defaults imported from protoc descriptors, including exponent notation, special floating-point values, negative numbers, and exact 64-bit integers. For example, protoc may canonicalize `9e9` as `8.999999488e+09`, which was subsequently truncated to `8` by `parseInt`.