### PR TITLE
fix: Preserve symbol visibility

### DIFF
--- a/ext/descriptor.generated.d.ts
+++ b/ext/descriptor.generated.d.ts
@@ -215,6 +215,9 @@ export interface IDescriptorProto {
 
     /** Reserved names */
     reservedName?: string[];
+
+    /** Declared symbol visibility */
+    visibility?: number;
 }
 
 /** Properties of a MessageOptions message. */
@@ -311,6 +314,9 @@ export interface IEnumDescriptorProto {
 
     /** Enum options */
     options?: IEnumOptions;
+
+    /** Declared symbol visibility */
+    visibility?: number;
 }
 
 /** Properties of an EnumValueDescriptorProto message. */

--- a/ext/descriptor.js
+++ b/ext/descriptor.js
@@ -209,6 +209,7 @@ function Root_toDescriptorRecursive(ns, files, edition) {
  * @property {IMessageOptions} [options] Not supported
  * @property {IDescriptorProtoReservedRange[]} [reservedRange] Reserved ranges
  * @property {string[]} [reservedName] Reserved names
+ * @property {number} [visibility] Declared symbol visibility
  */
 
 /**
@@ -253,6 +254,7 @@ function Type_fromDescriptor(descriptor, ctx, nested, depth) {
     var type = new Type(descriptor.name.length ? descriptor.name : "Type" + unnamedMessageIndex++, fromDescriptorOptions(descriptor.options, exports.MessageOptions)),
         i,
         mapEntries = Object.create(null);
+    type.visibility = visibilityFromDescriptor(descriptor.visibility);
 
     if (!nested) {
         type._edition = ctx.edition;
@@ -317,6 +319,9 @@ function Type_fromDescriptor(descriptor, ctx, nested, depth) {
 Type.prototype.toDescriptor = function toDescriptor(edition) {
     var descriptor = exports.DescriptorProto.create({ name: this.name }),
         i;
+
+    if (this.visibility)
+        descriptor.visibility = visibilityToDescriptor(this.visibility);
 
     /* Fields */ for (i = 0; i < this.fieldsArray.length; ++i) {
         var fieldDescriptor;
@@ -656,6 +661,7 @@ Field.prototype.toDescriptor = function toDescriptor(edition) {
  * @property {string} [name] Enum name
  * @property {IEnumValueDescriptorProto[]} [value] Enum values
  * @property {IEnumOptions} [options] Enum options
+ * @property {number} [visibility] Declared symbol visibility
  */
 
 /**
@@ -737,6 +743,7 @@ function Enum_fromDescriptor(descriptor, ctx, nested) {
         undefined,
         valuesOptions
     );
+    enm.visibility = visibilityFromDescriptor(descriptor.visibility);
 
     if (!nested) {
         enm._edition = ctx.edition;
@@ -778,6 +785,8 @@ Enum.prototype.toDescriptor = function toDescriptor() {
         value: values,
         options: toDescriptorOptions(this.options, exports.EnumOptions)
     });
+    if (this.visibility)
+        descriptor.visibility = visibilityToDescriptor(this.visibility);
 
     /* Reserved... */ if (this.reserved)
         for (i = 0; i < this.reserved.length; ++i)
@@ -1000,6 +1009,14 @@ function applyContextFeatures(object, ctx) {
     var options = object.options || (object.options = {});
     options.features = $protobuf.util.merge({}, ctx.features, options.features);
     return object;
+}
+
+function visibilityFromDescriptor(visibility) {
+    return visibility === 1 ? "local" : visibility === 2 ? "export" : undefined;
+}
+
+function visibilityToDescriptor(visibility) {
+    return visibility === "local" ? 1 : visibility === "export" ? 2 : 0;
 }
 
 // Converts a descriptor type to a protobuf.js basic type

--- a/index.d.ts
+++ b/index.d.ts
@@ -190,6 +190,9 @@ export class Enum extends ReflectionObject {
     /** Reserved ranges, if any. */
     reserved: (number[]|string)[];
 
+    /** Declared symbol visibility, if any. */
+    visibility?: ("local"|"export");
+
     /**
      * Constructs an enum from an enum descriptor.
      * @param name Enum name
@@ -259,6 +262,9 @@ export interface IEnum {
 
     /** Reserved ranges */
     reserved?: (number[]|string)[];
+
+    /** Declared symbol visibility */
+    visibility?: ("local"|"export");
 
     /** Enum comment */
     comment?: (string|null);
@@ -1804,6 +1810,9 @@ export class Type extends NamespaceBase {
     /** Reserved ranges, if any. */
     reserved: (number[]|string)[];
 
+    /** Declared symbol visibility, if any. */
+    visibility?: ("local"|"export");
+
     /** Message fields by id. */
     readonly fieldsById: { [k: number]: Field };
 
@@ -1981,6 +1990,9 @@ export interface IType extends INamespace {
 
     /** Whether a legacy group or not */
     group?: boolean;
+
+    /** Declared symbol visibility */
+    visibility?: ("local"|"export");
 
     /** Message type comment */
     comment?: (string|null);

--- a/src/enum.js
+++ b/src/enum.js
@@ -76,6 +76,12 @@ function Enum(name, values, options, comment, comments, valuesOptions) {
      */
     this.reserved = undefined; // toJSON
 
+    /**
+     * Declared symbol visibility, if any.
+     * @type {"local"|"export"|undefined}
+     */
+    this.visibility = undefined; // toJSON
+
     // Note that values inherit valuesById on their prototype which makes them a TypeScript-
     // compatible enum. This is used by pbts to write actual enum definitions that work for
     // static and reflection code alike instead of emitting generic object definitions.
@@ -112,6 +118,7 @@ Enum.prototype._resolveFeatures = function _resolveFeatures(edition) {
  * @property {Object.<string,*>} [options] Enum options
  * @property {Object.<string,Object.<string,*>>} [valuesOptions] Enum value options
  * @property {Array.<number[]|string>} [reserved] Reserved ranges
+ * @property {"local"|"export"} [visibility] Declared symbol visibility
  * @property {string|null} [comment] Enum comment
  * @property {Object.<string,string|null>} [comments] Value comments
  */
@@ -126,6 +133,8 @@ Enum.prototype._resolveFeatures = function _resolveFeatures(edition) {
 Enum.fromJSON = function fromJSON(name, json) {
     var enm = new Enum(name, json.values, json.options, json.comment, json.comments, json.valuesOptions);
     enm.reserved = json.reserved;
+    if (json.visibility)
+        enm.visibility = json.visibility;
     if (json.edition)
         enm._edition = json.edition;
     enm._defaultEdition = "proto3";  // For backwards-compatibility.
@@ -145,6 +154,7 @@ Enum.prototype.toJSON = function toJSON(toJSONOptions) {
         "valuesOptions" , this.valuesOptions,
         "values"        , this.values,
         "reserved"      , this.reserved && this.reserved.length ? this.reserved : undefined,
+        "visibility"    , this.visibility,
         "comment"       , keepComments ? this.comment : undefined,
         "comments"      , keepComments ? this.comments : undefined
     ]);

--- a/src/parse.js
+++ b/src/parse.js
@@ -342,6 +342,7 @@ function parse(source, root, options) {
                 if (edition < "2024") {
                     return false;
                 }
+                var visibility = token;
                 token = next();
                 if (token === "export" || token === "local") {
                     return false;
@@ -349,9 +350,11 @@ function parse(source, root, options) {
                 if (token !== "message" && token !== "enum") {
                     return false;
                 }
-                /* eslint-disable no-warning-comments */
-                // TODO: actually enforce visiblity modifiers like protoc does.
-                return parseCommon(parent, token, depth);
+                (token === "message"
+                    ? parseType(parent, token, depth + 1)
+                    : parseEnum(parent, token)
+                ).visibility = visibility;
+                return true;
 
             case "service":
                 parseService(parent, token, depth + 1);
@@ -456,6 +459,7 @@ function parse(source, root, options) {
         if (parent === ptr) {
             topLevelObjects.push(type);
         }
+        return type;
     }
 
     function parseField(parent, rule, extend, depth) {
@@ -720,6 +724,7 @@ function parse(source, root, options) {
         if (parent === ptr) {
             topLevelObjects.push(enm);
         }
+        return enm;
     }
 
     function parseEnumValue(token) {

--- a/src/type.js
+++ b/src/type.js
@@ -71,6 +71,12 @@ function Type(name, options) {
     this.group = undefined; // toJSON
 
     /**
+     * Declared symbol visibility, if any.
+     * @type {"local"|"export"|undefined}
+     */
+    this.visibility = undefined; // toJSON
+
+    /**
      * Cached fields by id.
      * @type {Object.<number,Field>|null}
      * @private
@@ -254,6 +260,7 @@ function clearCache(type) {
  * @property {number[][]} [extensions] Extension ranges
  * @property {Array.<number[]|string>} [reserved] Reserved ranges
  * @property {boolean} [group=false] Whether a legacy group or not
+ * @property {"local"|"export"} [visibility] Declared symbol visibility
  * @property {string|null} [comment] Message type comment
  */
 
@@ -304,6 +311,8 @@ Type.fromJSON = function fromJSON(name, json, depth) {
         type.reserved = json.reserved;
     if (json.group)
         type.group = true;
+    if (json.visibility)
+        type.visibility = json.visibility;
     if (json.comment)
         type.comment = json.comment;
     if (json.edition)
@@ -328,6 +337,7 @@ Type.prototype.toJSON = function toJSON(toJSONOptions) {
         "extensions" , this.extensions && this.extensions.length ? this.extensions : undefined,
         "reserved"   , this.reserved && this.reserved.length ? this.reserved : undefined,
         "group"      , this.group || undefined,
+        "visibility" , this.visibility,
         "nested"     , inherited && inherited.nested || undefined,
         "comment"    , keepComments ? this.comment : undefined
     ]);

--- a/tests/api_descriptor.js
+++ b/tests/api_descriptor.js
@@ -290,6 +290,37 @@ tape.test("descriptor - imports file-level edition features", function(test) {
     test.end();
 });
 
+tape.test("descriptor - symbol visibility", function(test) {
+    var type = protobuf.Type.fromDescriptor(descriptor.DescriptorProto.create({
+            name: "LocalMessage",
+            visibility: descriptor.SymbolVisibility.VISIBILITY_LOCAL,
+            nestedType: [{
+                name: "NestedMessage",
+                visibility: descriptor.SymbolVisibility.VISIBILITY_EXPORT
+            }],
+            enumType: [{
+                name: "NestedEnum",
+                visibility: descriptor.SymbolVisibility.VISIBILITY_LOCAL
+            }]
+        }), "2024"),
+        enm = protobuf.Enum.fromDescriptor(descriptor.EnumDescriptorProto.create({
+            name: "ExportedEnum",
+            visibility: descriptor.SymbolVisibility.VISIBILITY_EXPORT
+        }), "2024");
+
+    test.equal(type.visibility, "local", "imports message visibility");
+    test.equal(type.lookupType("NestedMessage").visibility, "export", "imports nested message visibility");
+    test.equal(type.lookupEnum("NestedEnum").visibility, "local", "imports nested enum visibility");
+    var typeDescriptor = type.toDescriptor("2024");
+    test.equal(typeDescriptor.visibility, descriptor.SymbolVisibility.VISIBILITY_LOCAL, "exports message visibility");
+    test.equal(typeDescriptor.nestedType[0].visibility, descriptor.SymbolVisibility.VISIBILITY_EXPORT, "exports nested message visibility");
+    test.equal(typeDescriptor.enumType[0].visibility, descriptor.SymbolVisibility.VISIBILITY_LOCAL, "exports nested enum visibility");
+    test.equal(enm.visibility, "export", "imports enum visibility");
+    test.equal(enm.toDescriptor().visibility, descriptor.SymbolVisibility.VISIBILITY_EXPORT, "exports enum visibility");
+
+    test.end();
+});
+
 tape.test("descriptor - imports legacy group metadata", function(test) {
     var root = protobuf.parse(`syntax = "proto2";
         message WithGroup {

--- a/tests/parse_editions.js
+++ b/tests/parse_editions.js
@@ -85,20 +85,21 @@ tape.test("edition 2023 reserved", function(test) {
 });
 
 tape.test("edition 2024 visibility", function(test) {
-    test.ok(protobuf.parse(`edition = "2024"; export message Foo {}`), "messages should allow export modifier");;
-    test.ok(protobuf.parse(`edition = "2024"; export enum Foo {}`), "enums should allow export modifier");;
-    test.ok(protobuf.parse(`edition = "2024"; local message Foo {}`), "messages should allow local modifier");;
-    test.ok(protobuf.parse(`edition = "2024"; local enum Foo {}`), "enums should allow local modifier");;
-    test.ok(protobuf.parse(`edition = "2024";
-        message Foo {
-            export message Export {}
-            local message Local {}
-        }`), "nested messages should allow visibility modifiers");;
-    test.ok(protobuf.parse(`edition = "2024";
-        message Foo {
-            export enum Export {}
-            local enum Local {}
-        }`), "nested enums should allow visibility modifiers");;
+    var root = protobuf.parse(`edition = "2024";
+        local message LocalMessage {}
+        export enum ExportedEnum {}
+        message Outer {
+            export message ExportedMessage {}
+            local enum LocalEnum { ZERO = 0; }
+        }
+    `).root;
+    test.equal(root.lookupType("LocalMessage").visibility, "local", "messages should preserve local modifier");
+    test.equal(root.lookupEnum("ExportedEnum").visibility, "export", "enums should preserve export modifier");
+    test.equal(root.lookupType("Outer.ExportedMessage").visibility, "export", "nested messages should preserve export modifier");
+    test.equal(root.lookupEnum("Outer.LocalEnum").visibility, "local", "nested enums should preserve local modifier");
+    var roundtrip = protobuf.Root.fromJSON(root.toJSON());
+    test.equal(roundtrip.lookupType("LocalMessage").visibility, "local", "reflection JSON should preserve message visibility");
+    test.equal(roundtrip.lookupEnum("ExportedEnum").visibility, "export", "reflection JSON should preserve enum visibility");
 
     test.throws(function() {
         protobuf.parse(`edition = "2023"; export message Foo {}`)
@@ -136,7 +137,6 @@ tape.test("edition 2024 visibility", function(test) {
 
     test.end();
 });
-
 
 tape.test("edition 2024 import option", function(test) {
     test.same(protobuf.parse(`edition = "2024"; import "foo.proto";`).imports, ["foo.proto"], "regular options should fetch");


### PR DESCRIPTION
Preserves Edition 2024 `local` and `export` modifiers on reflection objects and during descriptor conversion.

Similar to #2401, but focused on preserving these modifiers without attempting to reimplement protoc's cross-file enforcement, which is less useful in protobuf.js's runtime schema loader respectively already performed by protoc when using the plugin.