### PR TITLE
fix: Limit Any.fromObject recursion

### DIFF
--- a/src/wrappers.js
+++ b/src/wrappers.js
@@ -40,6 +40,10 @@ var Message = require("./message"),
 wrappers[".google.protobuf.Any"] = {
 
     fromObject: function(object, depth) {
+        if (depth === undefined)
+            depth = 0;
+        if (depth > util.recursionLimit)
+            throw Error("max depth exceeded");
 
         // unwrap value type if mapped
         if (object && object["@type"]) {
@@ -57,7 +61,7 @@ wrappers[".google.protobuf.Any"] = {
                 }
                 return this.create({
                     type_url: type_url,
-                    value: type.encode(type.fromObject(object, depth === undefined ? 1 : depth + 1)).finish()
+                    value: type.encode(type.fromObject(object, depth + 1)).finish()
                 });
             }
         }

--- a/tests/comp_google_protobuf_any.js
+++ b/tests/comp_google_protobuf_any.js
@@ -137,3 +137,20 @@ tape.test("google.protobuf.Any - toObject recursion limit", function(test) {
 
     test.end();
 });
+
+tape.test("google.protobuf.Any - fromObject recursion limit", function(test) {
+
+    var recursionLimit = protobuf.util.recursionLimit;
+    protobuf.util.recursionLimit = 3;
+    try {
+        test.throws(function() {
+            Any.fromObject({
+                "@type": "type.googleapis.com/google.protobuf.Any"
+            });
+        }, /max depth exceeded/, "should reject excessive Any object expansion depth");
+    } finally {
+        protobuf.util.recursionLimit = recursionLimit;
+    }
+
+    test.end();
+});


### PR DESCRIPTION
Applies the guard already present in the `Any` wrapper's `toObject` method to `fromObject` as well.