### PR TITLE
fix: Harden ProtoJSON and Text Format parsing

### DIFF
--- a/ext/protojson.js
+++ b/ext/protojson.js
@@ -91,6 +91,15 @@ function invalid(name, value, what) {
     return Error(name + ": " + what + ": " + JSON.stringify(value));
 }
 
+function normalizeIntegerString(str, name, what) {
+    str = str.replace(/^\+/, "").replace(/^(-?)0+(?=\d)/, "$1");
+    if (str === "-0")
+        str = "0";
+    if (str.length > 20) // max uint64 and min int64
+        throw Error(name + ": out of range for " + what);
+    return str;
+}
+
 function parseIntegerString(value, type, name) {
     var str;
     if (typeof value === "number") {
@@ -113,6 +122,7 @@ function parseIntegerString(value, type, name) {
         throw invalid(name, value, "expected integer (number or string)");
 
     var range = INT_RANGE[type];
+    str = normalizeIntegerString(str, name, type);
     if (LONG_TYPE[type]) {
         if (hasBigInt) {
             var big = BigInt(str);
@@ -128,17 +138,17 @@ function parseMapIntegerKey(key, type, name) {
     var unsigned = type === "uint32" || type === "fixed32" || type === "uint64" || type === "fixed64";
     if (!(unsigned ? /^[0-9]+$/ : /^-?[0-9]+$/).test(key))
         throw invalid(name, key, "invalid " + type + " map key");
+    var range = INT_RANGE[type];
+    key = normalizeIntegerString(key, name, type + " map key");
     if (hasBigInt) {
-        var big = BigInt(key),
-            range = INT_RANGE[type];
+        var big = BigInt(key);
         if (big < BigInt(range[0]) || big > BigInt(range[1]))
             throw invalid(name, key, "out of range for " + type + " map key");
         return big.toString();
     }
     parseIntegerString(key, type, name);
     if (LONG_TYPE[type]) {
-        var normalized = key.replace(/^-?0+(?=\d)/, key.charAt(0) === "-" ? "-" : "");
-        return normalized === "-0" ? "0" : normalized;
+        return key;
     }
     return String(Number(key));
 }

--- a/ext/textformat.js
+++ b/ext/textformat.js
@@ -586,14 +586,14 @@ Parser.prototype.parseScalar = function parseScalar(field) {
 };
 
 Parser.prototype.readStringBytes = function readStringBytes() {
-    var token = this.tn.next(),
-        bytes = [];
+    var token = this.tn.next();
     if (!token || token.type !== "string")
         this.error("expected string");
-    Array.prototype.push.apply(bytes, token.value);
+    var bytes = token.value;
     while ((token = this.tn.peek()) && token.type === "string") {
         token = this.tn.next();
-        Array.prototype.push.apply(bytes, token.value);
+        for (var i = 0; i < token.value.length; ++i)
+            bytes.push(token.value[i]);
     }
     return bytes;
 };
@@ -841,6 +841,10 @@ function parseInteger(token, sign, unsigned, bits) {
         digits = raw.substring(1);
     } else if (!/^(?:0|[1-9][0-9]*)$/.test(raw))
         throw Error("integer value expected");
+
+    digits = digits.replace(/^0+(?=.)/, "");
+    if (digits.length > Math.ceil(bits / 3)) // 3 bits per octal digit
+        throw Error((unsigned ? "unsigned " : "") + "integer value out of range");
 
     if (typeof util.global.BigInt === "function")
         return parseIntegerBigInt(digits, radix, sign, unsigned, bits);

--- a/tests/api_protojson.js
+++ b/tests/api_protojson.js
@@ -13,6 +13,7 @@ function bytes(buf) {
 
 var proto = "syntax = \"proto3\";\
 message Msg { int32 value = 1; }\
+message LongMsg { int64 value = 1; }\
 enum Choice { A = 0; B = 1; }\
 message Inner { int32 value = 1; }\
 message Outer {\
@@ -35,6 +36,7 @@ message MapMsg {\
 
 var root = protobuf.parse(proto).root,
     Msg = root.lookupType("Msg"),
+    LongMsg = root.lookupType("LongMsg"),
     Outer = root.lookupType("Outer"),
     OneofDefault = root.lookupType("OneofDefault"),
     MapMsg = root.lookupType("MapMsg"),
@@ -186,6 +188,37 @@ tape.test("protojson - rejects duplicate keys in string input", function(test) {
 tape.test("protojson - accepts already-parsed input", function(test) {
     var message = protojson.fromJson(Msg, { value: 1 });
     test.equal(message.value, 1, "parses object input");
+    test.end();
+});
+
+tape.test("protojson - bounds integer conversion inputs", function(test) {
+    var nativeBigInt = protobuf.util.global.BigInt,
+        maxBigIntLength = 0,
+        oversized = "9".repeat(1000),
+        error;
+    protobuf.util.global.BigInt = function(value) {
+        maxBigIntLength = Math.max(maxBigIntLength, String(value).length);
+        return nativeBigInt(value);
+    };
+    try {
+        try {
+            protojson.fromJson(LongMsg, { value: oversized });
+        } catch (err) {
+            error = err;
+        }
+        test.ok(error && /out of range/.test(error.message), "rejects oversized integer strings");
+        test.ok(error && error.message.length < oversized.length, "does not copy oversized values into errors");
+        test.equal(protojson.fromJson(LongMsg, { value: "0".repeat(1000) + "1" }).value.toString(), "1", "accepts insignificant leading zeros");
+
+        var map = {};
+        map[oversized] = "bad";
+        test.throws(function() {
+            protojson.fromJson(MapMsg, { uint64Map: map });
+        }, /out of range/, "rejects oversized integer map keys");
+        test.ok(maxBigIntLength <= 20, "passes only bounded values to BigInt");
+    } finally {
+        protobuf.util.global.BigInt = nativeBigInt;
+    }
     test.end();
 });
 

--- a/tests/api_textformat.js
+++ b/tests/api_textformat.js
@@ -80,6 +80,32 @@ tape.test("textformat - parses scalar, repeated, map and nested fields", functio
     test.end();
 });
 
+tape.test("textformat - bounds integer conversion inputs", function(test) {
+    var nativeBigInt = protobuf.util.global.BigInt,
+        maxBigIntLength = 0;
+    protobuf.util.global.BigInt = function(value) {
+        maxBigIntLength = Math.max(maxBigIntLength, String(value).length);
+        return nativeBigInt(value);
+    };
+    try {
+        test.throws(function() {
+            Msg.fromText("int64_field: " + "9".repeat(1000));
+        }, /out of range/, "rejects oversized integer literals");
+        test.equal(Msg.fromText("uint64_field: 0" + "0".repeat(1000) + "1").uint64Field.toString(), "1", "accepts insignificant leading zeros");
+        test.ok(maxBigIntLength <= 24, "passes only bounded values to BigInt");
+    } finally {
+        protobuf.util.global.BigInt = nativeBigInt;
+    }
+    test.end();
+});
+
+tape.test("textformat - parses large string literals", function(test) {
+    var value = "a".repeat(200000),
+        message = Msg.fromText("string_field: \"" + value + "\"");
+    test.equal(message.stringField, value, "does not depend on the argument count limit");
+    test.end();
+});
+
 tape.test("textformat - preserves __proto__ map key as own data", function(test) {
     var MapRoot = protobuf.parse("syntax = \"proto3\"; message Value { bool admin = 1; string role = 2; } message M { map<string, Value> labels = 1; }").root,
         M = MapRoot.lookupType("M"),


### PR DESCRIPTION
Bounds integer literals before passing them to the `BigInt` constructor in the ProtoJSON and Text Format extensions, and replaces `push.apply` with a loop that reliably handles large Text Format string literals.