### PR TITLE
fix(cli): resolve --filter dependencies at any namespace depth

### DIFF
--- a/cli/util.js
+++ b/cli/util.js
@@ -120,117 +120,135 @@ exports.pad = function(str, len, l) {
 
 
 /**
- * DFS to get all message dependencies, cache in filterMap.
- * @param {Root} root  The protobuf root instance
- * @param {Message} message  The message need to process.
- * @param {Map} filterMap  The result of message you need and their dependencies.
- * @param {Map} flatMap  A flag to record whether the message was searched.
- * @returns {undefined}  Does not return a value
+ * Retains an object and, if it is a message, everything it transitively references.
+ * The set of retained objects doubles as the guard against cyclic references.
+ * @param {Set} retained Set of retained reflection objects
+ * @param {ReflectionObject} object Object to retain
+ * @returns {undefined} Does not return a value
  */
-function dfsFilterMessageDependencies(root, message, filterMap, flatMap) {
-    if (message instanceof protobuf.Type) {
-        if (flatMap.get(`${message.fullName}`)) return;
-        flatMap.set(`${message.fullName}`, true);
-        for (var field of message.fieldsArray) {
-            if (field.resolvedType) {
-                // a nested message
-                if (field.resolvedType.parent.name === message.name) {
-                    var nestedMessage = message.nested[field.resolvedType.name];
-                    dfsFilterMessageDependencies(root, nestedMessage, filterMap, flatMap);
-                    continue;
-                }
-                var packageName = field.resolvedType.parent.name;
-                var typeName = field.resolvedType.name;
-                var fullName = packageName ? `${packageName}.${typeName}` : typeName;
-                doFilterMessage(root, { messageNames: [fullName] }, filterMap, flatMap, packageName);
-            }
-        }
-    }
+function retainWithDependencies(retained, object) {
+    if (retained.has(object))
+        return;
+    retained.add(object);
+
+    // Enums have no dependencies of their own, everything else is reached through fields.
+    // fieldsArray covers plain, repeated, map value, oneof and group fields alike.
+    if (object instanceof protobuf.Type)
+        object.fieldsArray.forEach(function(field) {
+            if (field.resolvedType)
+                retainWithDependencies(retained, field.resolvedType);
+        });
 }
 
 /**
- * DFS to get all message you need and their dependencies, cache in filterMap.
- * @param {Root} root  The protobuf root instance
- * @param {object} needMessageConfig  Need message config:
- * @param {string[]} needMessageConfig.messageNames  The message names array in the root namespace you need to gen. example: [msg1, msg2]
- * @param {Map} filterMap The result of message you need and their dependencies.
- * @param {Map} flatMap A flag to record whether the message was searched.
- * @param {string} currentPackageName  Current package name
- * @returns {undefined}  Does not return a value
+ * Determines the edition an object is subject to, which it may inherit from its parents.
+ * @param {ReflectionObject} object Object to inspect
+ * @returns {string|undefined} Edition, if any
  */
-function doFilterMessage(root, needMessageConfig, filterMap, flatMap, currentPackageName) {
-    var needMessageNames = needMessageConfig.messageNames;
-
-    for (var messageFullName of needMessageNames) {
-        var nameSplit = messageFullName.split(".");
-        var packageName = "";
-        var messageName = "";
-        if (nameSplit.length > 1) {
-            packageName = nameSplit[0];
-            messageName = nameSplit[1];
-        } else {
-            messageName = nameSplit[0];
-        }
-
-        // in Namespace
-        if (packageName) {
-            var ns = root.nested[packageName];
-            if (!ns || !(ns instanceof protobuf.Namespace)) {
-                throw new Error(`package not foud ${currentPackageName}.${messageName}`);
-            }
-
-            doFilterMessage(root, { messageNames: [messageName] }, filterMap, flatMap, packageName);
-        } else {
-            var message = root.nested[messageName];
-
-            if (currentPackageName) {
-                message = root.nested[currentPackageName].nested[messageName];
-            }
-
-            if (!message) {
-                throw new Error(`message not foud ${currentPackageName}.${messageName}`);
-            }
-
-            var set = filterMap.get(currentPackageName);
-            if (!filterMap.has(currentPackageName)) {
-                set = new Set();
-                filterMap.set(currentPackageName, set);
-            }
-
-            set.add(messageName);
-
-            // dfs to find all dependencies
-            dfsFilterMessageDependencies(root, message, filterMap, flatMap, currentPackageName);
-        }
-    }
+function inheritedEdition(object) {
+    var current = object;
+    while (current && !current._edition)
+        current = current.parent;
+    return current ? current._edition : undefined;
 }
 
 /**
- * filter the message you need and their dependencies, all others will be delete from root.
- * @param {Root} root  Root the protobuf root instance
- * @param {object} needMessageConfig  Need message config:
- * @param {string[]} needMessageConfig.messageNames  Tthe message names array in the root namespace you need to gen. example: [msg1, msg2]
- * @returns {boolean} True if a message should present in the generated files
+ * Replaces a namespace subclass with a plain namespace, keeping its nested objects.
+ * Used for types that are only needed to spell out the full name of a retained object.
+ * @param {NamespaceBase} parent Parent namespace of `object`
+ * @param {NamespaceBase} object Object to replace
+ * @returns {undefined} Does not return a value
  */
-exports.filterMessage = function (root, needMessageConfig) {
-    var filterMap = new Map();
-    var flatMap = new Map();
-    doFilterMessage(root, needMessageConfig, filterMap, flatMap, "");
-    root._nestedArray = root._nestedArray.filter(ns => {
-        if (ns instanceof protobuf.Type || ns instanceof protobuf.Enum) {
-            return filterMap.get("").has(ns.name);
-        } else if (ns instanceof protobuf.Namespace) {
-            if (!filterMap.has(ns.name)) {
-                return false;
-            }
-            ns._nestedArray = ns._nestedArray.filter(nns => {
-                const nnsSet = filterMap.get(ns.name);
-                return nnsSet.has(nns.name);
-            });
+function replaceWithNamespace(parent, object) {
+    var replacement = new protobuf.Namespace(object.name, object.options);
+    replacement.comment = object.comment;
+    replacement.filename = object.filename;
 
-            return true;
-        }
-        return true;
+    // Types inherit the edition of the enclosing type, whereas Namespace#add stamps direct
+    // children of a plain namespace with the default edition. Pinning the edition that was
+    // in effect before the replacement keeps feature resolution, and thus field presence,
+    // unchanged for everything that is moved over.
+    var edition = inheritedEdition(object);
+    replacement._edition = edition;
+
+    object.nestedArray.slice().forEach(function(nested) {
+        if (!nested._edition)
+            nested._edition = edition;
+        object.remove(nested);
+        replacement.add(nested);
     });
+
+    parent.remove(object);
+    parent.add(replacement);
+}
+
+/**
+ * Recursively removes everything that is neither retained nor required to address a
+ * retained object by its full name.
+ * @param {NamespaceBase} namespace Namespace to prune
+ * @param {Set} retained Set of retained reflection objects
+ * @returns {undefined} Does not return a value
+ */
+function pruneNamespace(namespace, retained) {
+    // The array is a snapshot because removing and replacing children mutates it.
+    namespace.nestedArray.slice().forEach(function(child) {
+        if (child instanceof protobuf.Namespace)
+            pruneNamespace(child, retained);
+
+        if (retained.has(child))
+            return;
+
+        // Nothing retained inside, so nothing to keep it around for. Non-namespace children
+        // (declaring extension fields) always end up here, and removing them makes the root
+        // drop their sister fields as well.
+        if (!(child instanceof protobuf.Namespace) || !child.nestedArray.length) {
+            namespace.remove(child);
+            return;
+        }
+
+        // Retained descendants below an object that was not selected itself: keep it as a
+        // container only, so that message and service code is not emitted for it.
+        if (child instanceof protobuf.Type || child instanceof protobuf.Service)
+            replaceWithNamespace(namespace, child);
+    });
+}
+
+/**
+ * Removes everything from the root that is neither one of the configured messages nor a
+ * transitive dependency of one of them.
+ * @param {Root} root The protobuf root instance
+ * @param {object} needMessageConfig Filter configuration
+ * @param {string[]} needMessageConfig.messageNames The full names of the messages to keep.
+ * example: ["mypackage.Message", "mypackage.nested.Other"]
+ * @returns {undefined} Does not return a value
+ * @throws {TypeError} If the configuration is invalid
+ * @throws {Error} If one of the configured messages does not exist
+ */
+exports.filterMessage = function filterMessage(root, needMessageConfig) {
+    if (!needMessageConfig || !Array.isArray(needMessageConfig.messageNames) || !needMessageConfig.messageNames.length)
+        throw TypeError("filter.messageNames must be a non-empty array");
+
+    // Dependencies are followed through resolvedType, so everything must be resolved first.
+    root.resolveAll();
+
+    var retained = new Set();
+
+    // Names are resolved before anything is removed, so a filter that cannot be applied
+    // leaves the root untouched.
+    needMessageConfig.messageNames.forEach(function(name) {
+        if (typeof name !== "string" || !name.length)
+            throw TypeError("filter.messageNames must contain non-empty strings");
+
+        // Looking up from the root handles full names of any namespace depth.
+        var message = root.lookup(name, [ protobuf.Type ]);
+        if (!message)
+            throw Error("no such message: " + name);
+
+        retainWithDependencies(retained, message);
+    });
+
+    pruneNamespace(root, retained);
+
+    root.resolveAll();
 };
 

--- a/tests/cli-pbjs.js
+++ b/tests/cli-pbjs.js
@@ -1194,3 +1194,136 @@ tape.test("pbjs generates static code with message filter", function (test) {
         });
     });
 });
+
+// Applies a filter to a freshly loaded root and asserts on what survived.
+function filterTest(test, file, messageNames, kept, removed) {
+    var util = require("../cli/util");
+    var root = protobuf.loadSync(path.join("tests/data/cli", file));
+
+    util.filterMessage(root, { messageNames: messageNames });
+
+    kept.forEach(function(name) {
+        test.ok(root.lookup(name), "keeps " + name);
+    });
+    removed.forEach(function(name) {
+        test.equal(root.lookup(name), null, "removes " + name);
+    });
+    // Resolving the pruned root in place is not enough: its objects are already resolved and
+    // Namespace#remove does not invalidate them. Reloading from JSON resolves from scratch and
+    // so is the check that no retained field points at a type that was pruned away.
+    test.doesNotThrow(function() {
+        protobuf.Root.fromJSON(JSON.parse(JSON.stringify(root.toJSON()))).resolveAll();
+    }, "leaves a root that resolves from scratch");
+    return root;
+}
+
+tape.test("pbjs filter keeps dependencies in deeply nested namespaces", function(test) {
+    cliTest(test, function() {
+        filterTest(test, "filter-nested.proto", [ "example.Response" ], [
+            ".example.Response",
+            ".example.values.Value",
+            ".example.values.Meta",
+            ".example.values.Kind"
+        ], [
+            ".example.UnusedRoot",
+            ".example.values.UnusedValue"
+        ]);
+        test.end();
+    });
+});
+
+tape.test("pbjs filter follows cyclic, repeated, map and oneof dependencies", function(test) {
+    cliTest(test, function() {
+        filterTest(test, "filter-edge.proto", [ "edge.Cyclic" ], [
+            ".edge.Cyclic",
+            ".edge.CyclicPeer"
+        ], [
+            ".edge.Unused"
+        ]);
+
+        filterTest(test, "filter-edge.proto", [ "edge.Collections" ], [
+            ".edge.Collections",
+            ".edge.Item",
+            ".edge.Flavor"
+        ], [
+            ".edge.Unused"
+        ]);
+
+        filterTest(test, "filter-edge.proto", [ "edge.Choice" ], [
+            ".edge.Choice",
+            ".edge.FirstChoice",
+            ".edge.SecondChoice"
+        ], [
+            ".edge.Unused"
+        ]);
+
+        test.end();
+    });
+});
+
+tape.test("pbjs filter keeps used nested types and drops unused ones", function(test) {
+    cliTest(test, function() {
+        filterTest(test, "filter-edge.proto", [ "edge.Container" ], [
+            ".edge.Container",
+            ".edge.Container.UsedNested",
+            ".edge.Container.UsedNestedEnum"
+        ], [
+            ".edge.Container.UnusedNested",
+            ".edge.Container.UnusedNestedEnum",
+            ".edge.EdgeService"
+        ]);
+        test.end();
+    });
+});
+
+tape.test("pbjs filter reduces an unselected parent type to a namespace", function(test) {
+    cliTest(test, function() {
+        var root = filterTest(test, "filter-edge.proto", [ "edge.Outer.SelectedNested" ], [
+            ".edge.Outer",
+            ".edge.Outer.SelectedNested"
+        ], [
+            ".edge.OuterDependency"
+        ]);
+
+        var outer = root.lookup(".edge.Outer");
+        test.ok(outer instanceof protobuf.Namespace, "keeps Outer as a namespace");
+        test.notOk(outer instanceof protobuf.Type, "does not keep Outer as a message");
+
+        var json = root.toJSON().nested.edge.nested.Outer;
+        test.notOk(json.fields, "does not keep the fields of Outer");
+        test.notOk(json.edition, "does not change the edition of the retained nested type");
+
+        test.end();
+    });
+});
+
+tape.test("pbjs filter rejects invalid configurations", function(test) {
+    cliTest(test, function() {
+        var util = require("../cli/util");
+        var root = protobuf.loadSync("tests/data/cli/filter-nested.proto");
+
+        [ undefined, {}, { messageNames: [] }, { messageNames: "example.Response" } ].forEach(function(config) {
+            test.throws(function() {
+                util.filterMessage(root, config);
+            }, /messageNames must be a non-empty array/, "rejects " + JSON.stringify(config));
+        });
+
+        [ [ "" ], [ 42 ] ].forEach(function(messageNames) {
+            test.throws(function() {
+                util.filterMessage(root, { messageNames: messageNames });
+            }, /messageNames must contain non-empty strings/, "rejects " + JSON.stringify(messageNames));
+        });
+
+        // Only messages can be selected, everything else is kept as a dependency or not at all.
+        [ "example.Missing", "example.values.Kind", "example.values" ].forEach(function(name) {
+            test.throws(function() {
+                util.filterMessage(root, { messageNames: [ name ] });
+            }, /no such message: /, "rejects " + name + " as a root");
+        });
+
+        test.ok(root.lookup(".example.UnusedRoot"), "leaves the root untouched on error");
+
+        test.end();
+    });
+});
+

--- a/tests/data/cli/filter-edge.proto
+++ b/tests/data/cli/filter-edge.proto
@@ -1,0 +1,90 @@
+syntax = "proto3";
+
+package edge;
+
+// Cyclic references between messages must not recurse endlessly.
+message Cyclic {
+  Cyclic self = 1;
+  CyclicPeer peer = 2;
+}
+
+message CyclicPeer {
+  Cyclic peer = 1;
+}
+
+// Repeated and map fields carry their dependencies just like singular fields do.
+message Collections {
+  repeated Item items = 1;
+  repeated Flavor flavors = 2;
+  map<string, Item> itemsByName = 3;
+}
+
+message Item {
+  string id = 1;
+}
+
+enum Flavor {
+  FLAVOR_UNSPECIFIED = 0;
+  FLAVOR_SWEET = 1;
+}
+
+// All branches of a oneof are ordinary fields of the containing message.
+message Choice {
+  oneof pick {
+    FirstChoice first = 1;
+    SecondChoice second = 2;
+    string plain = 3;
+  }
+}
+
+message FirstChoice {
+  string value = 1;
+}
+
+message SecondChoice {
+  string value = 1;
+}
+
+// Only the nested types that are actually used are kept.
+message Container {
+  message UsedNested {
+    string value = 1;
+  }
+
+  message UnusedNested {
+    string value = 1;
+  }
+
+  enum UsedNestedEnum {
+    USED_NESTED_ENUM_UNSPECIFIED = 0;
+  }
+
+  enum UnusedNestedEnum {
+    UNUSED_NESTED_ENUM_UNSPECIFIED = 0;
+  }
+
+  UsedNested used = 1;
+  UsedNestedEnum usedEnum = 2;
+}
+
+// Selecting Outer.SelectedNested must keep Outer as a container only.
+message Outer {
+  message SelectedNested {
+    string value = 1;
+  }
+
+  string outerOnly = 1;
+  OuterDependency dependency = 2;
+}
+
+message OuterDependency {
+  string value = 1;
+}
+
+message Unused {
+  string value = 1;
+}
+
+service EdgeService {
+  rpc Ping (Item) returns (Item);
+}

--- a/tests/data/cli/filter-nested-values.proto
+++ b/tests/data/cli/filter-nested-values.proto
@@ -1,0 +1,21 @@
+syntax = "proto3";
+
+package example.values;
+
+message Value {
+  Meta meta = 1;
+  Kind kind = 2;
+}
+
+message Meta {
+  string description = 1;
+}
+
+enum Kind {
+  KIND_UNSPECIFIED = 0;
+  KIND_PRIMARY = 1;
+}
+
+message UnusedValue {
+  string value = 1;
+}

--- a/tests/data/cli/filter-nested.proto
+++ b/tests/data/cli/filter-nested.proto
@@ -1,0 +1,13 @@
+syntax = "proto3";
+
+package example;
+
+import "./filter-nested-values.proto";
+
+message Response {
+  values.Value value = 1;
+}
+
+message UnusedRoot {
+  string value = 1;
+}


### PR DESCRIPTION
Fixes #2416

## Summary

`--filter` could not resolve a dependency whose package has more than one segment, so any schema using a package like `example.values` ended up producing a completely unfiltered root.

## Root cause

Dependency names were rebuilt from the immediate parent of the resolved type:

```js
var packageName = field.resolvedType.parent.name;
var typeName = field.resolvedType.name;
var fullName = packageName ? `${packageName}.${typeName}` : typeName;
```

For `.example.values.Value` the immediate parent is only `values`, producing the bogus name `values.Value`. That name was then consumed by a lookup that splits into exactly two segments and indexes `root.nested` directly, so nothing below `package.Message` could be addressed.

Pruning had the same one-level limitation: it filtered `root._nestedArray` and then a single level of `ns._nestedArray`.

## Fix

The filter now works on reflection objects instead of reconstructed names:

* each configured name is resolved with `root.lookup(name, [protobuf.Type])`, which handles full names of any namespace depth;
* the transitive closure is built over `field.resolvedType`, with a `Set` of reflection objects as the cycle guard. `fieldsArray` covers plain, repeated, map value, oneof and group fields alike;
* pruning is recursive and goes through the public `Namespace#remove` and `Namespace#add` rather than assigning to the private `_nestedArray`. This keeps `Root#_fullyQualifiedObjects` in sync, so pruned types are no longer reachable through `lookup` — previously they were, because that cache is a lookup fallback;
* namespaces that retained objects need for their full name are kept. An unselected `Type` or `Service` that only holds retained descendants is reduced to a plain `Namespace`, so no message or service code is emitted for it.

One subtlety worth calling out: `Namespace#add` stamps direct children of a plain namespace with the default edition. A type nested inside another type has no explicit edition of its own, so moving it into the replacement namespace as-is would silently change it from `proto3` to `proto2` and flip field presence from `IMPLICIT` to `EXPLICIT`. The edition in effect before the replacement is therefore pinned on the replacement and on each moved child.

The configuration is also validated up front and rejected unless it is a non-empty array of non-empty strings — otherwise an empty selection would now silently produce an empty root. Names are resolved before anything is removed, so a filter that cannot be applied leaves the root untouched for the existing fallback in `pbjs`.

No behavior outside `--filter` changes; `cli/pbjs.js` is untouched.

## Tests

Added to `tests/cli-pbjs.js`:

* the regression above, with a dependency in `example.values`;
* cyclic references, repeated message and enum fields, map values, and oneof branches;
* nested types that are used are kept while unused ones are dropped;
* a root selected inside an unselected parent type: the parent is reduced to a namespace, its own fields are gone, and the retained nested type keeps its edition;
* invalid configurations, including enum, service and package names, which are not valid roots.

Every filter assertion also reloads the pruned root through `Root.fromJSON(root.toJSON()).resolveAll()`. Resolving the pruned root in place is not sufficient — its objects are already resolved and `Namespace#remove` does not invalidate them — so reloading is what actually proves no retained field points at a pruned type.

The existing `--filter` test, which covers a single-segment package and a message without a package, is unchanged and still passes.

## Commands run

```sh
npm install
npm --prefix cli install
npm run build
npm run build:tests
npm run lint:sources -- --max-warnings 0
npm run lint:types
npm test
```

`npm run build:tests` produces an unrelated diff in `tests/data/test.js` that also reproduces on a clean `master`, so it is not included here.
